### PR TITLE
113 tk2211 0110 activypub chat standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## New Features
 
-* Implementing the [FEP-1970](https://codeberg.org/fediverse/fep/src/branch/main/fep/0ea0/fep-0ea0.md) draft for ActivityPub chat declaration.
+* Implementing the [FEP-1970](https://codeberg.org/fediverse/fep/src/branch/main/fep/1970/fep-1970.md) draft for ActivityPub chat declaration.
 
 ## 7.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.2.0 (Not Released Yet)
+
+## New Features
+
+* Implementing the [FEP-1970](https://codeberg.org/fediverse/fep/src/branch/main/fep/0ea0/fep-0ea0.md) draft for ActivityPub chat declaration.
+
 ## 7.1.0
 
 ### Minor changes and fixes

--- a/server/lib/federation/outgoing.ts
+++ b/server/lib/federation/outgoing.ts
@@ -12,6 +12,7 @@ import { getBoshUri, getWSUri, getWSS2SUri, getPublicChatUri } from '../uri/webc
 import { canonicalizePluginUri } from '../uri/canonicalize'
 import { getProsodyDomain } from '../prosody/config/domain'
 import { fillVideoCustomFields } from '../custom-fields'
+import { loc } from '../loc'
 
 /**
  * This function adds LiveChat information on video ActivityPub data if relevant.
@@ -84,11 +85,13 @@ async function videoBuildJSONLD (
     'chat-no-anonymous': settings['chat-no-anonymous']
   })
 
+  const chatTitle = loc('chat_for_live_stream') + ' ' + video.name
+
   // Adding attachments, as described in FEP-1970
   const discussionLinks: LiveChatVideoObject['attachment'] = []
   discussionLinks.push({
     type: 'Link',
-    name: 'Chat', // TODO: getter naming, maybe use chat_for_live_stream loc string
+    name: chatTitle,
     rel: 'discussion',
     href: getPublicChatUri(options, videoJsonld)
   })
@@ -99,7 +102,7 @@ async function videoBuildJSONLD (
   if (serverInfos.directs2s) {
     discussionLinks.push({
       type: 'Link',
-      name: 'Chat', // TODO: getter naming, maybe use chat_for_live_stream loc string
+      name: chatTitle,
       rel: 'discussion',
       href: 'xmpp://' + roomJID + '?join'
     })

--- a/server/lib/federation/types.ts
+++ b/server/lib/federation/types.ts
@@ -65,6 +65,12 @@ type LiveChatJSONLDAttributeV1 = LiveChatJSONLDInfosV1 | false
 
 interface LiveChatVideoObject extends VideoObject {
   peertubeLiveChat: LiveChatJSONLDAttribute
+  attachment: Array<{
+    type: 'Link'
+    name: string
+    href: string
+    rel: string
+  }>
 }
 
 interface RemoteVideoHandlerParams {

--- a/server/lib/uri/webchat.ts
+++ b/server/lib/uri/webchat.ts
@@ -1,6 +1,7 @@
 
-import type { RegisterServerOptions } from '@peertube/peertube-types'
+import type { RegisterServerOptions, VideoObject } from '@peertube/peertube-types'
 import { getBaseRouterRoute, getBaseWebSocketRoute } from '../helpers'
+import { canonicalizePluginUri } from './canonicalize'
 
 export function getBoshUri (options: RegisterServerOptions): string {
   return getBaseRouterRoute(options) + 'http-bind'
@@ -16,4 +17,11 @@ export function getWSS2SUri (options: RegisterServerOptions): string | undefined
   const base = getBaseWebSocketRoute(options) // can be undefined if Peertube is too old
   if (base === undefined) { return undefined }
   return base + 'xmpp-websocket-s2s'
+}
+
+export function getPublicChatUri (options: RegisterServerOptions, video: VideoObject): string {
+  const url = getBaseRouterRoute(options) + 'webchat/room/' + encodeURIComponent(video.uuid)
+  return canonicalizePluginUri(options, url, {
+    removePluginVersion: true
+  })
 }

--- a/support/documentation/content/contributing/translate/_index.en.md
+++ b/support/documentation/content/contributing/translate/_index.en.md
@@ -73,7 +73,8 @@ Now, you can simply call `peertubeHelpers.translate(LOC_USE_CHAT)` in your code.
 ### Use translations in back-end code
 
 In theory, the only parts of the backend code where you need localization is the
-settings declaration. Here we need to get english strings from the translation key.
+settings declaration and standardized data (ActivityPub, RSS, ...).
+Here we need to get english strings from the translation key.
 
 Note: you should never need another language translation from backend code.
 Localization must be done on front-end.

--- a/support/documentation/content/contributing/translate/_index.fr.md
+++ b/support/documentation/content/contributing/translate/_index.fr.md
@@ -78,7 +78,7 @@ Vous pouvez maintenant utiliser `peertubeHelpers.translate(LOC_USE_CHAT)` dans v
 
 ### Utiliser un segment dans le code back-end
 
-En théorie, les seules parties du code qui ont besoin de traductions sont les déclarations de paramètres.
+En théorie, les seules parties du code qui ont besoin de traductions sont les déclarations de paramètres et la génération de données standardisées (ActivityPub, RSS, ...).
 Ici on a besoin de récupérer les chaînes anglaises à partir des clés de traduction.
 
 Note: vous ne devriez jamais avoir besoin d'autres langues que l'anglais pour le code backend.

--- a/support/documentation/content/technical/_index.de.md
+++ b/support/documentation/content/technical/_index.de.md
@@ -1,0 +1,10 @@
++++
+title="Technical documentation"
+description="Technical documentation"
+weight=75
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/technical/_index.en.md
+++ b/support/documentation/content/technical/_index.en.md
@@ -1,0 +1,8 @@
++++
+title="Technical documentation"
+description="Technical documentation"
+weight=75
+chapter=false
++++
+
+{{% children style="li" depth="3" description="true" %}}

--- a/support/documentation/content/technical/_index.fr.md
+++ b/support/documentation/content/technical/_index.fr.md
@@ -1,0 +1,10 @@
++++
+title="Technical documentation"
+description="Technical documentation"
+weight=75
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/technical/_index.ja.md
+++ b/support/documentation/content/technical/_index.ja.md
@@ -1,0 +1,10 @@
++++
+title="Technical documentation"
+description="Technical documentation"
+weight=75
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/technical/thirdparty/_index.de.md
+++ b/support/documentation/content/technical/thirdparty/_index.de.md
@@ -1,0 +1,10 @@
++++
+title="Third party"
+description="Displaying the livechat with 3rd party software."
+weight=20
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/technical/thirdparty/_index.en.md
+++ b/support/documentation/content/technical/thirdparty/_index.en.md
@@ -1,0 +1,170 @@
++++
+title="Third party"
+description="Displaying the livechat with 3rd party software."
+weight=20
+chapter=false
++++
+
+{{% notice warning %}}
+This page describes experimental features.
+These features are available with the plugin version >= 7.2.0.
+{{% /notice %}}
+
+## Introduction
+
+Peertube is part of the Fediverse. So Peertube video can be watched from other Peertube instances,
+and from various other softwares:
+
+* from a Mastodon (or other fediverse application) instance,
+* from a mobile app (Fedilab, Tusky, ...),
+* from desktop fediverse app,
+* ...
+
+This livechat plugin is using well known standards, so it is possible to join chat rooms even when not viewing the video on Peertube.
+
+There are basically 2 ways to join the chat room associated to a video:
+
+* opening a web page (with an url like `https://yourinstance.tld/plugins/livechat/router/webchat/room/8df24108-6e70-4fc8-b1cc-f2db7fcdd535`),
+* using a XMPP client (and joining a room like `xmpp://8df24108-6e70-4fc8-b1cc-f2db7fcdd535@room.yourinstance.tld?join`)
+
+{{% notice warning %}}
+Joining the chat using a XMPP client is not always possible. It requires some DNS and server configuration.
+It will only be possible if instance's admins have correctly setup the
+[external XMPP clients connection](/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/) feature.
+{{% /notice %}}
+
+{{% notice warning %}}
+Don't try to gues these url and connection methods yourself. Please report to next chapters.
+{{% /notice %}}
+
+## Chat discovery
+
+### Using ActivityPub
+
+The livechat plugin adds some data in Video ActivityPub objects, so that the chat can be discovered.
+
+{{% notice info %}}
+This requires Peertube >= 5.1
+{{% /notice %}}
+
+This follows the [FEP-1970](https://codeberg.org/fediverse/fep/src/branch/main/fep/1970/fep-1970.md) recommendations.
+
+{{% notice warning %}}
+At the time of the writing, this FEP is in draft status, and the livechat plugin is a Proof-of-concept.
+Until the FEP is adopted, the specification can change, and the livechat plugin will be adapted accordingly.
+{{% /notice %}}
+
+Basically, the chat will be declared as `attachments` on the `Video` object, using the `discussion` relation.
+
+By default, here is an example of what you will get:
+
+```javascript
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    {
+      "RsaSignature2017": "https://w3id.org/security#RsaSignature2017"
+    },
+    {
+      // ...
+    }
+  ],
+  "to": [
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "cc": [
+    "https://yourinstance.tld/accounts/root/followers"
+  ],
+  "type": "Video",
+  "id": "https://yourinstance.tld/videos/watch/8df24108-6e70-4fc8-b1cc-f2db7fcdd535",
+  "name": "The video title",
+  // ...
+  "url": [ /* ... */ ],
+  "attachment": [
+    {
+      "type": "Link",
+      "name": "Chat for live stream: The video title",
+      "rel": "discussion",
+      "href": "https://yourinstance.tld/plugins/livechat/router/webchat/room/8df24108-6e70-4fc8-b1cc-f2db7fcdd535"
+    }
+  ]
+}
+```
+
+In case the instance has activated the
+ [external XMPP clients connection](/peertube-plugin-livechat/documentation/admin/advanced/xmpp_clients/) feature:
+
+```javascript
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    {
+      "RsaSignature2017": "https://w3id.org/security#RsaSignature2017"
+    },
+    {
+      // ...
+    }
+  ],
+  "to": [
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "cc": [
+    "https://yourinstance.tld/accounts/root/followers"
+  ],
+  "type": "Video",
+  "id": "https://yourinstance.tld/videos/watch/8df24108-6e70-4fc8-b1cc-f2db7fcdd535",
+  "name": "The video title",
+  // ...
+  "url": [ /* ... */ ],
+  "attachment": [
+    {
+      "type": "Link",
+      "name": "Chat for live stream: The video title",
+      "rel": "discussion",
+      "href": "https://yourinstance.tld/plugins/livechat/router/webchat/room/8df24108-6e70-4fc8-b1cc-f2db7fcdd535"
+    },
+    {
+      "type": "Link",
+      "name": "Chat for live stream: The video title",
+      "rel": "discussion",
+      "href": "xmpp://8df24108-6e70-4fc8-b1cc-f2db7fcdd535@room.yourinstance.tld?join"
+    }
+  ]
+}
+```
+
+#### Algorithm
+
+If you want to display the chat in a web page or in an iframe, here is what you should do:
+
+* get the Video ActivityPub object,
+* if there is no `attachment` key, stop.
+* loop through the `attachment` values (if `attachment is not an array, just iterate on this single value)
+* search for an entry with `rel` === `discussion`, and with `href` using the `https` scheme (that begins with `https://`)
+* if found, open this href
+
+If you want to open the chat room using the XMPP protocol:
+
+* get the Video ActivityPub object,
+* if there is no `attachment` key, stop.
+* loop through the `attachment` values (if `attachment is not an array, just iterate on this single value)
+* search for an entry with `rel` === `discussion`, and with `href` using the `xmpp` scheme (that begins with `xmpp://`)
+* if found, open this xmpp uri with your client, or connect to the XMPP room at that address
+
+#### Additional notes
+
+In the ActivityPub object, there is also a `peertubeLiveChat` entry.
+Don't use the content of this entry. This is specific to the livechat plugin, and can be changed or removed in a near future.
+It is currently required for some endpoint discovery.
+
+### Using RSS
+
+{{% notice warning %}}
+This part is not implemented yet, but should be available for v7.2.0 release.
+{{% /notice %}}
+
+{{% notice info %}}
+This requires Peertube >= 5.2
+{{% /notice %}}

--- a/support/documentation/content/technical/thirdparty/_index.fr.md
+++ b/support/documentation/content/technical/thirdparty/_index.fr.md
@@ -1,0 +1,10 @@
++++
+title="Third party"
+description="Displaying the livechat with 3rd party software."
+weight=20
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}

