### PR TITLE
Implement #143: User colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## ??? (Not Released Yet)
+
+* #143: User colors: implementing [XEP-0392](https://xmpp.org/extensions/xep-0392.html) to have random colors on users nicknames
+
 ## 8.4.0
 
 * Fix #87: updating chat room title when video/channel title is changed.

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -25,8 +25,9 @@ CONVERSE_COMMIT=""
 # - Adding "users" icon in the menu toggle button
 # - Removing unecessary plugins: headless/pubsub, minimize, notifications, profile, omemo, push, roomlist, dragresize.
 # - Destroy room: remove the challenge, and the new JID
+# - New config option [colorize_username](https://conversejs.org/docs/html/configuration.html#colorize_username)
 CONVERSE_VERSION="livechat-8.2.0"
-CONVERSE_COMMIT="cb6c0bd87c0078d5c62308fc3b83efd5019f993c"
+CONVERSE_COMMIT="ae1b576d5c9d2691df896d603cd65726b3e04480"
 CONVERSE_REPO="https://github.com/JohnXLivingston/converse.js"
 
 rootdir="$(pwd)"

--- a/conversejs/lib/converse-params.ts
+++ b/conversejs/lib/converse-params.ts
@@ -87,6 +87,7 @@ function defaultConverseParams (
 
     prune_messages_above: 100, // only keep 100 message in history.
     pruning_behavior: 'unscrolled',
+    colorize_username: true,
 
     // This is a specific settings, that is used in ConverseJS customization, to force avatars loading in readonly mode.
     livechat_load_all_vcards: !!forceReadonly


### PR DESCRIPTION

## Description

Implementing [XEP-0392](https://xmpp.org/extensions/xep-0392.html) to have random colors on users nicknames.

Implementation in ConverseJS upstream available here:
https://github.com/conversejs/converse.js/pull/3347

Here is the commit on the livechat specific ConverseJS:
https://github.com/JohnXLivingston/converse.js/commit/ae1b576d5c9d2691df896d603cd65726b3e04480

## Related issues

https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/143

## Screenshots

![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/a414602d-01ec-437c-b2cb-501682c44a0b)

![image](https://github.com/JohnXLivingston/peertube-plugin-livechat/assets/38844060/9a4bcbda-1b9f-4ebc-a323-588a1342023a)

