### PR TITLE
Fix #287: add a label before the anonymous nickname prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Anonymous chat user: remember the chosen nickname in sessionStorage, to avoid entering it again too often.
 * Fix: if an anonymous chat user enter spaces in the nickname choice, it will allows them to keep the random nickname.
 * Authenticated users: if current user nickname is already used in the room, automatically add a suffix.
+* UX: add a label ('Choose a nickname to enter') for the anonymous nickname prompt. Fix #287.
 * Translation updates: German, French.
 * New Swedish translations.
 

--- a/conversejs/custom/shared/styles/livechat.scss
+++ b/conversejs/custom/shared/styles/livechat.scss
@@ -50,9 +50,14 @@ body[livechat-viewer-mode="on"] {
     form {
       display: flex !important;
       flex-flow: row wrap !important;
-      padding-top: 0.5em !important;
       padding-bottom: 0.5em !important;
       border-top: var(--chatroom-separator-border-bottom) !important;
+      gap: 10px;
+      align-items: baseline;
+
+      label {
+        color: var(--text-color); // fix converseJs css that breaks this label color.
+      }
     }
   }
 

--- a/conversejs/custom/templates/muc-bottom-panel.js
+++ b/conversejs/custom/templates/muc-bottom-panel.js
@@ -20,17 +20,19 @@ export default (o) => {
     const model = o.model
     const i18nNickname = __('Nickname')
     const i18nJoin = __('Enter groupchat')
+    const i18n_heading = __('Choose a nickname to enter')
     return html`
     <div class="livechat-viewer-mode-nick chatroom-form-container"
             @submit=${ev => setNickname(ev, model)}>
         <form class="converse-form chatroom-form">
+            <label>${i18n_heading}</label>
             <fieldset class="form-group">
-                <input type="text"
-                    required="required"
-                    name="nick"
-                    value=""
-                    class="form-control"
-                    placeholder="${i18nNickname}"/>
+              <input type="text"
+                  required="required"
+                  name="nick"
+                  value=""
+                  class="form-control"
+                  placeholder="${i18nNickname}"/>
             </fieldset>
             <fieldset class="form-group">
                 <input type="submit" class="btn btn-primary" name="join" value="${i18nJoin}"/>


### PR DESCRIPTION
## Description

Adding a label on the nickname prompt.

## Related issues

#287 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [ ] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots
![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/76d82a7b-4c7e-46c8-b41a-b1139832670f)