### PR TITLE
114 tk2210 0094 xmpp clients connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ??? (Not Released Yet)
+
+### Minor changes and fixes
+
+* Diagnostic tool: add the result of `prosodyctl check` in the debug section.
+
 ## 6.2.3
 
 ### Minor changes and fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor changes and fixes
 
 * Diagnostic tool: add the result of `prosodyctl check` in the debug section.
+* New debug mode
 
 ## 6.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Diagnostic tool: add the result of `prosodyctl check` in the debug section.
 * New debug mode
+* Fix room topic: due to a [bug in mod_muc_http_defaults](https://hg.prosody.im/prosody-modules/rev/6d99ddd99694), room topics were badly configured. The plugin will fix them at startup, and stops trying to set the subject.
 
 ## 6.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ??? (Not Released Yet)
 
+### New Features
+
+* XMPP clients: you can now allow connection to rooms using external XMPP accounts and XMPP clients. Please note that this feature might require some server configuration to be available. Please refer to the [documentation](https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/) for more informations.
+
 ### Minor changes and fixes
 
 * Diagnostic tool: add the result of `prosodyctl check` in the debug section.

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -109,7 +109,7 @@ table.peertube-plugin-livechat-prosody-list-rooms td {
 
 .peertube-plugin-livechat-shareurl-modal {
   & > * {
-    margin-top: 30px;
+    margin-top: 10px;
   }
 
   .livechat-shareurl-copy {
@@ -126,8 +126,10 @@ table.peertube-plugin-livechat-prosody-list-rooms td {
     }
   }
 
-  .livechat-shareurl-custom {
-    input[type="checkbox"] {
+  .livechat-shareurl-web-options,
+  .livechat-shareurl-xmpp-options {
+    input[type="checkbox"],
+    input[type="radio"] {
       margin-right: 20px;
     }
 
@@ -135,18 +137,32 @@ table.peertube-plugin-livechat-prosody-list-rooms td {
       display: block;
     }
 
-    .livechat-shareurl-custom-readonly-options {
+    .livechat-shareurl-web-options-readonly {
       margin-left: 40px;
 
       & > * {
         display: block;
       }
 
-      &.livechat-shareurl-custom-readonly-disabled {
+      &.livechat-shareurl-web-options-readonly-disabled {
         label {
           color: var(--gray-dark);
         }
       }
     }
+  }
+
+  .livechat-shareurl-protocol {
+    display: flex;
+    flex-flow: row wrap;
+    column-gap: 30px;
+
+    input[type="radio"] {
+      margin-right: 10px;
+    }
+  }
+
+  .livechat-shareurl-tips {
+    min-height: 60px;
   }
 }

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -203,6 +203,9 @@ function register ({ registerHook, registerSettingsScript, peertubeHelpers }: Re
       switch (name) {
         case 'prosody-c2s-port':
           return options.formValues['prosody-c2s'] !== true
+        case 'prosody-s2s-port':
+        case 'prosody-s2s-interfaces':
+          return options.formValues['prosody-room-allow-s2s'] !== true
         case 'prosody-components-port':
         case 'prosody-components-list':
           return options.formValues['prosody-components'] !== true

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -205,6 +205,7 @@ function register ({ registerHook, registerSettingsScript, peertubeHelpers }: Re
           return options.formValues['prosody-c2s'] !== true
         case 'prosody-s2s-port':
         case 'prosody-s2s-interfaces':
+        case 'prosody-certificates-dir':
           return options.formValues['prosody-room-allow-s2s'] !== true
         case 'prosody-components-port':
         case 'prosody-components-list':

--- a/client/videowatch/uri.ts
+++ b/client/videowatch/uri.ts
@@ -66,10 +66,31 @@ function getIframeUri (
   return iframeUriStr
 }
 
+function getXMPPUri (
+  registerOptions: RegisterClientOptions, settings: any, video: Video
+): string | null {
+  // returns something like xmpp:256896ac-199a-4dab-bb3a-4fd916140272@room.instance.tdl?join
+  if (!settings['prosody-room-allow-s2s']) {
+    return null
+  }
+
+  let uuid: string
+  if (settings['prosody-room-type'] === 'channel') {
+    uuid = 'channel.' + video.channel.id.toString()
+  } else {
+    uuid = video.uuid.toString()
+  }
+
+  const hostname = window.location.hostname
+
+  return 'xmpp:' + uuid + '@room.' + hostname + '?join'
+}
+
 export type {
   UriOptions
 }
 export {
   getBaseRoute,
-  getIframeUri
+  getIframeUri,
+  getXMPPUri
 }

--- a/languages/ca.json
+++ b/languages/ca.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/de.json
+++ b/languages/de.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/eo.json
+++ b/languages/eo.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/eu.json
+++ b/languages/eu.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -21,5 +21,8 @@
   "Not found": "Non trouvé",
   "Video": "Vidéo",
   "Channel": "Chaîne",
-  "Last activity": "Dernière activité"
+  "Last activity": "Dernière activité",
+  "Web": "Web",
+  "Connect using XMPP": "Connexion avec un client XMPP",
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": "Vous pouvez vous connecter au salon en utilisant un compte XMPP externe, et votre client XMPP favori."
 }

--- a/languages/it.json
+++ b/languages/it.json
@@ -21,5 +21,8 @@
   "Not found": "Non trovato",
   "Video": "Video",
   "Channel": "Canale",
-  "Last activity": "Ultima attività"
+  "Last activity": "Ultima attività",
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/oc.json
+++ b/languages/oc.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -21,5 +21,8 @@
   "Not found": false,
   "Video": false,
   "Channel": false,
-  "Last activity": false
+  "Last activity": false,
+  "Web": false,
+  "Connect using XMPP": false,
+  "You can connect to the room using an external XMPP account, and your favorite XMPP client.": false
 }

--- a/languages/settings/de.yml
+++ b/languages/settings/de.yml
@@ -140,6 +140,15 @@ prosody_muc_expiration_description: |
        <li><b>nie</b>: Der Inhalt läuft nie ab und wird für immer aufbewahrt.</li>
    </ul>
 
+prosody_room_allow_s2s_label: ~
+prosody_room_allow_s2s_description: ~
+
+prosody_s2s_port_label: ~
+prosody_s2s_port_description: ~
+
+prosody_s2s_interfaces_label: ~
+prosody_s2s_interfaces_description: ~
+
 prosody_c2s_label: "Aktivieren von Client-Server-Verbindungen"
 prosody_c2s_description: |
   Ermöglichen Sie XMPP-Clients die Verbindung zum integrierten Prosody-Server.<br>

--- a/languages/settings/en.yml
+++ b/languages/settings/en.yml
@@ -140,6 +140,36 @@ prosody_muc_expiration_description: |
       <li><b>never</b>: the content will never expire, and will be kept forever.</li>
   </ul>
 
+prosody_room_allow_s2s_label: "Enable connection to room using external XMPP accounts"
+prosody_room_allow_s2s_description: |
+  By enabling this option, it will be possible to connect to rooms using external XMPP accounts and XMPP clients.<br>
+  Warning, enabling this option can request extra server and DNS configuration.
+  Please refer to the documentation:
+  <a href="https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/" target="_blank">
+    Enable external XMPP account connections.
+  </a>
+
+prosody_s2s_port_label: "Prosody server to server port"
+prosody_s2s_port_description: |
+  The port that will be used for XMPP s2s (server to server) connections.<br>
+  You should use the standard 5269 port.
+  Otherwise you should <a href="https://prosody.im/doc/s2s">
+    setup a specific DNS record
+  </a>.
+
+prosody_s2s_interfaces_label: "Server to server network interfaces"
+prosody_s2s_interfaces_description: |
+  The network interfaces to listen on for server to server connections.<br>
+  List of IP to listen on, coma separated (spaces will be stripped).<br>
+  You can use «*» to listen on all IPv4 interfaces, and «::» for all IPv6.<br>
+  Examples:
+  <ul>
+    <li>*, ::</li>
+    <li>*</li>
+    <li>127.0.0.1, ::1</li>
+    <li>172.18.0.42</li>
+  </ul>
+
 prosody_c2s_label: "Enable client to server connections"
 prosody_c2s_description: |
   Enable XMPP clients to connect to the built-in Prosody server.<br>

--- a/languages/settings/en.yml
+++ b/languages/settings/en.yml
@@ -174,7 +174,7 @@ prosody_certificates_dir_label: "Certificates directory"
 prosody_certificates_dir_description: |
   If this field is empty, the plugin will generate and use self-signed certificates.<br>
   If you want to use other certificates, just specify here the folder where
-  Prosody can find them. Note: the `peertube` user must have read access to this directory.
+  Prosody can find them. Note: the "peertube" user must have read access to this directory.
 
 prosody_c2s_label: "Enable client to server connections"
 prosody_c2s_description: |

--- a/languages/settings/en.yml
+++ b/languages/settings/en.yml
@@ -170,6 +170,12 @@ prosody_s2s_interfaces_description: |
     <li>172.18.0.42</li>
   </ul>
 
+prosody_certificates_dir_label: "Certificates directory"
+prosody_certificates_dir_description: |
+  If this field is empty, the plugin will generate and use self-signed certificates.<br>
+  If you want to use other certificates, just specify here the folder where
+  Prosody can find them. Note: the `peertube` user must have read access to this directory.
+
 prosody_c2s_label: "Enable client to server connections"
 prosody_c2s_description: |
   Enable XMPP clients to connect to the built-in Prosody server.<br>

--- a/languages/settings/fr.yml
+++ b/languages/settings/fr.yml
@@ -180,6 +180,12 @@ prosody_s2s_interfaces_description: |
     <li>172.18.0.42</li>
   </ul>
 
+prosody_certificates_dir_label: "Dossiers des certificats"
+prosody_certificates_dir_description: |
+  Si ce champ est vide, le plugin va générer et utiliser des certificats auto-signés.<br>
+  Si vous voulez utiliser d'autres certificats, vous avez juste à spécifier ici le dossier où
+  Prosody peut les trouver. Note: l'utilisateur `peertube` doit avoir un accès en lecture à ce dossier.
+
 prosody_c2s_label: "Activer les connexions client vers serveur"
 prosody_c2s_description: |
   Autoriser les clients XMPP à se connecter au serveur Prosody.<br>

--- a/languages/settings/fr.yml
+++ b/languages/settings/fr.yml
@@ -184,7 +184,7 @@ prosody_certificates_dir_label: "Dossiers des certificats"
 prosody_certificates_dir_description: |
   Si ce champ est vide, le plugin va générer et utiliser des certificats auto-signés.<br>
   Si vous voulez utiliser d'autres certificats, vous avez juste à spécifier ici le dossier où
-  Prosody peut les trouver. Note: l'utilisateur `peertube` doit avoir un accès en lecture à ce dossier.
+  Prosody peut les trouver. Note: l'utilisateur «peertube» doit avoir un accès en lecture à ce dossier.
 
 prosody_c2s_label: "Activer les connexions client vers serveur"
 prosody_c2s_description: |

--- a/languages/settings/fr.yml
+++ b/languages/settings/fr.yml
@@ -150,6 +150,36 @@ prosody_muc_expiration_description: |
       <li><b>never</b>: le contenu ne sera jamais effacé.</li>
   </ul>
 
+prosody_room_allow_s2s_label: "Autoriser les connexions aux salons via des comptes XMPP externes"
+prosody_room_allow_s2s_description: |
+  En activant cette option, il sera possible de se connecter aux salons en utilisant des comptes XMPP externes via des clients XMPP.<br>
+  Attention, activer cette option peut demander une configuration au niveau du serveur et des enregistrements DNS.
+  Pour en savoir plus, merci de vous référer à la documentation:
+  <a href="https://johnxlivingston.github.io/peertube-plugin-livechat/fr/documentation/admin/advanced/xmpp_clients/" target="_blank">
+    Autoriser les connexions avec des comptes XMPP externes.
+  </a>
+
+prosody_s2s_port_label: "Port Prosody serveur vers serveur"
+prosody_s2s_port_description: |
+  Le port à utiliser pour les connexions XMPP s2s (server to server).<br>
+  Il est recommandé d'utiliser le port standard 5269.
+  Sinon vous devrez <a href="https://prosody.im/doc/s2s">
+    configurer un enregistrement DNS spécifique
+  </a>.
+
+prosody_s2s_interfaces_label: "Interfaces réseau pour les connexions serveur vers serveur"
+prosody_s2s_interfaces_description: |
+  Les interfaces réseau sur lequelles écouter pour les connexions s2s (server to server).<br>
+  Une liste d'IP séparées par des virgules (les espaces seront retirés).
+  On pourra utiliser «*» pour écouter sur toutes les IPv4, et «::» pour toutes les IPv6.<br>
+  Exemples de configuration possible:
+  <ul>
+    <li>*, ::</li>
+    <li>*</li>
+    <li>127.0.0.1, ::1</li>
+    <li>172.18.0.42</li>
+  </ul>
+
 prosody_c2s_label: "Activer les connexions client vers serveur"
 prosody_c2s_description: |
   Autoriser les clients XMPP à se connecter au serveur Prosody.<br>

--- a/languages/settings/it.yml
+++ b/languages/settings/it.yml
@@ -134,6 +134,15 @@ prosody_muc_expiration_description: |
       <li><b>never</b>: il contenuto non sarà mai cancellato.</li>
   </ul>
 
+prosody_room_allow_s2s_label: ~
+prosody_room_allow_s2s_description: ~
+
+prosody_s2s_port_label: ~
+prosody_s2s_port_description: ~
+
+prosody_s2s_interfaces_label: ~
+prosody_s2s_interfaces_description: ~
+
 prosody_c2s_label: "Abilitare le connessioni dal client al server"
 prosody_c2s_description: |
   Consenti ai clienti XMPP a connettersi al server Prosody incorporato nel plugin.<br>

--- a/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
+++ b/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
@@ -89,7 +89,7 @@ local function apply_config(room, settings)
 		if type(config.description) == "string" then room:set_description(config.description); end
 		if type(config.language) == "string" then room:set_language(config.language); end
 		if type(config.password) == "string" then room:set_password(config.password); end
-		if type(config.subject) == "string" then room:set_subject(config.subject); end
+		if type(config.subject) == "string" then room:set_subject(room.jid, config.subject); end
 
 		if type(config.public) == "boolean" then room:set_public(config.public); end
 		if type(config.members_only) == "boolean" then room:set_members_only(config.members_only); end

--- a/prosody/appimage_aarch64.yml
+++ b/prosody/appimage_aarch64.yml
@@ -46,6 +46,7 @@ AppDir:
       - lua-event
       # lua-zlib is suggested. Not sure it is used, by make sense to add.
       - lua-zlib
+      - lua-sec
       - prosody
 
   files:

--- a/prosody/appimage_x86_64.yml
+++ b/prosody/appimage_x86_64.yml
@@ -40,6 +40,7 @@ AppDir:
       - lua-event
       # lua-zlib is suggested. Not sure it is used, by make sense to add.
       - lua-zlib
+      - lua-sec
       - prosody/bullseye-backports
 
   files:

--- a/server/lib/debug.ts
+++ b/server/lib/debug.ts
@@ -1,0 +1,19 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import * as path from 'path'
+import * as fs from 'fs'
+
+export function isDebugMode (options: RegisterServerOptions): boolean {
+  const peertubeHelpers = options.peertubeHelpers
+  const logger = peertubeHelpers.logger
+
+  if (!peertubeHelpers.plugin) {
+    return false
+  }
+  const filepath = path.resolve(peertubeHelpers.plugin.getDataDirectoryPath(), 'debug_mode')
+  logger.debug('Testing debug mode by testing if file exists: ' + filepath)
+  if (fs.existsSync(filepath)) {
+    logger.info('Plugin livechat Debug mode is on.')
+    return true
+  }
+  return false
+}

--- a/server/lib/diagnostic/backend.ts
+++ b/server/lib/diagnostic/backend.ts
@@ -5,6 +5,6 @@ export async function diagBackend (test: string, _options: RegisterServerOptions
   const result = newResult(test)
   result.label = 'Backend connection'
   result.ok = true
-  result.next = 'webchat-video'
+  result.next = 'debug'
   return result
 }

--- a/server/lib/diagnostic/debug.ts
+++ b/server/lib/diagnostic/debug.ts
@@ -1,0 +1,12 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import { newResult, TestResult } from './utils'
+import { isDebugMode } from '../../lib/debug'
+
+export async function diagDebug (test: string, options: RegisterServerOptions): Promise<TestResult> {
+  const result = newResult(test)
+  result.label = 'Test debug mode'
+  result.ok = true
+  result.messages = [isDebugMode(options) ? 'Debug mode is ON' : 'Debug mode is OFF']
+  result.next = 'webchat-video'
+  return result
+}

--- a/server/lib/diagnostic/index.ts
+++ b/server/lib/diagnostic/index.ts
@@ -1,6 +1,7 @@
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { diagBackend } from './backend'
 import { TestResult, newResult } from './utils'
+import { diagDebug } from './debug'
 import { diagProsody } from './prosody'
 import { diagVideo } from './video'
 
@@ -9,6 +10,8 @@ export async function diag (test: string, options: RegisterServerOptions): Promi
 
   if (test === 'backend') {
     result = await diagBackend(test, options)
+  } else if (test === 'debug') {
+    result = await diagDebug(test, options)
   } else if (test === 'webchat-video') {
     result = await diagVideo(test, options)
   } else if (test === 'prosody') {

--- a/server/lib/diagnostic/prosody.ts
+++ b/server/lib/diagnostic/prosody.ts
@@ -1,6 +1,6 @@
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { getProsodyConfig, getProsodyConfigContentForDiagnostic, getWorkingDir } from '../prosody/config'
-import { getProsodyAbout, testProsodyCorrectlyRunning } from '../prosody/ctl'
+import { checkProsody, getProsodyAbout, testProsodyCorrectlyRunning } from '../prosody/ctl'
 import { newResult, TestResult } from './utils'
 import { getAPIKey } from '../apikey'
 import * as fs from 'fs'
@@ -189,6 +189,12 @@ export async function diagProsody (test: string, options: RegisterServerOptions)
     result.messages.push('Error when calling Prosody test api (test-prosody-peertube): ' + (error as string))
     return result
   }
+
+  const check = await checkProsody(options)
+  result.debug.push({
+    title: 'Prosody check',
+    message: check
+  })
 
   // Checking if there is a Prosody error log, and returning last lines.
   try {

--- a/server/lib/diagnostic/prosody.ts
+++ b/server/lib/diagnostic/prosody.ts
@@ -80,6 +80,14 @@ export async function diagProsody (test: string, options: RegisterServerOptions)
     }
     result.messages.push(`Room content will be saved for '${wantedConfig.logExpiration.value}'`)
 
+    if (wantedConfig.paths.certs === undefined) {
+      result.messages.push({
+        level: 'error',
+        message: 'Error: The certificates path is misconfigured.'
+      })
+      return result
+    }
+
     await fs.promises.access(filePath, fs.constants.R_OK) // throw an error if file does not exist.
     result.messages.push(`The prosody configuration file (${filePath}) exists`)
     const actualContent = await fs.promises.readFile(filePath, {

--- a/server/lib/diagnostic/utils.ts
+++ b/server/lib/diagnostic/utils.ts
@@ -1,4 +1,4 @@
-type nextValue = 'backend' | 'webchat-video' | 'prosody'
+type nextValue = 'backend' | 'debug' | 'webchat-video' | 'prosody'
 
 interface MessageWithLevel {
   level: 'info' | 'warning' | 'error'

--- a/server/lib/prosody/certificates.ts
+++ b/server/lib/prosody/certificates.ts
@@ -7,70 +7,9 @@ import * as fs from 'fs'
 
 interface Renew {
   timer: NodeJS.Timer
+  lastFromDirMtime?: number
 }
 let renew: Renew | undefined
-
-function _filePathToTest (options: RegisterServerOptions, config: ProsodyConfig): string {
-  return path.resolve(config.paths.certs, config.host + '.crt')
-}
-
-async function ensureProsodyCertificates (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
-  if (config.certificates !== 'generate-self-signed') { return }
-  const logger = options.peertubeHelpers.logger
-  logger.info('Prosody needs certicicates, checking if certificates are okay...')
-
-  const prosodyDomain = config.host
-  const filepath = _filePathToTest(options, config)
-  if (fs.existsSync(filepath)) {
-    logger.info(`The certificate ${filepath} exists, no need to generate it`)
-    return
-  }
-
-  // Using: prososyctl --config /.../prosody.cfg.lua cert generate prosodyDomain.tld
-  await prosodyCtl(options, 'cert', {
-    additionalArgs: ['generate', prosodyDomain],
-    yesMode: true,
-    stdErrFilter: (data) => {
-      // For an unknow reason, `prosodyctl cert generate` outputs openssl data on stderr...
-      // So we filter these logs.
-      if (data.match(/Generating \w+ private key/)) { return false }
-      if (data.match(/^[.+o*\n]*$/m)) { return false }
-      if (data.match(/e is \d+/)) { return false }
-      return true
-    }
-  })
-}
-
-async function renewCheckSelfSigned (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
-  const logger = options.peertubeHelpers.logger
-  // We have to check if the self signed certificate is still valid.
-  // Prosodyctl generated certificates are valid 365 days.
-  // We will renew it every 10 months (and every X minutes in debug mode)
-
-  const renewEvery = isDebugMode(options) ? 5 * 60000 : 3600000 * 24 * 30 * 10
-  // getting the file date...
-  const filepath = _filePathToTest(options, config)
-  if (!fs.existsSync(filepath)) {
-    logger.error('Missing certificate file: ' + filepath)
-    return
-  }
-  const stat = fs.statSync(filepath)
-  const age = (new Date()).getTime() - stat.mtimeMs
-  if (age <= renewEvery) {
-    logger.debug(`The age of the certificate ${filepath} is ${age}ms, which is less than the period ${renewEvery}ms`)
-    return
-  }
-  logger.info(`The age of the certificate ${filepath} is ${age}ms, which is more than the period ${renewEvery}ms`)
-  await ensureProsodyCertificates(options, config)
-  await reloadProsody(options)
-}
-
-async function renewCheck (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
-  if (config.certificates === 'generate-self-signed') {
-    return renewCheckSelfSigned(options, config)
-  }
-  throw new Error('Unknown value for config.certificates')
-}
 
 function startProsodyCertificatesRenewCheck (options: RegisterServerOptions, config: ProsodyConfig): void {
   const logger = options.peertubeHelpers.logger
@@ -107,6 +46,105 @@ function stopProsodyCertificatesRenewCheck (options: RegisterServerOptions): voi
   }
   logger.info('Stoping Prosody Certificates Renew Check')
   clearInterval(renew.timer)
+}
+
+async function ensureProsodyCertificates (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  if (config.certificates !== 'generate-self-signed') { return }
+  const logger = options.peertubeHelpers.logger
+  logger.info('Prosody needs certificates, checking if certificates are okay...')
+
+  const prosodyDomain = config.host
+  const filepath = _filePathToTest(options, config)
+  if (!filepath) { return }
+  if (fs.existsSync(filepath)) {
+    logger.info(`The certificate ${filepath} exists, no need to generate it`)
+    return
+  }
+
+  // Using: prososyctl --config /.../prosody.cfg.lua cert generate prosodyDomain.tld
+  await prosodyCtl(options, 'cert', {
+    additionalArgs: ['generate', prosodyDomain],
+    yesMode: true,
+    stdErrFilter: (data) => {
+      // For an unknow reason, `prosodyctl cert generate` outputs openssl data on stderr...
+      // So we filter these logs.
+      if (data.match(/Generating \w+ private key/)) { return false }
+      if (data.match(/^[.+o*\n]*$/m)) { return false }
+      if (data.match(/e is \d+/)) { return false }
+      return true
+    }
+  })
+}
+
+async function renewCheck (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  if (config.certificates === 'generate-self-signed') {
+    return renewCheckSelfSigned(options, config)
+  }
+  if (config.certificates === 'use-from-dir') {
+    return renewCheckFromDir(options, config)
+  }
+  throw new Error('Unknown value for config.certificates')
+}
+
+async function renewCheckSelfSigned (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+  // We have to check if the self signed certificate is still valid.
+  // Prosodyctl generated certificates are valid 365 days.
+  // We will renew it every 10 months (and every X minutes in debug mode)
+
+  const renewEvery = isDebugMode(options) ? 5 * 60000 : 3600000 * 24 * 30 * 10
+  // getting the file date...
+  const filepath = _filePathToTest(options, config)
+  if (!filepath) { return }
+  if (!fs.existsSync(filepath)) {
+    logger.error('Missing certificate file: ' + filepath)
+    return
+  }
+  const stat = fs.statSync(filepath)
+  const age = (new Date()).getTime() - stat.mtimeMs
+  if (age <= renewEvery) {
+    logger.debug(`The age of the certificate ${filepath} is ${age}ms, which is less than the period ${renewEvery}ms`)
+    return
+  }
+  logger.info(`The age of the certificate ${filepath} is ${age}ms, which is more than the period ${renewEvery}ms`)
+  await ensureProsodyCertificates(options, config)
+  await reloadProsody(options)
+}
+
+async function renewCheckFromDir (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  // We will browse all dir files, get the more recent file update time, and compare it to the previous call.
+  const logger = options.peertubeHelpers.logger
+  if (!renew) { return }
+  let mtimeMs: number | undefined
+  const dir = config.paths.certs
+  if (!dir) { return }
+  const files = fs.readdirSync(dir, { withFileTypes: true })
+  files.forEach(file => {
+    if (!file.isFile()) { return }
+    const stat = fs.statSync(path.resolve(dir, file.name))
+    if (stat.mtimeMs > (mtimeMs ?? 0)) {
+      mtimeMs = stat.mtimeMs
+    }
+  })
+  logger.debug('renewCheckFromDir: the most recent file in the certs dir has mtimeMs=' + (mtimeMs ?? '').toString())
+  if (!mtimeMs) {
+    return
+  }
+  if (!renew.lastFromDirMtime) {
+    renew.lastFromDirMtime = mtimeMs
+    return
+  }
+  if (renew.lastFromDirMtime === mtimeMs) {
+    logger.debug('No change in certs modification dates.')
+    return
+  }
+  logger.info('There is a file that was modified in the certs dir, reloading prosody...')
+  await reloadProsody(options)
+}
+
+function _filePathToTest (options: RegisterServerOptions, config: ProsodyConfig): string | null {
+  if (!config.paths.certs) { return null }
+  return path.resolve(config.paths.certs, config.host + '.crt')
 }
 
 export {

--- a/server/lib/prosody/certificates.ts
+++ b/server/lib/prosody/certificates.ts
@@ -1,0 +1,116 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import type { ProsodyConfig } from './config'
+import { isDebugMode } from '../debug'
+import { prosodyCtl, reloadProsody } from './ctl'
+import * as path from 'path'
+import * as fs from 'fs'
+
+interface Renew {
+  timer: NodeJS.Timer
+}
+let renew: Renew | undefined
+
+function _filePathToTest (options: RegisterServerOptions, config: ProsodyConfig): string {
+  return path.resolve(config.paths.certs, config.host + '.crt')
+}
+
+async function ensureProsodyCertificates (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  if (config.certificates !== 'generate-self-signed') { return }
+  const logger = options.peertubeHelpers.logger
+  logger.info('Prosody needs certicicates, checking if certificates are okay...')
+
+  const prosodyDomain = config.host
+  const filepath = _filePathToTest(options, config)
+  if (fs.existsSync(filepath)) {
+    logger.info(`The certificate ${filepath} exists, no need to generate it`)
+    return
+  }
+
+  // Using: prososyctl --config /.../prosody.cfg.lua cert generate prosodyDomain.tld
+  await prosodyCtl(options, 'cert', {
+    additionalArgs: ['generate', prosodyDomain],
+    yesMode: true,
+    stdErrFilter: (data) => {
+      // For an unknow reason, `prosodyctl cert generate` outputs openssl data on stderr...
+      // So we filter these logs.
+      if (data.match(/Generating \w+ private key/)) { return false }
+      if (data.match(/^[.+o*\n]*$/m)) { return false }
+      if (data.match(/e is \d+/)) { return false }
+      return true
+    }
+  })
+}
+
+async function renewCheckSelfSigned (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+  // We have to check if the self signed certificate is still valid.
+  // Prosodyctl generated certificates are valid 365 days.
+  // We will renew it every 10 months (and every X minutes in debug mode)
+
+  const renewEvery = isDebugMode(options) ? 5 * 60000 : 3600000 * 24 * 30 * 10
+  // getting the file date...
+  const filepath = _filePathToTest(options, config)
+  if (!fs.existsSync(filepath)) {
+    logger.error('Missing certificate file: ' + filepath)
+    return
+  }
+  const stat = fs.statSync(filepath)
+  const age = (new Date()).getTime() - stat.mtimeMs
+  if (age <= renewEvery) {
+    logger.debug(`The age of the certificate ${filepath} is ${age}ms, which is less than the period ${renewEvery}ms`)
+    return
+  }
+  logger.info(`The age of the certificate ${filepath} is ${age}ms, which is more than the period ${renewEvery}ms`)
+  await ensureProsodyCertificates(options, config)
+  await reloadProsody(options)
+}
+
+async function renewCheck (options: RegisterServerOptions, config: ProsodyConfig): Promise<void> {
+  if (config.certificates === 'generate-self-signed') {
+    return renewCheckSelfSigned(options, config)
+  }
+  throw new Error('Unknown value for config.certificates')
+}
+
+function startProsodyCertificatesRenewCheck (options: RegisterServerOptions, config: ProsodyConfig): void {
+  const logger = options.peertubeHelpers.logger
+
+  if (!config.certificates) {
+    return
+  }
+
+  const debugMode = isDebugMode(options)
+  // check every day (or every minutes in debug mode)
+  const checkInterval = debugMode ? 60000 : 3600000 * 24
+
+  if (renew) {
+    stopProsodyCertificatesRenewCheck(options)
+  }
+
+  logger.info('Starting Prosody Certificates Renew Check')
+  renewCheck(options, config).then(() => {}, () => {})
+
+  const timer = setInterval(() => {
+    logger.debug('Checking if Prosody certificates need to be renewed')
+    renewCheck(options, config).then(() => {}, () => {})
+  }, checkInterval)
+
+  renew = {
+    timer: timer
+  }
+}
+
+function stopProsodyCertificatesRenewCheck (options: RegisterServerOptions): void {
+  const logger = options.peertubeHelpers.logger
+  if (renew === undefined) {
+    return
+  }
+  logger.info('Stoping Prosody Certificates Renew Check')
+  clearInterval(renew.timer)
+}
+
+export {
+  ensureProsodyCertificates,
+  startProsodyCertificatesRenewCheck,
+  stopProsodyCertificatesRenewCheck
+}

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -87,6 +87,8 @@ async function getProsodyFilePaths (options: RegisterServerOptions): Promise<Pro
   }
 }
 
+type ProsodyConfigCertificates = false | 'generate-self-signed'
+
 interface ProsodyConfig {
   content: string
   paths: ProsodyFilePaths
@@ -97,7 +99,7 @@ interface ProsodyConfig {
   logByDefault: boolean
   logExpiration: ConfigLogExpiration
   valuesToHideInDiagnostic: Map<string, string>
-  needCerticates: boolean
+  certificates: ProsodyConfigCertificates
 }
 async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<ProsodyConfig> {
   const logger = options.peertubeHelpers.logger
@@ -134,7 +136,7 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
   const prosodyDomain = await getProsodyDomain(options)
   const paths = await getProsodyFilePaths(options)
   const roomType = settings['prosody-room-type'] === 'channel' ? 'channel' : 'video'
-  let needCerticates: boolean = false
+  let certificates: ProsodyConfigCertificates = false
 
   const apikey = await getAPIKey(options)
   valuesToHideInDiagnostic.set('APIKey', apikey)
@@ -182,7 +184,7 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
   }
 
   if (enableRoomS2S) {
-    needCerticates = true
+    certificates = 'generate-self-signed'
     const s2sPort = (settings['prosody-s2s-port'] as string) || '5269'
     if (!/^\d+$/.test(s2sPort)) {
       throw new Error('Invalid s2s port')
@@ -238,7 +240,7 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
     logByDefault,
     logExpiration,
     valuesToHideInDiagnostic,
-    needCerticates
+    certificates
   }
 }
 

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -27,7 +27,7 @@ async function getProsodyFilePaths (options: RegisterServerOptions): Promise<Pro
   logger.debug('Calling getProsodyFilePaths')
 
   const dir = await getWorkingDir(options)
-  const settings = await options.settingsManager.getSettings(['use-system-prosody'])
+  const settings = await options.settingsManager.getSettings(['use-system-prosody', 'prosody-room-allow-s2s'])
   let exec
   let execArgs: string[] = []
   let execCtl
@@ -60,6 +60,14 @@ async function getProsodyFilePaths (options: RegisterServerOptions): Promise<Pro
     }
   }
 
+  let certsDir = path.resolve(dir, 'certs')
+  if (settings['prosody-room-allow-s2s']) {
+    // Note: when using prosodyctl to generate self-signed certificates,
+    // there are wrongly generated in the data dir.
+    // So we will use this dir as the certs dir.
+    certsDir = path.resolve(dir, 'data')
+  }
+
   return {
     dir: dir,
     pid: path.resolve(dir, 'prosody.pid'),
@@ -67,9 +75,7 @@ async function getProsodyFilePaths (options: RegisterServerOptions): Promise<Pro
     log: path.resolve(dir, 'prosody.log'),
     config: path.resolve(dir, 'prosody.cfg.lua'),
     data: path.resolve(dir, 'data'),
-    // Certificates dir for Prosody.
-    // Note: not used yet, but we create the directory to avoid errors in prosody logs.
-    certs: path.resolve(dir, 'certs'),
+    certs: certsDir,
     modules: path.resolve(__dirname, '../../prosody-modules'),
     avatars: path.resolve(__dirname, '../../avatars'),
     exec,

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -91,6 +91,7 @@ interface ProsodyConfig {
   logByDefault: boolean
   logExpiration: ConfigLogExpiration
   valuesToHideInDiagnostic: Map<string, string>
+  needCerticates: boolean
 }
 async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<ProsodyConfig> {
   const logger = options.peertubeHelpers.logger
@@ -127,6 +128,7 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
   const prosodyDomain = await getProsodyDomain(options)
   const paths = await getProsodyFilePaths(options)
   const roomType = settings['prosody-room-type'] === 'channel' ? 'channel' : 'video'
+  let needCerticates: boolean = false
 
   const apikey = await getAPIKey(options)
   valuesToHideInDiagnostic.set('APIKey', apikey)
@@ -174,6 +176,7 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
   }
 
   if (enableRoomS2S) {
+    needCerticates = true
     const s2sPort = (settings['prosody-s2s-port'] as string) || '5269'
     if (!/^\d+$/.test(s2sPort)) {
       throw new Error('Invalid s2s port')
@@ -228,7 +231,8 @@ async function getProsodyConfig (options: RegisterServerOptionsV5): Promise<Pros
     roomType,
     logByDefault,
     logExpiration,
-    valuesToHideInDiagnostic
+    valuesToHideInDiagnostic,
+    needCerticates
   }
 }
 
@@ -309,6 +313,7 @@ function getProsodyConfigContentForDiagnostic (config: ProsodyConfig, content?: 
 }
 
 export {
+  ProsodyConfig,
   getProsodyConfig,
   getWorkingDir,
   getProsodyFilePaths,

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -64,22 +64,26 @@ async function getProsodyFilePaths (options: RegisterServerOptions): Promise<Pro
 
   let certsDir: string | undefined = path.resolve(dir, 'certs')
   let certsDirIsCustom = false
-  if ((settings['prosody-certificates-dir'] as string ?? '') !== '') {
-    if (!fs.statSync(settings['prosody-certificates-dir'] as string).isDirectory()) {
-      // We can throw an exception here...
-      // Because if the user input a wrong directory, the plugin will not register,
-      // and he will never be able to fix the conf
-      logger.error('Certificate directory does not exist or is not a directory')
-      certsDir = undefined
+  if (settings['prosody-room-allow-s2s']) {
+    if ((settings['prosody-certificates-dir'] as string ?? '') !== '') {
+      if (!fs.statSync(settings['prosody-certificates-dir'] as string).isDirectory()) {
+        // We can throw an exception here...
+        // Because if the user input a wrong directory, the plugin will not register,
+        // and he will never be able to fix the conf
+        logger.error('Certificate directory does not exist or is not a directory')
+        certsDir = undefined
+      } else {
+        certsDir = settings['prosody-certificates-dir'] as string
+      }
+      certsDirIsCustom = true
     } else {
-      certsDir = settings['prosody-certificates-dir'] as string
+      // In this case we are generating and using self signed certificates
+
+      // Note: when using prosodyctl to generate self-signed certificates,
+      // there are wrongly generated in the data dir.
+      // So we will use this dir as the certs dir.
+      certsDir = path.resolve(dir, 'data')
     }
-    certsDirIsCustom = true
-  } else if (settings['prosody-room-allow-s2s']) {
-    // Note: when using prosodyctl to generate self-signed certificates,
-    // there are wrongly generated in the data dir.
-    // So we will use this dir as the certs dir.
-    certsDir = path.resolve(dir, 'data')
   }
 
   return {

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -260,7 +260,9 @@ class ProsodyConfigContent {
   useRoomS2S (s2sPort: string, s2sInterfaces: string[]): void {
     this.global.set('s2s_ports', [s2sPort])
     this.global.set('s2s_interfaces', s2sInterfaces)
+    this.global.set('s2s_secure_auth', false)
     this.muc.add('modules_enabled', 's2s')
+    this.muc.add('modules_enabled', 'dialback') // This allows s2s connections without certicicates!
   }
 
   useExternalComponents (componentsPort: string, components: ExternalComponent[]): void {

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -173,7 +173,7 @@ class ProsodyConfigContent {
     this.global.set('consider_bosh_secure', false)
     // this.global.set('cross_domain_websocket', false) No more needed with Prosody 0.12
     this.global.set('consider_websocket_secure', false)
-    this.global.set('certificates', this.paths.data)
+    this.global.set('certificates', this.paths.certs)
 
     this.muc.set('muc_room_locking', false)
     this.muc.set('muc_tombstones', false)

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -145,7 +145,7 @@ class ProsodyConfigContent {
     this.global.set('pidfile', this.paths.pid)
     this.global.set('plugin_paths', [this.paths.modules])
     this.global.set('data_path', this.paths.data)
-    this.global.set('default_storage', 'internal')
+    // this.global.set('default_storage', 'internal') Not needed as storage is set to a string
     this.global.set('storage', 'internal')
 
     this.global.set('modules_enabled', [
@@ -162,7 +162,6 @@ class ProsodyConfigContent {
       // 'vcard_legacy' // Conversion between legacy vCard and PEP Avatar, vcard
       // 'vcard4' // User profiles (stored in PEP)
       'disco' // Enable mod_disco (feature discovering)
-
     ])
     this.global.set('modules_disabled', [
       // 'offline' // Store offline messages
@@ -170,10 +169,11 @@ class ProsodyConfigContent {
       's2s' // Handle server-to-server connections
     ])
 
-    this.global.set('cross_domain_bosh', false)
+    // this.global.set('cross_domain_bosh', false) No more needed with Prosody 0.12
     this.global.set('consider_bosh_secure', false)
-    this.global.set('cross_domain_websocket', false)
+    // this.global.set('cross_domain_websocket', false) No more needed with Prosody 0.12
     this.global.set('consider_websocket_secure', false)
+    this.global.set('certificates', this.paths.data)
 
     this.muc.set('muc_room_locking', false)
     this.muc.set('muc_tombstones', false)
@@ -197,7 +197,7 @@ class ProsodyConfigContent {
     this.authenticated = new ProsodyConfigVirtualHost(this.prosodyDomain)
 
     this.authenticated.set('authentication', 'http')
-    this.authenticated.set('modules_enabled', ['ping', 'auth_http'])
+    this.authenticated.set('modules_enabled', ['ping'])
 
     this.authenticated.set('http_auth_url', url)
   }
@@ -213,6 +213,7 @@ class ProsodyConfigContent {
     this.global.set('http_interfaces', ['127.0.0.1', '::1'])
     this.global.set('https_ports', [])
     this.global.set('https_interfaces', ['127.0.0.1', '::1'])
+    this.global.set('trusted_proxies', ['127.0.0.1', '::1'])
 
     this.global.set('consider_bosh_secure', true)
     if (useWS) {
@@ -221,11 +222,10 @@ class ProsodyConfigContent {
       this.global.set('c2s_close_timeout', 29)
 
       // This line seems to be required by Prosody, otherwise it rejects websocket...
-      this.global.set('cross_domain_websocket', [publicServerUrl])
+      // this.global.set('cross_domain_websocket', [publicServerUrl])  No more needed with Prosody 0.12
     }
 
     if (this.anon) {
-      this.anon.set('trusted_proxies', ['127.0.0.1', '::1'])
       this.anon.set('allow_anonymous_s2s', false)
       this.anon.add('modules_enabled', 'http')
       this.anon.add('modules_enabled', 'bosh')
@@ -241,7 +241,6 @@ class ProsodyConfigContent {
     this.muc.set('http_external_url', 'http://' + prosodyDomain)
 
     if (this.authenticated) {
-      this.authenticated.set('trusted_proxies', ['127.0.0.1', '::1'])
       this.authenticated.set('allow_anonymous_s2s', false)
       this.authenticated.add('modules_enabled', 'http')
       this.authenticated.add('modules_enabled', 'bosh')
@@ -261,6 +260,7 @@ class ProsodyConfigContent {
     this.global.set('s2s_ports', [s2sPort])
     this.global.set('s2s_interfaces', s2sInterfaces)
     this.global.set('s2s_secure_auth', false)
+    this.global.add('modules_enabled', 'tls') // required for s2s and co
     this.muc.add('modules_enabled', 's2s')
     this.muc.add('modules_enabled', 'dialback') // This allows s2s connections without certicicates!
   }

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -173,7 +173,9 @@ class ProsodyConfigContent {
     this.global.set('consider_bosh_secure', false)
     // this.global.set('cross_domain_websocket', false) No more needed with Prosody 0.12
     this.global.set('consider_websocket_secure', false)
-    this.global.set('certificates', this.paths.certs)
+    if (this.paths.certs) {
+      this.global.set('certificates', this.paths.certs)
+    }
 
     this.muc.set('muc_room_locking', false)
     this.muc.set('muc_tombstones', false)

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -257,6 +257,12 @@ class ProsodyConfigContent {
     this.global.set('c2s_ports', [c2sPort])
   }
 
+  useRoomS2S (s2sPort: string, s2sInterfaces: string[]): void {
+    this.global.set('s2s_ports', [s2sPort])
+    this.global.set('s2s_interfaces', s2sInterfaces)
+    this.muc.add('modules_enabled', 's2s')
+  }
+
   useExternalComponents (componentsPort: string, components: ExternalComponent[]): void {
     this.global.set('component_ports', [componentsPort])
     this.global.set('component_interfaces', ['127.0.0.1', '::1'])

--- a/server/lib/prosody/config/paths.ts
+++ b/server/lib/prosody/config/paths.ts
@@ -5,7 +5,8 @@ interface ProsodyFilePaths {
   log: string
   config: string
   data: string
-  certs: string
+  certs?: string
+  certsDirIsCustom: boolean
   modules: string
   avatars: string
   exec?: string

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -347,7 +347,7 @@ async function ensureProsodyRunning (options: RegisterServerOptions): Promise<vo
     return
   }
   logger.info('Prosody is running')
-  startProsodyLogRotate(options, filePaths, reloadProsody)
+  await startProsodyLogRotate(options, filePaths, reloadProsody)
 }
 
 async function ensureProsodyNotRunning (options: RegisterServerOptions): Promise<void> {

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -12,7 +12,8 @@ async function _ensureWorkingDir (
   options: RegisterServerOptions,
   workingDir: string,
   dataDir: string,
-  certsDir: string,
+  certsDir: string | undefined,
+  certsDirIsCustom: boolean,
   appImageExtractPath: string
 ): Promise<string> {
   const logger = options.peertubeHelpers.logger
@@ -33,7 +34,7 @@ async function _ensureWorkingDir (
     logger.debug(`data dir ${dataDir} was created`)
   }
 
-  if (!fs.existsSync(certsDir)) {
+  if (certsDir && !certsDirIsCustom && !fs.existsSync(certsDir)) {
     // Certificates dir for Prosody.
     // Note: not used yet, but we create the directory to avoid errors in prosody logs.
     logger.info(`The certs dir ${certsDir} does not exists, trying to create it`)
@@ -61,7 +62,14 @@ async function prepareProsody (options: RegisterServerOptions): Promise<void> {
   const filePaths = await getProsodyFilePaths(options)
 
   logger.debug('Ensuring that the working dir exists')
-  await _ensureWorkingDir(options, filePaths.dir, filePaths.data, filePaths.certs, filePaths.appImageExtractPath)
+  await _ensureWorkingDir(
+    options,
+    filePaths.dir,
+    filePaths.data,
+    filePaths.certs,
+    filePaths.certsDirIsCustom,
+    filePaths.appImageExtractPath
+  )
 
   const appImageToExtract = filePaths.appImageToExtract
   if (!appImageToExtract) {

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -158,6 +158,11 @@ async function reloadProsody (options: RegisterServerOptions): Promise<boolean> 
   return true
 }
 
+async function checkProsody (options: RegisterServerOptions): Promise<string> {
+  const ctl = await prosodyCtl(options, 'check')
+  return ctl.message
+}
+
 interface ProsodyRunning {
   ok: boolean
   messages: string[]
@@ -341,6 +346,7 @@ async function ensureProsodyNotRunning (options: RegisterServerOptions): Promise
 
 export {
   getProsodyAbout,
+  checkProsody,
   testProsodyRunning,
   testProsodyCorrectlyRunning,
   prepareProsody,

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -5,6 +5,7 @@ import {
   ensureProsodyCertificates, startProsodyCertificatesRenewCheck, stopProsodyCertificatesRenewCheck
 } from './certificates'
 import { disableProxyRoute, enableProxyRoute } from '../routers/webchat'
+import { fixRoomSubject } from './fix-room-subject'
 import * as fs from 'fs'
 import * as child_process from 'child_process'
 
@@ -70,6 +71,12 @@ async function prepareProsody (options: RegisterServerOptions): Promise<void> {
     filePaths.certsDirIsCustom,
     filePaths.appImageExtractPath
   )
+
+  try {
+    await fixRoomSubject(options, filePaths)
+  } catch (err) {
+    logger.error(err)
+  }
 
   const appImageToExtract = filePaths.appImageToExtract
   if (!appImageToExtract) {

--- a/server/lib/prosody/fix-room-subject.ts
+++ b/server/lib/prosody/fix-room-subject.ts
@@ -1,0 +1,56 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import { ProsodyFilePaths } from './config/paths'
+import * as path from 'path'
+import * as fs from 'fs'
+
+/**
+ * Until plugin verstion 6.2.3, there where a bug in mod_muc_http_defaults
+ * that messed up room metadata. This bug is blocking for external XMPP account
+ * connections.
+ * This functions corrects room metadata if needed.
+ * @param options
+ * @param filePaths
+ */
+export async function fixRoomSubject (options: RegisterServerOptions, filePaths: ProsodyFilePaths): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+  // When this scripts run the first time, it create a file, so that we can know if we need to run it again:
+  const doneFilePath = path.resolve(filePaths.dir, 'fix-room-done')
+  if (fs.existsSync(doneFilePath)) {
+    logger.debug('fixRoomSubject already runned.')
+    return
+  }
+
+  logger.info('Fixing Prosody room subjects...')
+
+  // Room data are in a folder named something like "room%2evideos%2edomain%2etld".
+  // There should only be one. But if you renamed your instance, it could be more than one.
+  // Just in case, we will loop on each folder with name beginning with "room%2e".
+  const folders = fs.readdirSync(filePaths.data, { withFileTypes: true }).filter(file => {
+    return file.isDirectory() && file.name.startsWith('room%2e')
+  })
+  folders.forEach(folder => {
+    // the folder must contain a «config» directory
+    const configDir = path.resolve(filePaths.data, folder.name, 'config')
+    if (!fs.existsSync(configDir)) { return }
+    const roomDataFiles = fs.readdirSync(configDir, { withFileTypes: true }).filter(file => {
+      return file.isFile() && file.name.endsWith('.dat')
+    })
+    roomDataFiles.forEach(file => {
+      logger.debug('Checking room ' + file.name + ' subject')
+      const filepath = path.resolve(configDir, file.name)
+      let content = fs.readFileSync(filepath).toString()
+      // To detect wrongly configured files, we just check if there is a "subject_from" and no "subject" key.
+      // Indeed, the bug was that mod_muc_http_defaults set subject_from (which should be a jid) to the subject, and
+      // did not set any subject.
+      // See https://hg.prosody.im/prosody-modules/rev/6d99ddd99694
+      if (content.includes('["subject_from"]') && !content.includes('["subject"]')) {
+        logger.info('We must fix room ' + file.name + ' by removing subject_from')
+        content = content.replace(/^\s*\["subject_from"\]\s*=.*;\s*$/gm, '')
+        content = content.replace(/^\s*\["subject_time"\]\s*=.*;\s*$/gm, '')
+        fs.writeFileSync(filepath, content)
+      }
+    })
+  })
+
+  fs.writeFileSync(doneFilePath, '')
+}

--- a/server/lib/prosody/logrotate.ts
+++ b/server/lib/prosody/logrotate.ts
@@ -1,5 +1,6 @@
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ProsodyFilePaths } from './config/paths'
+import { isDebugMode } from '../debug'
 
 type Rotate = (file: string, options: {
   count?: number
@@ -32,8 +33,9 @@ async function _rotate (options: RegisterServerOptions, path: string): Promise<v
 
 function startProsodyLogRotate (options: RegisterServerOptions, paths: ProsodyFilePaths, reload: ReloadProsody): void {
   const logger = options.peertubeHelpers.logger
-  const checkInterval = process.env.NODE_ENV === 'test' ? 60 * 1000 : 60 * 60 * 1000 // check every hour
-  const rotateEvery = process.env.NODE_ENV === 'test' ? 2 * 60 * 1000 : 24 * 60 * 60 * 1000 // rotate every 24hour
+  const debugMode = isDebugMode(options)
+  const checkInterval = debugMode ? 60 * 1000 : 60 * 60 * 1000 // check every hour
+  const rotateEvery = debugMode ? 2 * 60 * 1000 : 24 * 60 * 60 * 1000 // rotate every 24hour
   // TODO: also rotate when file is too big
 
   if (logRotate) {

--- a/server/lib/prosody/logrotate.ts
+++ b/server/lib/prosody/logrotate.ts
@@ -1,6 +1,7 @@
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ProsodyFilePaths } from './config/paths'
 import { isDebugMode } from '../debug'
+import { reloadProsody } from './ctl'
 
 type Rotate = (file: string, options: {
   count?: number
@@ -12,7 +13,6 @@ interface ProsodyLogRotate {
   timer: NodeJS.Timeout
   lastRotation: number
 }
-type ReloadProsody = (options: RegisterServerOptions) => Promise<boolean>
 
 let logRotate: ProsodyLogRotate | undefined
 
@@ -31,7 +31,7 @@ async function _rotate (options: RegisterServerOptions, path: string): Promise<v
   return p
 }
 
-function startProsodyLogRotate (options: RegisterServerOptions, paths: ProsodyFilePaths, reload: ReloadProsody): void {
+function startProsodyLogRotate (options: RegisterServerOptions, paths: ProsodyFilePaths): void {
   const logger = options.peertubeHelpers.logger
   const debugMode = isDebugMode(options)
   const checkInterval = debugMode ? 60 * 1000 : 60 * 60 * 1000 // check every hour
@@ -63,7 +63,7 @@ function startProsodyLogRotate (options: RegisterServerOptions, paths: ProsodyFi
       _rotate(options, paths.error)
     ])
     p.then(() => {
-      reload(options).then(() => {
+      reloadProsody(options).then(() => {
         logger.debug('Prosody reloaded')
       }, () => {
         logger.error('Prosody failed to reload')

--- a/server/lib/routers/api.ts
+++ b/server/lib/routers/api.ts
@@ -21,7 +21,8 @@ interface RoomDefaults {
     members_only?: boolean
     allow_member_invites?: boolean
     public_jids?: boolean
-    subject: string
+    // subject_from: string
+    // subject: string
     changesubject?: boolean
     // historylength: number
     moderated?: boolean
@@ -80,8 +81,8 @@ async function initApiRouter (options: RegisterServerOptions): Promise<Router> {
         const roomDefaults: RoomDefaults = {
           config: {
             name: channelInfos.displayName,
-            description: '',
-            subject: channelInfos.displayName
+            description: ''
+            // subject: channelInfos.displayName
           },
           affiliations: affiliations
         }
@@ -129,8 +130,8 @@ async function initApiRouter (options: RegisterServerOptions): Promise<Router> {
           config: {
             name: video.name,
             description: '',
-            language: video.language,
-            subject: video.name
+            language: video.language
+            // subject: video.name
           },
           affiliations: affiliations
         }

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -303,6 +303,33 @@ Please read
   })
 
   registerSetting({
+    name: 'prosody-room-allow-s2s',
+    label: loc('prosody_room_allow_s2s_label'),
+    type: 'input-checkbox',
+    default: false,
+    private: true,
+    descriptionHTML: loc('prosody_room_allow_s2s_description')
+  })
+
+  registerSetting({
+    name: 'prosody-s2s-port',
+    label: loc('prosody_s2s_port_label'),
+    type: 'input',
+    default: '5269',
+    private: true,
+    descriptionHTML: loc('prosody_s2s_port_description')
+  })
+
+  registerSetting({
+    name: 'prosody-s2s-interfaces',
+    label: loc('prosody_s2s_interfaces_label'),
+    type: 'input',
+    default: '*, ::',
+    private: true,
+    descriptionHTML: loc('prosody_s2s_interfaces_description')
+  })
+
+  registerSetting({
     name: 'prosody-c2s',
     label: loc('prosody_c2s_label'),
     type: 'input-checkbox',

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -307,7 +307,7 @@ Please read
     label: loc('prosody_room_allow_s2s_label'),
     type: 'input-checkbox',
     default: false,
-    private: true,
+    private: false,
     descriptionHTML: loc('prosody_room_allow_s2s_description')
   })
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -330,6 +330,15 @@ Please read
   })
 
   registerSetting({
+    name: 'prosody-certificates-dir',
+    label: loc('prosody_certificates_dir_label'),
+    type: 'input',
+    default: '',
+    private: true,
+    descriptionHTML: loc('prosody_certificates_dir_description')
+  })
+
+  registerSetting({
     name: 'prosody-c2s',
     label: loc('prosody_c2s_label'),
     type: 'input-checkbox',

--- a/support/documentation/content/contributing/develop/_index.de.md
+++ b/support/documentation/content/contributing/develop/_index.de.md
@@ -64,3 +64,16 @@ ESBuild kann mit Typescript umgehen, prüft aber keine Typen
 (siehe [ESBuild-Dokumentation](https://esbuild.github.io/content-types/#typescript)).
 Deshalb kompilieren wir Typescript zuerst mit der Option `-noEmit`, nur um die Typen zu überprüfen (`check:client:ts` in der package.json Datei).
 Dann, wenn alles in Ordnung ist, führen wir ESBuild aus, um das kompilierte Javascript zu erzeugen.
+
+## Debug Mode
+
+There is a debug mode for this plugin, that shorten some delay.
+For example, some log files will rotate every two minutes, instead of once per day.
+This permit to test more easily certain actions, for which it could normally take hours or days to wait.
+
+To enable this mode, you juste have to create the
+`/var/www/peertube/storage/plugins/data/peertube-plugin-livechat/debug_mode` file
+(replacing `/var/www/peertube/storage/` by the correct path on your installation).
+
+The simple existence of this file is sufficient to trigger the debug mode.
+To make sure it's taken into account, you can restart your Peertube instance.

--- a/support/documentation/content/contributing/develop/_index.en.md
+++ b/support/documentation/content/contributing/develop/_index.en.md
@@ -66,3 +66,16 @@ ESBuild can handle Typescript, but does not check types
 (see [ESBuild documentation](https://esbuild.github.io/content-types/#typescript)).
 That's why we first compile Typescript with the `-noEmit` option, just to check types (`check:client:ts` in package.json file).
 Then, if everything is okay, we run ESBuild to generate the compiled javascript.
+
+## Debug Mode
+
+There is a debug mode for this plugin, that shorten some delay.
+For example, some log files will rotate every two minutes, instead of once per day.
+This permit to test more easily certain actions, for which it could normally take hours or days to wait.
+
+To enable this mode, you juste have to create the
+`/var/www/peertube/storage/plugins/data/peertube-plugin-livechat/debug_mode` file
+(replacing `/var/www/peertube/storage/` by the correct path on your installation).
+
+The simple existence of this file is sufficient to trigger the debug mode.
+To make sure it's taken into account, you can restart your Peertube instance.

--- a/support/documentation/content/contributing/develop/_index.fr.md
+++ b/support/documentation/content/contributing/develop/_index.fr.md
@@ -64,3 +64,17 @@ ESBuild peut gérer Typescript, mais ne vérifie pas les types
 (voir [la documentation ESBuild](https://esbuild.github.io/content-types/#typescript)).
 C'est pourquoi on compile d'abord Typescript avec l'option `-noEmit`, juste pour vérifier les types (`check:client:ts` dans le fichier package.json).
 Ensuite, si tout est ok, on lance ESBuild pour générer le javascript compilé.
+
+## Debug Mode
+
+Il existe un mode de debug pour le plugin, qui va raccourcir le délais de certaines actions.
+Par exemple, il va faire tourner les journaux toutes les deux minutes, au lieu de tous les jours.
+Cela permet de tester plus facilement certaines actions, pour lesquelles il faudrait normalement attendre
+des heures ou des jours.
+
+Pour activer ce mode, il suffit de créer un fichier
+`/var/www/peertube/storage/plugins/data/peertube-plugin-livechat/debug_mode`
+(en adaptant `/var/www/peertube/storage/` à votre installation le cas échéant).
+
+La simple existance de ce fichier suffit à déclencher le mode debug.
+Pour être sûr qu'il est pris en compte, vous pouvez redémarrer votre instance Peertube.

--- a/support/documentation/content/documentation/admin/advanced/xmpp_clients.de.md
+++ b/support/documentation/content/documentation/admin/advanced/xmpp_clients.de.md
@@ -1,0 +1,10 @@
++++
+title="Allow connection using XMPP clients"
+description="Allow connections using external XMPP accounts and XMPP clients"
+weight=30
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/documentation/admin/advanced/xmpp_clients.en.md
+++ b/support/documentation/content/documentation/admin/advanced/xmpp_clients.en.md
@@ -1,0 +1,15 @@
++++
+title="XMPP clients"
+description="Allow connections using external XMPP accounts and XMPP clients"
+weight=30
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not written yet. It should explain how you can connect with XMPP clients.
+{{% /notice %}}
+
+{{% notice tip %}}
+For now you can't connect to your Peertube chat account using a XMPP client.
+This feature could be added one day, depending on the interest about it.
+{{% /notice %}}

--- a/support/documentation/content/documentation/admin/advanced/xmpp_clients.fr.md
+++ b/support/documentation/content/documentation/admin/advanced/xmpp_clients.fr.md
@@ -1,0 +1,10 @@
++++
+title="Allow connection using XMPP clients"
+description="Allow connections using external XMPP accounts and XMPP clients"
+weight=30
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/documentation/admin/advanced/xmpp_clients.ja.md
+++ b/support/documentation/content/documentation/admin/advanced/xmpp_clients.ja.md
@@ -1,0 +1,10 @@
++++
+title="Allow connection using XMPP clients"
+description="Allow connections using external XMPP accounts and XMPP clients"
+weight=30
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/documentation/admin/settings.de.md
+++ b/support/documentation/content/documentation/admin/settings.de.md
@@ -139,6 +139,36 @@ indem Sie seine Eigenschaften bearbeiten.
 Hier können Sie die Ablaufzeit für Raumprotokolle einstellen.
 Siehe die Online-Hilfe für akzeptierte Werte.
 
+### Enable connection to room using external XMPP accounts
+
+By enabling this option, it will be possible to connect to rooms using external XMPP accounts and XMPP clients.<br>
+Warning, enabling this option can request extra server and DNS configuration.
+Please refer to the documentation: [Enable external XMPP account connections](/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/).
+
+### Prosody server to server port
+
+The port that will be used for XMPP s2s (server to server) connections.<br>
+You should use the standard 5269 port.
+Otherwise you should [setup a specific DNS record](https://prosody.im/doc/s2s).
+
+### Server to server network interfaces
+
+The network interfaces to listen on for server to server connections.<br>
+List of IP to listen on, coma separated (spaces will be stripped).<br>
+You can use «*» to listen on all IPv4 interfaces, and «::» for all IPv6.<br>
+Examples:
+
+- `*, ::`
+- `*`
+- `127.0.0.1, ::1`
+- `172.18.0.42`
+
+### Certificates directory
+
+If this field is empty, the plugin will generate and use self-signed certificates.<br>
+If you want to use other certificates, just specify here the folder where
+Prosody can find them. Note: the `peertube` user must have read access to this directory.
+
 ### Enable client to server connections (Aktivieren von Client-Server-Verbindungen)
 
 Diese Einstellung ermöglicht es XMPP-Clients, sich mit dem eingebauten Prosody-Server zu verbinden.

--- a/support/documentation/content/documentation/admin/settings.en.md
+++ b/support/documentation/content/documentation/admin/settings.en.md
@@ -135,6 +135,30 @@ by editing its properties.
 You can set here the expiration delay for room logs.
 See the online help for accepted values.
 
+### Enable connection to room using external XMPP accounts
+
+By enabling this option, it will be possible to connect to rooms using external XMPP accounts and XMPP clients.<br>
+Warning, enabling this option can request extra server and DNS configuration.
+Please refer to the documentation: [Enable external XMPP account connections](/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/).
+
+### Prosody server to server port
+
+The port that will be used for XMPP s2s (server to server) connections.<br>
+You should use the standard 5269 port.
+Otherwise you should [setup a specific DNS record](https://prosody.im/doc/s2s).
+
+### Server to server network interfaces
+
+The network interfaces to listen on for server to server connections.<br>
+List of IP to listen on, coma separated (spaces will be stripped).<br>
+You can use «*» to listen on all IPv4 interfaces, and «::» for all IPv6.<br>
+Examples:
+
+- `*, ::`
+- `*`
+- `127.0.0.1, ::1`
+- `172.18.0.42`
+
 ### Enable client to server connections
 
 This setting enable XMPP clients to connect to the built-in Prosody server.

--- a/support/documentation/content/documentation/admin/settings.en.md
+++ b/support/documentation/content/documentation/admin/settings.en.md
@@ -159,6 +159,12 @@ Examples:
 - `127.0.0.1, ::1`
 - `172.18.0.42`
 
+### Certificates directory
+
+If this field is empty, the plugin will generate and use self-signed certificates.<br>
+If you want to use other certificates, just specify here the folder where
+Prosody can find them. Note: the `peertube` user must have read access to this directory.
+
 ### Enable client to server connections
 
 This setting enable XMPP clients to connect to the built-in Prosody server.


### PR DESCRIPTION
### New Features

* XMPP clients: you can now allow connection to rooms using external XMPP accounts and XMPP clients.

### Minor changes and fixes

* Diagnostic tool: add the result of `prosodyctl check` in the debug section.
* New debug mode
* Fix room topic: due to a [bug in mod_muc_http_defaults](https://hg.prosody.im/prosody-modules/rev/6d99ddd99694), room topics were badly configured. The plugin will fix them at startup, and stops trying to set the subject.


Implements https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/114