### PR TITLE
Fix #136: display anonymous users at the end of the participants list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 * UX: add a label ('Choose a nickname to enter') for the anonymous nickname prompt. Fix #287.
 * Translation updates: German, French.
 * New Swedish translations.
-* UI/UX improvment: hide nickname changes when previous nickname was like "Anonymous 12345". Helps to improve performances when massive anonymous users are joining (#138), and prevent displaying unnecessary messages (#111).
+* UI/UX improvments:
+  * hide nickname changes when previous nickname was like "Anonymous 12345". Helps to improve performances when massive anonymous users are joining (#138), and prevent displaying unnecessary messages (#111).
+  * display anonymous users at the end of the participants list (Fix #136)
 * Using patched ConverseJS for performance improvment (related to #96):
   * debounce MUC sidebar rendering in ConverseJS (Fix #138)
   * force history pruning, even if messages keep coming (Fix #140)

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -14,7 +14,8 @@ CONVERSE_COMMIT=""
 # This version includes following changes:
 # - #converse.js/3300: Adding the maxWait option for `debouncedPruneHistory`
 # - #converse.js/3302: debounce MUC sidebar rendering
-CONVERSE_COMMIT="732f58b50d1b1cf0d3f091668057032fb52b164a"
+# - Fix: refresh the MUC sidebar when participants collection is sorted
+CONVERSE_COMMIT="4861395f047e4abee2b30271c80d29a86baf7828"
 CONVERSE_REPO="https://github.com/JohnXLivingston/converse.js"
 
 rootdir="$(pwd)"


### PR DESCRIPTION
## Description

With this commit, anonymous users are displayed at the end of the room participants.

## Related issues

* #136 
* #111 

## Screenshots

![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/3b8b28fa-1f22-4764-950e-e4ae60046a9d)