### PR TITLE
UI/UX improvment:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * UX: add a label ('Choose a nickname to enter') for the anonymous nickname prompt. Fix #287.
 * Translation updates: German, French.
 * New Swedish translations.
+* UI/UX improvment: hide nickname changes when previous nickname was like "Anonymous 12345". Helps to improve performances when massive anonymous users are joining (#138), and prevent displaying unnecessary messages (#111).
 
 ## 8.0.4
 

--- a/conversejs/builtin.ts
+++ b/conversejs/builtin.ts
@@ -109,6 +109,29 @@ window.initConverse = async function initConverse (initConverseParams: InitConve
       }
     })
 
+    // livechatSpecifics plugins add some customization for the livechat plugin.
+    converse.plugins.add('livechatSpecifics', {
+      dependencies: ['converse-muc'],
+      overrides: {
+        ChatRoom: {
+          getActionInfoMessage: function (this: any, code: string, nick: string, actor: any): any {
+            if (code === '303') {
+              // When there is numerous anonymous users joining at the same time,
+              // they can all change their nicknames at the same time, generating a log of action messages.
+              // To mitigate this, will don't display nickname changes if the previous nick is something like
+              // 'Anonymous 12345'.
+              // To avoid displaying the message, we just have to return an empty one
+              // (createInfoMessage will ignore if !data.message).
+              if (/^Anonymous \d+$/.test(nick)) {
+                return null
+              }
+            }
+            return this.__super__.getActionInfoMessage(code, nick, actor)
+          }
+        }
+      }
+    })
+
     if (autoViewerMode && !isAuthenticated && !isRemoteWithNicknameSet) {
       const previousNickname = getPreviousAnonymousNick()
       converse.plugins.add('livechatViewerModePlugin', {

--- a/conversejs/lib/converse-params.ts
+++ b/conversejs/lib/converse-params.ts
@@ -23,7 +23,8 @@ function defaultConverseParams (
         '110', // self
         '104', '201', // non_privacy_changes
         '170', '171', // muc_logging_changes
-        '210', '303', // nickname_changes
+        '210', // nickname_changes. 210=Inform user that the service has assigned or modified the occupant's roomnick
+        '303', // nickname_changes. 303=Inform all occupants of new room nickname
         '301', '307', '321', '322', '332', '333', // disconnected
         'owner', 'admin', 'member', 'exadmin', 'exowner', 'exoutcast', 'exmember', // affiliation_changes
         // 'entered', 'exited', // join_leave_events
@@ -72,7 +73,12 @@ function defaultConverseParams (
     persistent_store: 'sessionStorage',
     show_images_inline: false, // for security reason, and to avoid bugs when image is larger that iframe
     render_media: false, // for security reason, and to avoid bugs when image is larger that iframe
-    whitelisted_plugins: ['livechatWindowTitlePlugin', 'livechatViewerModePlugin', 'livechatDisconnectOnUnloadPlugin'],
+    whitelisted_plugins: [
+      'livechatWindowTitlePlugin',
+      'livechatSpecifics',
+      'livechatViewerModePlugin',
+      'livechatDisconnectOnUnloadPlugin'
+    ],
     show_retraction_warning: false, // No need to use this warning (except if we open to external clients?)
     muc_show_info_messages: mucShowInfoMessages,
     send_chat_state_notifications: false, // don't send this for performance reason


### PR DESCRIPTION
## Description

Hide nickname changes when previous nickname was like "Anonymous 12345". Helps to improve performances when massive anonymous users are joining (#138), and prevent displaying unnecessary messages (#111).
