### PR TITLE
Add localhost c2s connections

### DIFF
--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -42,7 +42,11 @@ function register ({ registerHook, registerSettingsScript, peertubeHelpers }: Re
         case 'prosody-port':
         case 'prosody-peertube-uri':
         case 'chat-type-help-builtin-prosody':
+        case 'prosody-advanced':
+        case 'prosody-c2s':
           return options.formValues['chat-type'] !== ('builtin-prosody' as ChatType)
+        case 'prosody-c2s-port':
+          return options.formValues['chat-type'] !== ('builtin-prosody' as ChatType) || options.formValues['prosody-c2s'] === false
         case 'chat-server':
         case 'chat-room':
         case 'chat-bosh-uri':

--- a/documentation/prosody.md
+++ b/documentation/prosody.md
@@ -68,3 +68,19 @@ If the video is local (not from a remote Peertube), the video owner will be admi
 
 You can use [ConverseJS moderation commands](https://conversejs.org/docs/html/features.html#moderating-chatrooms) to moderate the room.
 When you open the chat room in full screen, there will also be a menu with dedicated commands on the top right.
+
+
+### Prosody advanced settings
+
+#### Enable client to server connections
+
+This setting enable XMPP clients to connect to the builtin Prosody server.
+This option alone **only allows connections from localhost clients**.
+
+As example, this option can allow an instance of Matterbridge (once it could use anonymous login) *on the same machine* to bridge your chat with another services like a Matrix room.
+
+##### Prosody client to server port
+
+The port that will be used by the c2s module of the builtin Prosody server.
+XMPP clients shall use this port to connect.
+Change it if this port is already in use on your server.

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -77,6 +77,11 @@ async function getProsodyConfig (options: RegisterServerOptions): Promise<Prosod
   if (!/^\d+$/.test(port)) {
     throw new Error('Invalid port')
   }
+  const enableC2s = (await options.settingsManager.getSetting('prosody-c2s') as boolean) || false
+  const c2sPort = (await options.settingsManager.getSetting('prosody-c2s-port') as string) || '52822'
+  if (!/^\d+$/.test(c2sPort)) {
+    throw new Error('Invalid c2s port')
+  }
   const prosodyDomain = await getProsodyDomain(options)
   const paths = await getProsodyFilePaths(options)
 
@@ -96,7 +101,7 @@ async function getProsodyConfig (options: RegisterServerOptions): Promise<Prosod
 
   const config = new ProsodyConfigContent(paths, prosodyDomain)
   config.useHttpAuthentication(authApiUrl)
-  config.usePeertubeBosh(prosodyDomain, port)
+  config.usePeertubeBosh(prosodyDomain, port, enableC2s, c2sPort)
   config.useMucHttpDefault(roomApiUrl)
 
   // TODO: add a settings so that admin can choose? (on/off and duration)

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -168,10 +168,14 @@ class ProsodyConfigContent {
     this.authenticated.set('http_auth_url', url)
   }
 
-  usePeertubeBosh (prosodyDomain: string, port: string): void {
+  usePeertubeBosh (prosodyDomain: string, port: string, enableC2s: boolean, c2sPort: string): void {
     this.global.set('c2s_require_encryption', false)
     this.global.set('interfaces', ['127.0.0.1', '::1'])
-    this.global.set('c2s_ports', [])
+    if (enableC2s) {
+      this.global.set('c2s_ports', [c2sPort])
+    } else {
+      this.global.set('c2s_ports', [])
+    }
     this.global.set('c2s_interfaces', ['127.0.0.1', '::1'])
     this.global.set('s2s_ports', [])
     this.global.set('s2s_interfaces', ['127.0.0.1', '::1'])

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -269,6 +269,38 @@ Example: height:400px;`,
     private: false
   })
 
+  // ********** Built-in Prosody advanced settings
+  registerSetting({
+    name: 'prosody-advanced',
+    type: 'html',
+    private: true,
+    descriptionHTML: '<h3>Prosody advanced settings</h3>'
+  })
+
+  registerSetting({
+    name: 'prosody-c2s',
+    label: 'Enable client to server connections',
+    type: 'input-checkbox',
+    default: false,
+    private: true,
+    descriptionHTML:
+`Enable XMPP clients to connect to the builtin Prosody server.<br>
+This option alone only allows connections from localhost clients.`
+  })
+
+  registerSetting({
+    name: 'prosody-c2s-port',
+    label: 'Prosody client to server port',
+    type: 'input',
+    default: '52822',
+    private: true,
+    descriptionHTML:
+`The port that will be used by the c2s module of the builtin Prosody server.<br>
+XMPP clients shall use this port to connect.<br>
+Change it if this port is already in use on your server.<br>
+Keep it close this port on your firewall for now, it will not be accessed from the outer world.`
+  })
+
   // ********** settings changes management
   settingsManager.onSettingsChange(async (settings: any) => {
     if ('chat-type' in settings) {


### PR DESCRIPTION
I wanted to make a Matterbridge (modified by me, working on it to make a PR) instance able to connect to the builtin prosody. Both are on the same machine.
So I added two options:
 - Enable client to server connection, which enable c2s **local** connection by just adding the port to the config file.
 - Prosody client to server port, default to 5822 rather than 5222, make the admin able to change it if needed.
 
In the future an another option changing the c2s interfaces could be added to enable external connections.

If you need that I change something, ask me.