--- a/support/documentation/content/technical/thirdparty/_index.ja.md
+++ b/support/documentation/content/technical/thirdparty/_index.ja.md
@@ -1,0 +1,10 @@
++++
+title="Third party"
+description="Displaying the livechat with 3rd party software."
+weight=20
+chapter=false
++++
+
+{{% notice warning %}}
+This page is not yet translated in your language, please refer to the english version. You can switch to it by using the language selector in the left menu.
+{{% /notice %}}


### PR DESCRIPTION
Implementing the [FEP-1970](https://codeberg.org/John_Livingston/fep/src/branch/fep-1970/fep/1970/fep-1970.md) draft for ActivityPub chat declaration.

See https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/113 for more context.


##  Documentation

Chat discovery using ActivityPub will be documented here (as soon as the PR is merged to the `documentation` branch):

https://johnxlivingston.github.io/peertube-plugin-livechat/technical/thirdparty/

## Notes

Some notes about choices that where made.

### Simplicity

After reading a lot of specification, documentation, and other FEPs, i came up with this simple proposal. It seems elegant, and is consistent with other draft FEP (for example [FEP 0ea0](https://codeberg.org/fediverse/fep/src/branch/main/fep/0ea0/fep-0ea0.md)).

### Missing discovering data

The livechat plugin needs more data to know how to connect. For example, it needs to find the Websocket S2S endpoint. 

For now, this is not using XMPP standards (but could be in a near future).
So, in previous livechat version, I added some data in the `video.peertubeLiveChat` object (see commits related to https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/112).

These data are in the ActivityPub object to avoid every remote server to requests this data using API call at the same time (and minimize the server overload risk, in case of massive live streams).

These data don't have to be in the standardized chat declaration, as they are very specific to the livechat plugin.
3rd party software don't have to use these data. They have enough information with whats in FEP-1970.

These data could be removed in a near future. For example, if I merge the S2S Websocket module in Prosody core.

### Plugin publishing

I will wait some days before releasing the plugin. To see if there are relevant comments on the FEP-1970, in order to adapt the code if needed.
