### PR TITLE
Fix self-signed certificates on ubuntu + v8.0.2:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 8.0.2
+
+### Minor changes and fixes
+
+* On some Ubuntu server, the self-signed certificates generation fails:
+  * See [issue #268](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/268)
+  * This prevents the bot to connect to the server
+  * As a fallback, we directly call openssl to generate the certificates
+
 ## 8.0.1
 
 ### Minor changes and fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peertube-plugin-livechat",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "peertube-plugin-livechat",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "async": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "peertube-plugin-livechat",
   "description": "PeerTube plugin livechat: create chat rooms for your Peertube lives!",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "license": "AGPL-3.0",
   "author": {
     "name": "John Livingston",

--- a/server/lib/debug.ts
+++ b/server/lib/debug.ts
@@ -11,6 +11,7 @@ interface ProsodyDebuggerOptions {
 interface DebugContent {
   renewCertCheckInterval?: number
   renewSelfSignedCertInterval?: number
+  useOpenSSL?: boolean
   logRotateCheckInterval?: number
   logRotateEvery?: number
   remoteServerInfosMaxAge?: number
@@ -25,7 +26,7 @@ type DebugNumericValue = 'renewCertCheckInterval'
 | 'logRotateCheckInterval'
 | 'remoteServerInfosMaxAge'
 
-type DebugBooleanValue = 'alwaysPublishXMPPRoom' | 'enablePodcastChatTagForNonLive'
+type DebugBooleanValue = 'alwaysPublishXMPPRoom' | 'enablePodcastChatTagForNonLive' | 'useOpenSSL'
 
 let debugContent: DebugContent | null | false = null
 function _readDebugFile (options: RegisterServerOptions): DebugContent | false {
@@ -58,6 +59,7 @@ function _readDebugFile (options: RegisterServerOptions): DebugContent | false {
     debugContent.logRotateEvery = _getNumericOptions(options, json, 'log_rotate_every')
     debugContent.renewCertCheckInterval = _getNumericOptions(options, json, 'renew_cert_check_interval')
     debugContent.renewSelfSignedCertInterval = _getNumericOptions(options, json, 'renew_self_signed_cert_interval')
+    debugContent.useOpenSSL = json.use_openssl === true
     debugContent.remoteServerInfosMaxAge = _getNumericOptions(options, json, 'remote_server_infos_max_age')
     debugContent.alwaysPublishXMPPRoom = json.always_publish_xmpp_room === true
     debugContent.enablePodcastChatTagForNonLive = json.enable_podcast_chat_tag_for_nonlive === true


### PR DESCRIPTION
* On some Ubuntu server, the self-signed certificates generation fails:
  * See [issue #268](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/268)
  * This prevents the bot to connect to the server
  * As a fallback, we directly call openssl to generate the certificates

## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [ ] I have added a description of the changes in the CHANGELOG files
- [ ] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
