### PR TITLE
Fix #140: using ConverseJS `prune_messages_above` to purge old messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Minor changes and fixes
 
-* Updated spanish translations
+* Updated spanish translations.
+* ConverseJS: using `prune_messages_above` to purge old messages, keeping only last 100 (Fix #140).
 
 ## 8.0.3
 

--- a/conversejs/lib/converse-params.ts
+++ b/conversejs/lib/converse-params.ts
@@ -75,7 +75,10 @@ function defaultConverseParams (
     whitelisted_plugins: ['livechatWindowTitlePlugin', 'livechatViewerModePlugin', 'livechatDisconnectOnUnloadPlugin'],
     show_retraction_warning: false, // No need to use this warning (except if we open to external clients?)
     muc_show_info_messages: mucShowInfoMessages,
-    send_chat_state_notifications: false // don't send this for performance reason
+    send_chat_state_notifications: false, // don't send this for performance reason
+
+    prune_messages_above: 100, // only keep 100 message in history.
+    pruning_behavior: 'unscrolled'
   }
 
   // TODO: params.clear_messages_on_reconnection = true when muc_mam will be available.


### PR DESCRIPTION
## Description

Setting `prune_messages_above` to 100 is confirmed to fix this issue.
I made some tests with my new stress-test tools. See the results here:

https://github.com/JohnXLivingston/livechat-perf-test/tree/main/tests/10-browser-vs-flooding-bot

(runs `2023-12-18`, `2023-12-19`, `03-prune-message-above-100`, `04-prune-message-above-100-converse-patched`)

TL;DR:

Before:
![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/2adf62b6-a766-42cd-bfa9-064cf417ec45)

After:
![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/65dc732b-a736-42a7-92fc-5d323a6e3723)


## Related issues

https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/140

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files
