### PR TITLE
Fix docker certbot renewal documentation

### DIFF
--- a/support/documentation/content/documentation/admin/advanced/xmpp_clients.en.md
+++ b/support/documentation/content/documentation/admin/advanced/xmpp_clients.en.md
@@ -268,7 +268,7 @@ Modify your `docker-compose.yml` file, changing the `entrypoint` line under the 
 This is the same as the above, but to be automatically executed after every certificate renewal.
 
 ```text
-  entrypoint: /bin/sh -c "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; chown -R root:999 /etc/letsencrypt/live; chmod 750 /etc/letsencrypt/live; chown -R root:999 /etc/letsencrypt/archive; chmod 750 /etc/letsencrypt/archive; find /etc/letsencrypt/ -name 'privkey*' -exec chmod 0640 {} \; sleep 12h & wait $${!}; done;"
+  entrypoint: /bin/sh -c "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; chown -R root:999 /etc/letsencrypt/live; chmod 750 /etc/letsencrypt/live; chown -R root:999 /etc/letsencrypt/archive; chmod 750 /etc/letsencrypt/archive; find /etc/letsencrypt/ -name 'privkey*' -exec chmod 0640 {} +; sleep 12h & wait $${!}; done;"
 ```
 
 Continuing to modify `docker-compose.yml`, add the certbot certificate volume into the peertube container.


### PR DESCRIPTION
This fixes a small error in the docker certbot documentation, in find -exec.  Without this, the renewal will result in an infinite loop of failure because of the way `\;` is interpreted.