### PR TITLE
Fix #295: Prosody: disabling message carbons for anonymous users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Using patched ConverseJS for performance improvement (related to #96):
   * debounce MUC sidebar rendering in ConverseJS (Fix #138)
   * force history pruning, even if messages keep coming (Fix #140)
+* Prosody: disabling message carbons for anonymous users (See #295)
 
 ## 8.0.4
 

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -211,6 +211,9 @@ class ProsodyConfigContent {
     this.anon = new ProsodyConfigVirtualHost('anon.' + this.prosodyDomain)
     this.anon.set('authentication', 'anonymous')
     this.anon.set('modules_enabled', ['ping'])
+    this.anon.set('modules_disabled', [
+      'carbons' // carbon make no sense for anonymous users, they can't have multiple windows
+    ])
     if (autoBanIP) {
       this.anon.add('modules_enabled', 'muc_ban_ip')
     }


### PR DESCRIPTION
Anonymous users can't use carbons, as they cannot connect with multiple tabs on the same anonymous account.
So we disable carbons on the anonymous virtualhost, to improve performances.

See here for some performances tests: https://github.com/JohnXLivingston/livechat-perf-test/tree/main/tests/50-anonymous-carbons
