### PR TITLE
Translation: update German translation for the new docs site

### DIFF
--- a/support/documentation/config.toml
+++ b/support/documentation/config.toml
@@ -41,7 +41,7 @@ weight = 20
 
   [Languages.de]
   title = "Peertube Plugin Livechat Dokumentation"
-  languageName = "Deutsche"
+  languageName = "Deutsch"
   landingPageName = "<i class='fas fa-home'></i> Home"
   landingPageURL = "/peertube-plugin-livechat/de/"
 

--- a/support/documentation/content/contributing/_index.de.md
+++ b/support/documentation/content/contributing/_index.de.md
@@ -5,6 +5,6 @@ weight=60
 chapter=false
 +++
 
-Interested in contributing? Awesome!
+Interessiert beizutragen? Super!
 
 {{% children style="li" depth="3" description="true" %}}

--- a/support/documentation/content/contributing/codeofconduct/_index.de.md
+++ b/support/documentation/content/contributing/codeofconduct/_index.de.md
@@ -1,10 +1,117 @@
 +++
-title="Code of Conduct"
-description="Contributor Covenant Code of Conduct"
+title="Verhaltenskodex"
+description="Verhaltenskodex für Mitwirkende"
 weight=10
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+## Unser Versprechen
+
+Wir als Mitglieder, Mitwirkende und Führungskräfte verpflichten uns, die Teilnahme an unserer
+Gemeinschaft zu einer belästigungsfreien Erfahrung für alle zu machen, unabhängig von Alter, Körpergröße
+Körpergröße, sichtbarer oder unsichtbarer Behinderung, ethnischer Zugehörigkeit, Geschlechtsmerkmalen, 
+Geschlechtsidentität und -ausdruck, Erfahrungsstand, Bildung, sozioökonomischem Status, Nationalität
+Nationalität, persönlichem Aussehen, Rasse, Kaste, Hautfarbe, Religion oder sexueller Identität
+und Orientierung.
+
+Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu einer offenen, einladenden,
+vielfältigen, integrativen und gesunden Gemeinschaft beitragen.
+
+## Unsere Standards
+
+Beispiele für Verhaltensweisen, die zu einem positiven Umfeld für unsere Gemeinschaft beitragen:
+
+* Einfühlungsvermögen und Freundlichkeit gegenüber anderen Menschen zeigen
+* Respekt vor unterschiedlichen Meinungen, Standpunkten und Erfahrungen
+* Konstruktives Feedback zu geben und anstandslos anzunehmen
+* Verantwortung zu übernehmen und sich bei denjenigen zu entschuldigen, die von unseren Fehlern betroffen sind, und aus den Erfahrungen lernen
+* Sich auf das konzentrieren, was nicht nur für uns als Einzelpersonen, sondern für die gesamte Gemeinschaft am besten ist
+
+Beispiele für inakzeptables Verhalten sind:
+
+* Die Verwendung von sexualisierter Sprache oder Bildern sowie sexuelle Aufmerksamkeit oder Annäherungsversuche jeglicher Art
+* Trollen, beleidigende oder herabsetzende Kommentare und persönliche oder politische Angriffe
+* Öffentliche oder private Belästigung
+* Veröffentlichung privater Informationen anderer, wie z. B. einer physischen oder E-Mail Adresse, ohne deren ausdrückliche Erlaubnis
+* Anderes Verhalten, das in einem beruflichen Umfeld als unangemessen angesehen werden könnte
+
+## Zuständigkeiten bei der Durchsetzung
+
+Die Community Leiter sind für die Klärung und Durchsetzung unserer Standards für
+akzeptablen Verhaltens und werden angemessene und faire Korrekturmaßnahmen ergreifen
+Verhalten, das sie für unangemessen, bedrohlich, beleidigend oder schädlich halten,
+oder schädlich erachten, zuständig.
+
+Die Community Leiter haben das Recht und die Verantwortung, Kommentare, Commits, Code, Wiki-Edits, Issues und andere Beiträge zu entfernen, zu bearbeiten oder abzulehnen, die
+die nicht mit diesem Verhaltenskodex übereinstimmen, zu entfernen oder abzulehnen und werden die Gründe für
+Entscheidungen mitteilen, wenn dies angebracht ist.
+
+## Umfang
+
+Dieser Verhaltenskodex gilt in allen Gemeinschaftsräumen und auch dann, wenn
+eine Person die Gemeinschaft offiziell im öffentlichen Raum vertritt.
+Beispiele für die Vertretung unserer Gemeinschaft sind die Verwendung einer offiziellen E-Mail-Adresse,
+Postings über ein offizielles Social-Media-Konto oder das Auftreten als ernannter
+Vertreter bei einer Online- oder Offline-Veranstaltung.
+
+## Durchsetzung
+
+Fälle von beleidigendem, belästigendem oder anderweitig inakzeptablem Verhalten können
+an die für die Durchsetzung verantwortlichen Community Leiter per E-Mail an
+git.[at].john-livingston.fr gemeldet werden.
+Alle Beschwerden werden umgehend und auf faire Weise geprüft und untersucht.
+
+Alle Community Leiter sind verpflichtet, die Privatsphäre und Sicherheit des Meldenden zu respektieren.
+
+## Durchsetzungsrichtlinien
+
+Die Community Leiter befolgen diese Richtlinien für die Auswirkungen auf die Gemeinschaft bei der Festlegung
+die Konsequenzen für Handlungen, die sie als Verstoß gegen diesen Verhaltenskodex ansehen:
+
+### 1. Korrektur
+
+**Problem**: Verwendung unangemessener Sprache oder anderes Verhalten, das
+unprofessionell oder in der Gemeinschaft unerwünscht ist.
+
+**Folge**: Eine private, schriftliche Verwarnung durch die Community Leiter, die Klarheit über die Art des Verstoßes und eine Erklärung, warum das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt werden.
+
+### 2. Warnung
+
+**Problem**: Ein Verstoß durch einen einzelnen Vorfall oder eine Reihe von Handlungen.
+
+**Folge**: Eine Warnung mit Konsequenzen für weiteres Verhalten. Keine Interaktion mit den betroffenen Personen, einschließlich unaufgeforderter Interaktion mit denjenigen, die den Verhaltenskodex durchsetzen, für einen bestimmten Zeitraum. Diese
+Dazu gehört auch die Vermeidung von Interaktionen in Gemeinschaftsräumen sowie in externen Kanälen
+wie soziale Medien. Ein Verstoß gegen diese Bedingungen kann zu einem vorübergehenden oder
+permanenten Ausschluss führen.
+
+### 3. Vorübergehendes Verbot
+
+**Problem**: Ein schwerer Verstoß gegen die Gemeinschaftsstandards, einschließlich Anhaltendes unangemessenes Verhalten.
+
+**Folge**: Ein vorübergehendes Verbot jeder Art von Interaktion oder öffentlicher Kommunikation mit der Gemeinschaft während eines bestimmten Zeitraums. Keine öffentliche oder private Interaktion mit den betroffenen Personen, einschließlich unaufgeforderter Interaktion mit denjenigen, die den Verhaltenskodex durchsetzen, ist während dieses Zeitraums erlaubt.
+Ein Verstoß gegen diese Bedingungen kann zu einem permanenten Verbot führen.
+
+### 4. Dauerhaftes Verbot
+
+**Problem**: Nachweis eines Verstoßes gegen die Gemeinschaftsstandards, einschließlich anhaltend unangemessenen Verhaltens, Belästigung einer Person oder Aggression gegen oder Herabsetzung von Gruppen von Personen.
+
+**Folge**: Ein dauerhaftes Verbot jeder Art von öffentlicher Interaktion innerhalb der Gemeinschaft.
+
+## Zuordnung
+
+Dieser Verhaltenskodex ist der [Contributor Covenant][homepage] entnommen,
+Version 2.1, verfügbar unter
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Die Leitlinien für die Auswirkungen auf die Gemeinschaft wurden inspiriert durch
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+Antworten auf häufig gestellte Fragen zu diesem Verhaltenskodex finden Sie in den FAQ unter
+[https://www.contributor-covenant.org/faq][FAQ]. Die Übersetzungen sind verfügbar
+unter [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/support/documentation/content/contributing/develop/_index.de.md
+++ b/support/documentation/content/contributing/develop/_index.de.md
@@ -1,10 +1,62 @@
 +++
-title="Develop"
-description="Develop"
+title="Entwickeln"
+description="Entwickeln"
 weight=40
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Sprechen Sie immer über die Funktionen, die Sie entwickeln wollen, indem Sie das Issue, das Ihr Problem behandelt, erstellen/finden und kommentieren bevor Sie mit der Arbeit daran beginnen und informieren Sie die Gemeinschaft darüber, dass Sie mit der Programmierung beginnen, indem Sie das Thema für sich beanspruchen.
+
+Bitte benutzen Sie den `develop` Zweig. Der `main`-Zweig ist für veröffentlichte Versionen des Plugins reserviert, so dass die Dokumentation immer mit der veröffentlichten Version des Plugins synchronisiert ist.
+
+Voraussetzung für die Erstellung dieses Plugins:
+
+- Sie müssen `npm` installiert haben
+- Sie müssen python venv installiert haben (z.B. das Paket `python3-venv` auf Debian)
+
+Um das Repository zu klonen:
+
+```bash
+# Clone the repository
+git clone https://github.com/JohnXLivingston/peertube-plugin-livechat.git
+# Checkout the develop branch
+git checkout develop
+# Initialize the submodules. This command must be run again if any submodules' version changes.
+git submodule update --init --recursive
+
+# Install NPM dependencies and build the module for the first time:
+npm install
+
+# Build the plugin after a modification:
+npm run build
+
+# If you have a fork from the repository, add it as remote (example):
+git remote add me git@github.com:MY_GITHUB_ACCOUNT/peertube-plugin-livechat.git
+
+# Create a local branch for you developments, and checkout it (example):
+git checkout my_development # Note: if an issue is associated, use fix_1234 as your branch name (where 1234 is the issue's number)
+# To propose your modifications, push your branch to your repository (example):
+git push --set-upstream me my_development
+# Then go to your github repository with your web browser to propose the Pull Request (see additional instructions below)
+```
+
+Sobald Sie bereit sind, Ihren Code zu zeigen und um Feedback zu bitten, reichen Sie einen *Entwurf* für einen Pull Request ein.
+Sobald Sie bereit für eine Codeüberprüfung vor der Zusammenführung sind, reichen Sie einen Pull Request ein. In jedem Fall sollten Sie Ihren PR mit dem Problem, die er behebt, verlinken, indem Sie die GitHub-Syntax verwenden: "fixes #issue_number".
+
+Der Front-End-Code befindet sich im Ordner `client`, der Back-End-Code im Ordner `server`. Es gibt einige gemeinsam genutzte Codes im `shared` Ordner.
+
+Für allgemeine Anweisungen (Entwicklung von Plugins, Erstellung, Installation, ...), lesen Sie bitte die [Peertube Dokumentation] (https://docs.joinpeertube.org/contribute-plugins?id=write-a-plugintheme).
+
+Sie können das Plugin mit zusätzlichen Debug-Funktionen bauen, indem Sie es einfach benutzen:
+
+```bash
+NODE_ENV=dev npm run build
+```
+
+## ESBuild vs Typescript
+
+Dieses Plugin verwendet ESBuild für die Generierung von Frontend-Code, wie das offizielle `peertube-plugin-quickstart` Plugin.
+ESBuild kann mit Typescript umgehen, prüft aber keine Typen
+(siehe [ESBuild-Dokumentation](https://esbuild.github.io/content-types/#typescript)).
+Deshalb kompilieren wir Typescript zuerst mit der Option `-noEmit`, nur um die Typen zu überprüfen (`check:client:ts` in der package.json Datei).
+Dann, wenn alles in Ordnung ist, führen wir ESBuild aus, um das kompilierte Javascript zu erzeugen.

--- a/support/documentation/content/contributing/document/_index.de.md
+++ b/support/documentation/content/contributing/document/_index.de.md
@@ -1,10 +1,60 @@
 +++
-title="Document"
-description="Documenter the plugin, or translate the documentation."
+title="Dokumentation"
+description="Dokumentieren Sie das Plugin, oder übersetzen Sie die Dokumentation."
 weight=50
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+## Allgemeine Informationen
+
+Informieren Sie die Community immer vor der Arbeit (indem Sie ein neues Problem erstellen oder ein bestehendes kommentieren). Damit soll vermieden werden, dass zwei Personen
+an der gleichen Sache arbeiten, und Konflikte zu verhindern.
+
+Bitte benutzen Sie den `develop`-Zweig. Der `main`-Zweig ist für veröffentlichte Versionen des Plugins reserviert, so dass die Dokumentation immer mit der veröffentlichten Version des Plugins synchronisiert ist.
+
+Der Quellcode der Dokumentation befindet sich im Ordner `support/documentation/content`.
+
+Die Dokumentation wird mit [Hugo](https://gohugo.io/) erstellt.
+Sie müssen es auf Ihrem Computer installieren, wenn Sie eine Vorschau Ihrer Arbeit sehen wollen.
+
+Das verwendete Thema ist [hugo-theme-learn](https://learn.netlify.app/).
+Sie sollten dessen Dokumentation lesen, bevor Sie mit der Bearbeitung der Dokumentation beginnen.
+
+## Übersätzungen
+
+Die Hauptsprache ist Englisch (Code `en`).
+
+Die verschiedenen Übersetzungen der gleichen Datei stehen nebeneinander im Verzeichnis und sind durch einen Sprachcode in der Dateinamenerweiterung gekennzeichnet.
+Beispiel: `_index.fr.md` ist die französische Übersetzung von `_index.en.md`.
+
+Bitte beachten Sie, dass eine fehlende Übersetzungsdatei nicht in den Menüs der generierten Website erscheint.
+
+**Stellen Sie sicher, dass Sie immer alle Dateien für die Sprachen erstellen**, auch wenn die Übersetzung noch nicht verfügbar ist.
+
+Dafür gibt es ein Skript `doc-generate-missing-translations.sh` im Stammverzeichnis des Projektes. Wenn Sie eine neue Datei hinzufügen, müssen Sie nur die englische Version erstellen und dann dieses Skript ausführen. Es erstellt alle fehlenden Übersetzungen und fügt eine Beispielmeldung hinzu, die den Benutzer auffordert, die englische Version zu lesen.
+
+## Eine neue Sprache hinzufügen
+
+Kopieren und ändern Sie den Abschnitt `[Languages.fr]` in der Datei `support/documentation/config.toml`.
+
+Führen Sie dann das Skript `doc-generate-missing-translations.sh` aus.
+Es wird alle fehlenden Dateien erstellen.
+
+Dann können Sie sie eine Datei nach der anderen übersetzen.
+Wenn die Übersetzungen nicht vollständig sind, macht das nichts, die generierten Dateien zeigen eine Meldung an, die vorschlägt, die Sprache zu ändern.
+
+## Vorschau
+
+Um eine Vorschau Ihrer Änderungen zu sehen, führen Sie einfach diesen Befehl aus:
+
+```bash
+hugo serve -s support/documentation/
+```
+
+Öffnen Sie dann Ihren Browser und gehen Sie auf die Adresse
+[http://localhost:1313/peertube-plugin-livechat/](http://localhost:1313/peertube-plugin-livechat/).
+Diese Seite wird bei jeder Änderung automatisch aktualisiert.
+
+## Veröffentlichung
+
+Die Veröffentlichung der Dokumentation erfolgt automatisch, sobald die Änderungen in den `main` Zweig eingefügt wurden.

--- a/support/documentation/content/contributing/document/_index.en.md
+++ b/support/documentation/content/contributing/document/_index.en.md
@@ -5,7 +5,7 @@ weight=50
 chapter=false
 +++
 
-## General informatiosn
+## General information
 
 Always inform the community before working (by creating a new issue, or commenting an existing one). This is to avoid that two persons are
 working on the same thing, and prevent conflicts.

--- a/support/documentation/content/contributing/feedback/_index.de.md
+++ b/support/documentation/content/contributing/feedback/_index.de.md
@@ -1,10 +1,11 @@
 +++
-title="Give your feedback"
-description="Give your feedback"
+title="Feedback"
+description="Gib dein Feedback"
 weight=30
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Sie müssen keine Programmierkenntnisse haben, um zu diesem Plugin beizutragen! Andere
+Beiträge sind auch sehr wertvoll, darunter: 
+Sie können die Software testen und Fehler melden, Sie können Feedback geben, Funktionen die Sie
+interessieren, Benutzeroberfläche, Design, ...

--- a/support/documentation/content/contributing/translate/_index.de.md
+++ b/support/documentation/content/contributing/translate/_index.de.md
@@ -1,10 +1,21 @@
 +++
-title="Translate"
-description="Translate the plugin"
+title="Übersätzen"
+description="Das Plugin übersätzen"
 weight=20
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Sie können uns helfen, dieses PeerTube-Plugin zu übersetzen, indem Sie Übersetzungsdateien im Ordner `languages` erstellen oder ändern.
+
+Bitte arbeiten Sie auf dem `develop` Zweig, und machen Sie Ihre Änderungen und Pull Requests auf diesem Zweig.
+
+Wenn die Sprache, für die Sie sich interessieren, noch nicht existiert, erstellen Sie eine Datei `code.json` im Ordner `languages`, wobei `code` der Code der Sprache ist.
+Der Sprachcode muss derselbe sein wie der Sprachcode von Peertube (siehe [Peertube-Dokumentation](https://github.com/Chocobozzz/PeerTube/blob/develop/support/doc/translation.md)).
+Fügen Sie dann die Sprachdatei in der Datei `package.json` unter dem Schlüssel `translations` hinzu.
+
+Die Übersetzungen werden wie folgt in der Sprachdatei festgelegt:
+
+- die Dateien sind im [JSON Format](https://www.json.org)
+- der JSON Schlüssel ist der englische Text (Siehe die bestehenden Schlüssel in der [französischen Übersätzungsdatei](languages/fr.json)).
+- der JSON Wert ist der übersätzte Text
+- Hinweis: Es gibt keine englische Übersätzungsdatei (So funktionieren Übersätzungen für Peertube Plugins)

--- a/support/documentation/content/credits/_index.de.md
+++ b/support/documentation/content/credits/_index.de.md
@@ -1,10 +1,24 @@
 +++
-title="Credits"
-description="Plugin Credits"
+title="Impressum"
+description="Impressum des Plugins"
 weight=90
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+[package.json](https://github.com/JohnXLivingston/peertube-plugin-livechat/blob/main/package.json),
+[COPYRIGHT](https://github.com/JohnXLivingston/peertube-plugin-livechat/blob/main/COPYRIGHT.md)
+and [LICENSE](https://github.com/JohnXLivingston/peertube-plugin-livechat/blob/main/LICENSE)
+Dateien beinhalten die Lizenzinformationen für dieses Programm und seiner Abhängigkeiten.
+
+Das Plugin wird von [John Livingston](https://www.john-livingston.fr/) betrieben.
+
+Dank an David Revoy für seine Arbeit an dem Peertube Maskottchen, [Sepia](https://www.davidrevoy.com/index.php?tag/peertube).
+Das Charakterdesign steht unter CC-By-Lizenz, und die SVG-Dateien, die zur Erstellung einiger Logos und Avatare in diesem Plugin verwendet werden, sind GPLv3.0.
+
+Vielen Dank an [Framasoft](https://framasoft.org)für die Ermöglichung von [Peertube](https://joinpeertube.org/) und für die finanzielle Unterstützung.
+
+Vielen Dank an [ritimo](https://www.ritimo.org/) für die finanzielle Unterstützung.
+
+Vielen Dank an [Code Lutin](https://www.codelutin.com/) und [Rétribution Copie Publique](https://copiepublique.fr/) für die finanzielle Unterstützung.
+
+Vielen Dank an [NlNet](https://nlnet.nl/) und die [NGI0 Entrust fund](https://nlnet.nl/entrust/) für die finanzielle Unterstützung.

--- a/support/documentation/content/documentation/admin/_index.de.md
+++ b/support/documentation/content/documentation/admin/_index.de.md
@@ -1,6 +1,6 @@
 +++
-title="Admin documentation"
-description="Plugin Peertube Livechat administration"
+title="Admin Dokumentation"
+description="Plugin Peertube Livechat Administration"
 weight=30
 chapter=false
 +++

--- a/support/documentation/content/documentation/admin/advanced/_index.de.md
+++ b/support/documentation/content/documentation/admin/advanced/_index.de.md
@@ -1,10 +1,8 @@
 +++
-title="Advanced usage"
-description="Some advanced features"
+title="Fortgeschrittene Nutzung"
+description="Einige erweiterte Funktionen"
 weight=20
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+{{% children depth="3" style="li" description="true" %}}

--- a/support/documentation/content/documentation/admin/advanced/matterbridge.de.md
+++ b/support/documentation/content/documentation/admin/advanced/matterbridge.de.md
@@ -1,10 +1,8 @@
 +++
-title="Using Matterbridge"
-description="Using Matterbridge to bridge with other chats"
+title="Matterbridge benutzen"
+description="Matterbridge als Brücke zu anderen Chats nutzen"
 weight=50
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Hier ist ein Tutorial um Matterbridge mit diesem Plugin zu benutzen (nur auf englisch): <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>

--- a/support/documentation/content/documentation/admin/settings.de.md
+++ b/support/documentation/content/documentation/admin/settings.de.md
@@ -1,10 +1,162 @@
 +++
-title="Settings"
+title="Einstellungen"
 description="Plugin Peertube Livechat settings"
 weight=10
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% notice note %}}
+Die Einstellungsseite des Plugins kann momentan nicht übersätzt werden und ist daher nur auf englisch verfügbar. Deswegen wird hier die englische Bezeichnung der Knöpfe, Abschnitte, etc. verwendet. Für weitere Informationen bitte [dieses Problem](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/115) kontrollieren.
 {{% /notice %}}
+
+Dieser Abschnitt beschreibt die Einstellungsseite des Plugins.
+
+## List existing rooms (Bestehende Räume auflisten)
+
+Wenn der «List rooms» Knopf gedrückt wird, werden alle bestehenden Chaträume aufgelistet.
+Sie können die Chaträume damit finden und moderieren.
+
+## Chat behaviour (Chatverhalten)
+
+### Room type (Raumtyp)
+
+Sie können hier auswählen, ob seperate Räume für jedes Video oder nach Kanal gruppiert erstellt werden.
+
+### Automatically open the chat (Chat automatisch öffnen)
+
+Wenn ausgewählt wird der Chat geladen, sobald Sie auf der Videoseite sind.
+
+### Show the «open in new window» button (Zeige den «open in new window» Knopf)
+
+Wenn Ihr Webchat-Tool in einem eigenen Fenster geöffnet werden kann, können Sie einen Knopf hinzufügen um dies zu tun.
+
+Wenn Sie ein externes Web-Chat-Tool verwenden (siehe den Chat-Modus «Use an external web chat tool»), funktioniert es möglicherweise nicht im Vollbildmodus (z. B. wenn es auf das übergeordnete Fenster zugreifen muss, um Videoinformationen zu erhalten). Sie können diese Schaltfläche deaktivieren, indem Sie das Häkchen bei dieser Einstellung entfernen.
+
+### Show the «share chat link» button (Zeige den Chat Link teilen Knopf)
+
+Diese Funktion aktiviert das Dialogfenster «Chat-Link teilen». Mit diesem Fenster können Sie URLs generieren, um dem Chat beizutreten.
+Der Chat kann angepasst werden (schreibgeschützter Modus, Verwendung des aktuellen Themas, ...).
+
+Sie können zum Beispiel einen schreibgeschützten Link generieren und diesen in OBS verwenden, um den Chat in Ihren Live-Stream zu integrieren!
+
+Diese Einstellung ermöglicht es Ihnen, festzulegen, wer auf dieses Fenster zugreifen kann.
+
+### Chats are only available for local videos (Chats sind nur für lokale Videos verfügbar)
+
+Peertube ist ein gemeinschaftlicher Dienst. Plugins sind nur auf dem Server verfügbar, auf dem Sie sich gerade befinden.
+Wenn Sie also ein externes Video ansehen, steht der Webchat nur Ihnen zur Verfügung, nicht aber den Nutzern der anderen Instanzen.
+Daher ist diese Option standardmäßig aktiviert und verhindert die Anzeige eines Webchats für entfernte Videos.
+
+### Users can activate the chat for their lives (Nutzer können den Chat für ihre Live-Videos aktivieren)
+
+Wenn diese Option aktiviert ist, haben alle Live-Videos in ihren Eigenschaften ein Feld zur Aktivierung des Webchats.
+Der Videoeigentümer kann Webchats aktivieren.
+
+### Activate chat for all lives (Den Chat für alle Live-Videos aktivieren)
+
+Der Chat wird für alle Peertube-Live-Videos auf Ihrer Instanz verfügbar sein.
+
+### Activate chat for all non-lives (Aktiviere den Chat für alle Nicht-Live-Videos)
+
+Der Chat wird für alle Peertube-Videos verfügbar sein, die nicht live sind.
+
+### Activate chat for these videos (Aktivieren Sie den Chat für diese Videos)
+
+Sie können einige UUIDs auswählen, für die der Chat verfügbar sein soll.
+Wenn Sie die Funktion für alle Videos nicht aktivieren möchten, können Sie dieses Feld verwenden, um die UUIDs der Videos aufzulisten.
+Sie können Kommentare hinzufügen: alles, was dem Zeichen # entspricht, wird entfernt, ebenso wie leere Zeilen.
+
+### Hide the chat for anonymous users (Den Chat für anonyme Benutzer ausblenden)
+
+Wenn diese Option aktiviert ist, können anonyme Peertube-Nutzer den Chat nicht sehen.
+
+Hinweis: Im Moment blendet diese Funktion einfach den Chat aus.
+In einer zukünftigen Version wird der Chat durch eine Meldung ersetzt, die besagt "Bitte melden Sie sich an, um [...]".
+Siehe [v5.7.0 Release Notes](https://github.com/JohnXLivingston/peertube-plugin-livechat/blob/main/CHANGELOG.md#570) für weitere Informationen.
+
+## Theming
+
+### ConverseJS theme (ConverseJS Thema)
+
+Sie können wählen, welches Thema Sie für ConverseJS verwenden möchten:
+
+- Peertube-Theme: Dies ist ein spezielles Thema, das speziell für die Integration von Peertube erstellt wurde.
+- Standard-ConverseJS-Theme: Dies ist das Standard-Thema von ConverseJS.
+- ConverseJS-concord-Theme: Dies ist ein Thema, das von ConverseJS bereitgestellt wird.
+
+### Automatic color detection (Automatische Farberkennung)
+
+Versucht, die Farben aus dem aktuellen Thema des Benutzers automatisch zu erkennen.
+Wenn diese Einstellung aktiviert ist, versucht das Plugin, die Farben für das Chat-Thema automatisch zu erkennen.
+Wenn dies für einige Ihrer Peertube-Themen nicht korrekt funktioniert, können Sie diese Option deaktivieren.
+
+### Webchat iframe style attribute (Webchat Iframe Stil-Attribute)
+
+Sie können einige benutzerdefinierte Stile hinzufügen, die dem Iframe hinzugefügt werden.
+Zum Beispiel eine benutzerdefinierte Breite:
+
+```width:400px;```
+
+## Chat server advanced settings (Erweiterte Einstellungen des Chatservers)
+
+### Use system Prosody (System Prosody benutzen)
+
+Das Plugin wird mit einem AppImage geliefert, das zum Ausführen des [Prosody XMPP-Servers] (https://prosody.im) verwendet wird.
+Wenn dieses AppImage nicht funktioniert, können Sie auf das Prosody-Paket zurückgreifen, das für Ihren Server erstellt wurde. Installieren Sie einfach das Paket `prosody`.
+
+Diese Einstellung sollte nur verwendet werden, wenn das Plugin defekt ist und auf einen Patch wartet.
+
+### Disable Websocket (Websocket deaktivieren)
+
+Mit Peertube >= 5.0.0 versucht dieses Plugin, eine Websocket-Verbindung zum Chatten zu verwenden.
+Wenn der Browser oder die Verbindung des Benutzers nicht kompatibel ist, wird der Browser automatisch auf das BOSH-Protokoll zurückgreifen.
+
+Aber in seltenen Fällen kann dies fehlschlagen. Zum Beispiel, wenn Sie einen Reverse Proxy vor Peertube haben, der keine
+Websocket-Verbindung für Plugins erlaubt.
+In diesem Fall können Sie diese Einstellungen überprüfen, um Websocket-Verbindungen zu deaktivieren.
+
+### Prosody port
+
+Dies ist der Port, den der Prosody-Server verwenden wird. Standardmäßig ist er auf 52800 eingestellt. Wenn Sie einen anderen Port verwenden möchten, ändern Sie einfach den Wert hier.
+
+### Peertube URL for API calls (Peertube-URL für API-Aufrufe)
+
+In einigen seltenen Fällen kann Prosody die API von Peertube nicht über seine öffentliche Adresse (URI) aufrufen.
+Wenn Sie solche Probleme haben (siehe das Ergebnis des Diagnosetools), können Sie versuchen, den Wert
+dieser Einstellung auf `http://localhost:9000` oder `http://127.0.0.1:9000` zu setzen
+zu setzen (unter der Annahme, dass Ihr Peertube auf Port `9000` hört). Überprüfen Sie das in Ihrer Peertube `config/production.yaml` Datei).
+
+### Log rooms content by default (Standardmäßig Inhalte von Räumen protokollieren)
+
+Wenn diese Option aktiviert ist, wird der Rauminhalt standardmäßig auf dem Server archiviert.
+Das bedeutet, dass Benutzer, die dem Chat beitreten, Nachrichten sehen, die vor ihrem Beitritt gesendet wurden.
+
+Bitte beachten Sie, dass es immer möglich ist, die Inhaltsprotokollierung für einen bestimmten Raum zu aktivieren/deaktivieren,
+indem Sie seine Eigenschaften bearbeiten.
+
+### Room logs expiration (Ablaufzeit von Raumprotokollen)
+
+Hier können Sie die Ablaufzeit für Raumprotokolle einstellen.
+Siehe die Online-Hilfe für akzeptierte Werte.
+
+### Enable client to server connections (Aktivieren von Client-Server-Verbindungen)
+
+Diese Einstellung ermöglicht es XMPP-Clients, sich mit dem eingebauten Prosody-Server zu verbinden.
+Im Moment erlaubt diese Option **nur Verbindungen von localhost-Clients**.
+
+Zum Beispiel kann diese Option einer Instanz von Matterbridge (sobald sie einen anonymen Login verwenden kann) *auf demselben Rechner* erlauben, Ihren Chat mit einem anderen Dienst wie einem Matrix-Raum zu verbinden.
+
+#### Prosody client to server port (Prosody Client-Server-Verbindungsport)
+
+Der Port, der vom c2s-Modul des eingebauten Prosody-Servers verwendet wird.
+XMPP-Clients sollen diesen Port für die Verbindung verwenden.
+Ändern Sie ihn, wenn dieser Port bereits auf Ihrem Server verwendet wird.
+
+### Enable external XMPP components (Aktivieren externer XMPP-Komponenten)
+
+Diese Einstellung ermöglicht es externen XMPP-Komponenten, sich mit dem Server zu verbinden.
+Im Moment erlaubt diese Option **nur Verbindungen von localhost-Komponenten**.
+
+Diese Funktion könnte genutzt werden, um Bridges oder Bots zu verbinden.
+
+Weitere Informationen über externe Prosody-Komponenten [hier](https://prosody.im/doc/components).

--- a/support/documentation/content/documentation/installation/_index.de.md
+++ b/support/documentation/content/documentation/installation/_index.de.md
@@ -10,9 +10,9 @@ Bevor Sie auf eine Hauptversion aktualisieren, lesen Sie bitte die Versionshinwe
 {{% /notice %}}
 
 {{% notice tip %}}
-To install or update the plugin, **just use the Peertube web admin interface**.
+Um das Plugin zu installieren oder zu aktualisieren **einfach das Peertube Web-Admin-Interface benutzen**.
 {{% /notice %}}
 
-Here are some other more specific instructions:
+Hier sind weitere, spezifischere Anweisungen:
 
 {{% children style="li" depth="3" description="true" %}}

--- a/support/documentation/content/documentation/installation/cpu_compatibility.de.md
+++ b/support/documentation/content/documentation/installation/cpu_compatibility.de.md
@@ -1,10 +1,57 @@
 +++
-title="Known issues: CPU Compatibility"
-description="For now, the plugin only works out of the box for x86_64 CPU architecture. Here are some instructions for other CPU architectures."
+title="Bekannte Probleme: CPU Kompatibilität"
+description="Derzeit funktioniert das Plugin standartmäßig nur für x86_64 CPU Architekturen. Hier sind einige Anleitungen für andere CPU Architekturen."
 weight=10
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Das im Plugin enthaltene Prosody AppImage funktioniert nur mit x86_64 CPU Architekturen.
+Es ist nicht kompatibel mit arm64 und anderen CPU-Architekturen.
+Im Moment ist es mir noch nicht gelungen, es für andere CPU-Architekturen zum Laufen zu bringen. Wenn Sie benachrichtigt werden wollen, sobald es möglich ist, können Sie [dieses Problem](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/124) abonnieren und kommentieren.
+
+Um das Plugin zu verwenden, müssen Sie Prosody manuell auf Ihrem Server installieren
+(siehe unten).
+
+Sobald dies geschehen ist, müssen Sie in den Plugin-Einstellungen das Häkchen bei `Use system Prosody` setzen.
+
+## Nicht-Docker Peertube installation
+
+Für die Standardinstallation müssen Sie nur das offizielle `prosody`-Paket für Ihre Linux-Distribution installieren.
+
+Zum Beispiel, auf Debian/Ubuntu:
+
+```bash
+sudo apt install prosody
+```
+
+Sie können dann den Dienst deaktivieren, der automatisch startet, wenn Sie Prosody installieren (das Plugin startet einen Prosody-Prozess, der Dienst muss nicht dauerhaft laufen).
+Zum Beispiel unter Debian/Ubuntu (und anderen Systemd-basierten Linux-Distributionen):
+
+```bash
+sudo systemctl disable prosody && sudo systemctl stop prosody
+```
+
+Achtung: Deaktivieren Sie Prosody nicht, wenn es für einen anderen Dienst auf Ihrem Server verwendet wird, wie zum Beispiel Jitsi.
+
+## Docker
+
+Sie müssen ein Peertube-Image generieren, das Prosody in demselben
+Container enthält, der auch Peertube beinhaltet.
+Ich weiß, dass dies nicht der Standardweg ist, um dies mit Docker zu tun, aber bedenken Sie, dass eine vorübergehende Lösung ist.
+
+Um ein solches Image zu erzeugen und zu verwenden, lesen Sie bitte die Docker-Dokumentation.
+Die Docker-Datei, um das Paket zu erzeugen, sollte wie folgt sein:
+
+```Docker
+FROM chocobozzz/peertube:production-bullseye
+
+RUN apt -y update && apt install -y prosody && apt -y clean
+```
+
+## Yunohost
+
+Sie müssen `metronome` (der von Yunohost bereitgestellte XMPP-Server) deaktivieren, und `prosody` installieren.
+
+Dies wird bereits von der Yunohost Peertube Anwendung gemacht, da es für das Plugin vor v6.0.0 erforderlich war.
+Es kann aber sein, dass es in naher Zukunft entfernt wird (um die Nachteile dieser Methode zu vermeiden).
+Ich muss mit dem Yunohost Team diskutieren, um zu entscheiden, wie wir die Nachteile minimieren können, und die Kompatibilität zu maximieren.

--- a/support/documentation/content/documentation/installation/upgrade_before_6.0.0.de.md
+++ b/support/documentation/content/documentation/installation/upgrade_before_6.0.0.de.md
@@ -1,10 +1,14 @@
 +++
-title="Upgrade from version older than 6.0.0"
-description="Important notes when upgrading for an older version."
+title="Aktualisieren von Versionen vor 6.0.0"
+description="Wichtige Hinweise zum aktualisieren von älteren Versionen."
 weight=50
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+## WICHTIGER HINWEIS
+
+Seit Version v6.0.0 benötigt dieses Plugin keine andere Prosody-Installation.
+
+Falls Sie dieses Plugin vor dieser Version benutzt haben und Sie Prosody manuell installiert haben, können Sie Prosody sicher deinstallieren.
+
+Falls Sie ein eigenes Peertube Docker Paket genutzt haben, welches Prosody eingebettet hatte, können Sie zu den offiziellen Peertube Paketen zurück wechseln.

--- a/support/documentation/content/documentation/user/_index.de.md
+++ b/support/documentation/content/documentation/user/_index.de.md
@@ -1,6 +1,6 @@
 +++
-title="User documentation"
-description="Plugin peertube-plugin-livechat user documentation"
+title="Benutzer Dokumentation"
+description="Plugin peertube-plugin-livechat Benutzer Dokumentation"
 weight=40
 chapter=false
 +++

--- a/support/documentation/content/documentation/user/moderation.de.md
+++ b/support/documentation/content/documentation/user/moderation.de.md
@@ -1,10 +1,20 @@
 +++
 title="Moderation"
-description="Plugin peertube-plugin-livechat moderation"
+description="Plugin peertube-plugin-livechat Moderation"
 weight=10
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+Sie können auf die Raumeinstellungen und Moderationswerkzeuge zugreifen, indem Sie den Chat in einem neuen Fenster öffnen, und das Dropdown-Menü oben rechts verwenden.
+
+Sie können alle bestehenden Chaträume auflisten: in den Einstellungen des Plugins gibt es einen Knopf «Räume auflisten».
+
+Sie können alte Räume löschen: Treten Sie dem Raum bei, und verwenden Sie das Menü oben, um den Raum zu löschen.
+
+## Hinweise
+
+Alle Instanzmoderatoren und Admins sind Eigentümer der erstellten Chaträume.
+Wenn das Video lokal ist (nicht von einem entfernten Peertube), ist der Eigentümer des Videos der Administrator des Chatraums.
+
+Sie können [ConverseJS-Moderationsbefehle](https://conversejs.org/docs/html/features.html#moderating-chatrooms) verwenden, um den Raum zu moderieren.
+Wenn Sie den Chatraum im Vollbildmodus öffnen, finden Sie oben rechts ein Menü mit den entsprechenden Befehlen.

--- a/support/documentation/content/documentation/user/obs.de.md
+++ b/support/documentation/content/documentation/user/obs.de.md
@@ -5,6 +5,30 @@ weight=10
 chapter=false
 +++
 
-{{% notice warning %}}
-This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
-{{% /notice %}}
+## OBS Overlay
+
+Falls Sie OBS zum Streaming verwenden, können Sie den Chat ganz einfach in Ihren Stream integrieren.
+
+Sie können die Funktion «Chat Link teilen» verwenden, um einen Link zu Ihrem Chat zu erstellen.
+Die Schaltfläche sollte sich in der Nähe des Chats befinden, wenn Sie der Eigentümer des Videos sind (es sei denn, sie wurde von der Server-Administration deaktiviert).
+
+Aktivieren Sie das Feld «schreibgeschützt» in dem Dialogfenster.
+Verwenden Sie dann diesen Link als «Browser Quelle» in OBS.
+
+Sie können die Option «Transparenter Hintergrund» verwenden, um einen transparenten Hintergrund in OBS zu erhalten.
+Wenn Sie die Hintergrundtransparenz anpassen möchten, können Sie diesen CSS-Code in den Einstellungen Ihrer OBS-Browserquelle hinzufügen:
+
+```css
+:root {
+  --livechat-transparent: rgba(255 255 255 / 90%) !important;
+}
+```
+
+Hinweis: Sie können die Farben anpassen. Dies ist noch nicht dokumentiert, aber Sie können dies versuchen:
+Aktivieren Sie im Dialogfenster die Option «Aktuelle Themenfarben verwenden», und versuchen Sie dann, die Farbwerte in dem Link manuell zu ändern.
+Sie müssen gültige CSS-Farbwerte verwenden, und diese müssen in dem Link korrekt kodiert sein.
+
+## Mehrere Chats in Ihrem Live-Stream kombinieren
+
+Sie können die [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) verwenden, um mehrere Chat-Quellen (von Peertube, Twitch, Youtube, Facebook, ...) zu mischen und deren Inhalte in Ihren Live-Stream zu integrieren.
+Die Kompatibilität mit diesem Plugin wurde in den letzten Versionen hinzugefügt.

--- a/support/documentation/content/issues/_index.de.md
+++ b/support/documentation/content/issues/_index.de.md
@@ -7,9 +7,9 @@ chapter=false
 
 Wenn Sie neue Funktionswünsche, Fehler (Bugs) oder Schwierigkeiten bei der Einrichtung des Plugins haben, können Sie den [Github issue tracker](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues) verwenden.
 
-To have a glimpse to the roadmap for upcoming features, please refer to:
+Einen Einblick in die Roadmap für kommende Funktionen finden Sie hier:
 
-- this [github project](https://github.com/users/JohnXLivingston/projects/1).
-- the [milestones on github](https://github.com/JohnXLivingston/peertube-plugin-livechat/milestones).
+- [github project](https://github.com/users/JohnXLivingston/projects/1).
+- [milestones on github](https://github.com/JohnXLivingston/peertube-plugin-livechat/milestones).
 
 Wenn Sie ein Webdesigner oder ein ConverseJS/Prosody/XMPP-Experte sind und helfen wollen, dieses Plugin zu verbessern, sind Sie gerne willkommen.


### PR DESCRIPTION
### German Translation
I updated the german translation for the new documentation website.
fixes #152 
### Changelog
Added missing sites
Added note that setting names aren't translated in the `settings.de.md` file
removed typo "Deutsche" -> "Deutsch" in the `config.toml` file
removed typo "General informatiosn" in the `contributing/document/_index.en.md` file