### PR TITLE
build converse another way, and upgrade to v10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ support/documentation/content/translations/**/*.md
 support/documentation/i18n
 public
 vendor/prosody-appimage
+vendor/conversejs-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/converse.js"]
-	path = vendor/converse.js
-	url = https://github.com/conversejs/converse.js.git
 [submodule "documentation/themes/hugo-theme-learn"]
 	path = support/documentation/themes/hugo-theme-learn
 	url = https://github.com/matcornic/hugo-theme-learn.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## XXX (Unreleased Yet)
+
+### Minor changes and fixes
+
+* ConverseJS v10.1.5 (instead of v10.0.0).
+
 ## 7.2.2
 
 ### Minor changes and fixes

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -3,10 +3,13 @@
 set -euo pipefail
 set -x
 
+CONVERSE_VERSION="v10.1.5"
+CONVERSE_REPO="https://github.com/conversejs/converse.js.git"
+
 rootdir="$(pwd)"
 src_dir="$rootdir/conversejs"
-converse_src_dir="$rootdir/vendor/converse.js"
-converse_build_dir="$rootdir/build/converse.js"
+converse_src_dir="$src_dir/conversejs-$CONVERSE_VERSION"
+converse_build_dir="$rootdir/build/conversejs"
 converse_destination_dir="$rootdir/dist/client/conversejs"
 
 if [[ ! -d $src_dir ]]; then
@@ -15,8 +18,8 @@ if [[ ! -d $src_dir ]]; then
 fi
 
 if [[ ! -d "$converse_src_dir" ]]; then
-  echo "ConverseJS sources are not here. Please be sure to have all the submodules downloaded ('git pull --recurse-submodules')."
-  exit 1
+  git clone --depth=1 --branch $CONVERSE_VERSION $CONVERSE_REPO $converse_src_dir
+  rm -rf "$converse_build_dir"
 fi
 
 if cmp -s "$converse_src_dir/package.json" "$converse_build_dir/package.json"; then
@@ -38,7 +41,7 @@ mv "$converse_build_dir/custom/webpack.livechat.js" "$converse_build_dir/"
 if [[ ! -d "$converse_build_dir/node_modules" ]]; then
   echo "Missing node_modules directory, seems we have to call the makefile..."
   cd "$converse_build_dir"
-  make node_modules src/*
+  make dist
   cd $rootdir
 fi
 

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -8,7 +8,7 @@ CONVERSE_REPO="https://github.com/conversejs/converse.js.git"
 
 rootdir="$(pwd)"
 src_dir="$rootdir/conversejs"
-converse_src_dir="$src_dir/conversejs-$CONVERSE_VERSION"
+converse_src_dir="$rootdir/vendor/conversejs-$CONVERSE_VERSION"
 converse_build_dir="$rootdir/build/conversejs"
 converse_destination_dir="$rootdir/dist/client/conversejs"
 


### PR DESCRIPTION
This changes the way converse is integrated:

- removal of the git submodule
- shallow clone in the conversejs dir (with version number)
- change `converse.js` name to `conversjs` for consistency sake
- update of the converse build/override script

supersedes #221 

-----------

comments:

J'écris en français, ce sera plus rapide :p

Alors, dans les trucs à vérifier:

Regarder dans le dossier conversejs/custom: j'y surcharge quelques templates/fichiers js.
Il peut être utile de faire un diff de ConverseJS, pour voir si des choses ont été renommées dans les fichiers originaux, et si ça peut poser pb.

De même, j'ai un fichier livechat.scss.
Faire un diff des CSS originales, et voir si y'a des changements. Si oui, jeter un oeil, voir si ça peut impacter livechat.scss.
Bon, je me rend compte que ce n'est pas forcément simple là :/ (surtout que les templates aussi peuvent impacter)

Sinon, tester fonctionnellement:

le chat en étant connecté
le chat plein écran. Les différents menus (détails, configuration, ...)
le chat en anonymous
le chat en version OBS avec fond transparent. Vérifier que ce qui est dans la doc fonctionne toujours: https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/user/obs/
Et je crois qu'on sera pas mal !

Si tout fonctionne, on peut éventuellement voir pour remplacer le sous module git par le paquet NPM.
Dans la version que j'utilisais, le paquet NPM était bugué, et ne contenait pas les sources. C'est fixé dans la dernière version. On doit donc pouvoir adapter les scripts de build, pour partir de node_modules/conversejs plutôt que de vendor/conversejs. Ça serait sans doute plus simple à maintenir.

Pour le merge, je vais attendre d'avoir plublié la version courante (je fini un truc, et je le fais). Je passe la PR en draft, pour ne pas merge par accident.

Merci !