### PR TITLE
lang: add Occitan

### DIFF
--- a/languages/oc.json
+++ b/languages/oc.json
@@ -1,0 +1,7 @@
+{
+  "Open chat": "Dobrir la messatjariá",
+  "Open chat in a new window": "Dobrir la messatjariá dins una fenèstra novèla",
+  "Close chat": "Tancar la messatjariá",
+  "Use chat": "Activar la messatjariá",
+  "If enabled, there will be a chat next to the video.": "Se activat la messatjariá serà a costat de la vidèo."
+}

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "fr-FR": "./languages/fr.json",
     "eo": "./languages/eo.json",
     "eu-ES": "./languages/eu.json",
+    "oc-FR": "./languages/oc.json",    
     "pl-PL": "./languages/pl.json",
     "it-IT": "./languages/it.json"
   }


### PR DESCRIPTION
Salut,
j'ai traduit en occitan.
J'ai un léger doute pour oc_FR, est-ce qu'il aurait fallu mettre simplement «  oc  »  ?