### PR TITLE
Changing defaults muc affiliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ TODO: tag custom ConverseJS, and update build-conversejs.sh.
 
 * #177: streamer's task/to-do lists: streamers, and their room's moderators, can handle task lists directly. This can be used to handle viewers questions, moderation actions, ... More info in the [tasks documentation](https://livingston.frama.io/peertube-plugin-livechat/fr/documentation/user/streamers/tasks/).
 * #385: new way of managing chat access rights. Now streamers are owner of their chat rooms. Peertube admins/moderators are not by default, so that their identities are not leaking. But they have a button to promote as chat room owner, if they need to take action. Please note that there is a migration script that will remove all Peertube admins/moderators affiliations (unless they are video/channel's owner). They can get this access back using the button.
+* #385: the slow mode duration on the channel option page is now a default value for new rooms. Streamers can change the value room per room in the room's configuration.
 
 ### Minor changes and fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ TODO: tag custom ConverseJS, and update build-conversejs.sh.
 ### New features
 
 * #177: streamer's task/to-do lists: streamers, and their room's moderators, can handle task lists directly. This can be used to handle viewers questions, moderation actions, ... More info in the [tasks documentation](https://livingston.frama.io/peertube-plugin-livechat/fr/documentation/user/streamers/tasks/).
+* #385: new way of managing chat access rights. Now streamers are owner of their chat rooms. Peertube admins/moderators are not by default, so that their identities are not leaking. But they have a button to promote as chat room owner, if they need to take action. Please note that there is a migration script that will remove all Peertube admins/moderators affiliations (unless they are video/channel's owner). They can get this access back using the button.
+* #385: the slow mode duration on the channel option page is now a default value for new rooms. Streamers can change the value room per room in the room's configuration.
 
 ### Minor changes and fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ TODO: tag custom ConverseJS, and update build-conversejs.sh.
 
 * #177: streamer's task/to-do lists: streamers, and their room's moderators, can handle task lists directly. This can be used to handle viewers questions, moderation actions, ... More info in the [tasks documentation](https://livingston.frama.io/peertube-plugin-livechat/fr/documentation/user/streamers/tasks/).
 * #385: new way of managing chat access rights. Now streamers are owner of their chat rooms. Peertube admins/moderators are not by default, so that their identities are not leaking. But they have a button to promote as chat room owner, if they need to take action. Please note that there is a migration script that will remove all Peertube admins/moderators affiliations (unless they are video/channel's owner). They can get this access back using the button.
-* #385: the slow mode duration on the channel option page is now a default value for new rooms. Streamers can change the value room per room in the room's configuration.
 
 ### Minor changes and fixes
 

--- a/assets/images/moderator.svg
+++ b/assets/images/moderator.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333334"
+   version="1.1"
+   id="svg1428"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="moderator.svg"
+   inkscape:export-xdpi="9.6000004"
+   inkscape:export-ydpi="9.6000004"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb">
+  <defs
+     id="defs1422">
+    <linearGradient
+       id="linearGradient5158"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#7d7d7d;stop-opacity:1;"
+         offset="0"
+         id="stop5156" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter1150">
+      <feFlood
+         flood-opacity="1"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood1140" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite1142" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="0.2"
+         result="blur"
+         id="feGaussianBlur1144" />
+      <feOffset
+         dx="0"
+         dy="0"
+         result="offset"
+         id="feOffset1146" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite1148" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter1174">
+      <feFlood
+         flood-opacity="1"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood1164" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite1166" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="0.2"
+         result="blur"
+         id="feGaussianBlur1168" />
+      <feOffset
+         dx="0"
+         dy="0"
+         result="offset"
+         id="feOffset1170" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite1172" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="11.203223"
+     inkscape:cy="12.683728"
+     inkscape:document-units="px"
+     inkscape:current-layer="g1910"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1842"
+     inkscape:window-height="1011"
+     inkscape:window-x="1920"
+     inkscape:window-y="1082"
+     inkscape:window-maximized="1"
+     units="px"
+     showguides="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata1425">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1910"
+       transform="matrix(0.45207703,0,0,0.45207703,-0.52645128,1.334609)"
+       style="stroke-width:1.00021;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         id="path1141"
+         style="opacity:0.998;fill:#deddda;fill-opacity:1;stroke:#deddda;stroke-width:1.17052;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="rect1876-6"
+         d="m 2.4029499,0.58273862 0,-0.77222952 c 0,-0.5219815 0.4202233,-0.9422049 0.9422049,-0.9422049 l 1.9614175,-0.023585 1.9614174,0.010033 c 0.5219816,0 0.9422049,0.42022334 0.9422049,0.94220484 v 0.77222958 c 0,0 -1.6246328,4.32927978 -2.9036223,4.34980548 C 4.0275827,4.939518 2.4029499,0.58273862 2.4029499,0.58273862 Z"
+         sodipodi:nodetypes="cscccsczc" />
+    </g>
+  </g>
+</svg>

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -53,8 +53,11 @@
   display: none;
 }
 
-[peertube-plugin-livechat-state="closed"] .peertube-plugin-livechat-button-close {
-  display: none;
+[peertube-plugin-livechat-state="closed"] {
+  .peertube-plugin-livechat-button-promote,
+  .peertube-plugin-livechat-button-close {
+    display: none;
+  }
 }
 
 [peertube-plugin-livechat-state]:not([peertube-plugin-livechat-state="open"]) {

--- a/client/@types/global.d.ts
+++ b/client/@types/global.d.ts
@@ -77,3 +77,5 @@ declare const LOC_LIVECHAT_CONFIGURATION_CHANNEL_FOR_MORE_INFO: string
 
 declare const LOC_INVALID_VALUE: string
 declare const LOC_CHATROOM_NOT_ACCESSIBLE: string
+
+declare const LOC_PROMOTE: string

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -121,6 +121,7 @@ function register (clientOptions: RegisterClientOptions): void {
                 titleChannelConfiguration.textContent = labels.channelConfiguration
                 titleLineEl.append(titleChannelConfiguration)
               }
+              titleLineEl.append(document.createElement('th'))
               table.append(titleLineEl)
               rooms.forEach(room => {
                 const localpart = room.localpart
@@ -137,6 +138,35 @@ function register (clientOptions: RegisterClientOptions): void {
                   const date = new Date(room.lasttimestamp * 1000)
                   lastActivityEl.textContent = date.toLocaleDateString() + ' ' + date.toLocaleTimeString()
                 }
+                const promoteButton = document.createElement('a')
+                promoteButton.classList.add('orange-button', 'peertube-button-link')
+                promoteButton.style.margin = '5px'
+                promoteButton.onclick = async () => {
+                  await fetch(
+                    getBaseRoute(clientOptions) + '/api/promote/' + encodeURIComponent(room.jid.replace(/@.*$/, '')),
+                    {
+                      method: 'PUT',
+                      headers: peertubeHelpers.getAuthHeader()
+                    }
+                  )
+                }
+                // FIXME: we can use promoteSVG, which is in client scope...
+                promoteButton.innerHTML = `<svg
+                  xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 4.233 4.233"
+                >
+                  <g style="stroke-width:1.00021;stroke-miterlimit:4;stroke-dasharray:none">
+                    <path
+                    style="opacity:.998;fill:currentColor;fill-opacity:1;stroke:currentColor;stroke-width:1.17052;
+                    stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                    d="M2.403.583V-.19a.94.94 0 0 1 .942-.943l1.962-.023 1.961.01a.94.94 0 0 1
+                    .942.942v.772S6.586 4.9 5.307 4.92C4.027 4.939 2.403.583 2.403.583Z"
+                    transform="matrix(.45208 0 0 .45208 -.526 1.335)"
+                    />
+                  </g>
+                </svg>`
+                const promoteEl = document.createElement('td')
+                promoteEl.append(promoteButton)
+
                 const channelConfigurationEl = document.createElement('td')
                 nameEl.append(aEl)
                 lineEl.append(nameEl)
@@ -146,6 +176,7 @@ function register (clientOptions: RegisterClientOptions): void {
                 if (useChannelConfiguration) {
                   lineEl.append(channelConfigurationEl) // else the element will just be dropped.
                 }
+                lineEl.append(promoteEl)
                 table.append(lineEl)
 
                 const writeChannelConfigurationLink = (channelId: number | string): void => {

--- a/client/videowatch/button.ts
+++ b/client/videowatch/button.ts
@@ -10,7 +10,7 @@ interface displayButtonOptionsBase {
 }
 
 interface displayButtonOptionsCallback extends displayButtonOptionsBase {
-  callback: () => void | boolean
+  callback: () => void | boolean | Promise<void>
 }
 
 interface displayButtonOptionsHref extends displayButtonOptionsBase {

--- a/client/videowatch/buttons.ts
+++ b/client/videowatch/buttons.ts
@@ -111,12 +111,26 @@ const helpButtonSVG: SVGButton = () => {
 `
 }
 
+const promoteSVG: SVGButton = () => {
+  // This content comes from the file assets/images/moderator.svg, after svgo cleaning.
+  // To get the formated content, you can do:
+  // xmllint dist/client/images/moderator.svg --format
+  // Then replace the color by `currentColor`
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 4.233 4.233">
+  <g style="stroke-width:1.00021;stroke-miterlimit:4;stroke-dasharray:none">
+    <path style="opacity:.998;fill:currentColor;fill-opacity:1;stroke:currentColor;stroke-width:1.17052;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M2.403.583V-.19a.94.94 0 0 1 .942-.943l1.962-.023 1.961.01a.94.94 0 0 1 .942.942v.772S6.586 4.9 5.307 4.92C4.027 4.939 2.403.583 2.403.583Z" transform="matrix(.45208 0 0 .45208 -.526 1.335)"/>
+  </g>
+</svg>
+`
+}
+
 export {
   closeSVG,
   openChatSVG,
   openBlankChatSVG,
   shareChatUrlSVG,
-  helpButtonSVG
+  helpButtonSVG,
+  promoteSVG
 }
 export type {
   SVGButton

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -452,3 +452,5 @@ task_list_pick_message: |
   Once you have chosen a task list, a new task will be created.
   To see the task, open the task application using the top menu.
   More information in the livechat plugin documentation.
+
+promote: 'Become moderator'

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -365,7 +365,7 @@ livechat_configuration_channel_title: "Channel options"
 livechat_configuration_channel_desc: "You can setup here some options for this channel (moderation policies, ...)."
 livechat_configuration_channel_slow_mode_label: "Slow mode"
 livechat_configuration_channel_slow_mode_desc: |
-  Slow mode value:
+  Slow mode default value:
   <ul>
     <li>0: slow mode disabled</li>
     <li>Any positive integer: users can send a message every X seconds (moderators are not limited)</li>

--- a/languages/fr.yml
+++ b/languages/fr.yml
@@ -393,7 +393,7 @@ avatar_set_option_abstract: Abstrait
 livechat_configuration_channel_slow_mode_label: Mode lent
 slow_mode_info: Le mode lent est activé, les utilisateur⋅rices peuvent envoyer un
   message toutes les %1$s secondes.
-livechat_configuration_channel_slow_mode_desc: "Valeur du mode lent :\n<ul>\n  <li>0 :
+livechat_configuration_channel_slow_mode_desc: "Valeur par défaut du mode lent :\n<ul>\n  <li>0 :
   mode lent désactivé</li>\n  <li>Tout entier positif : les utilisateur⋅rices peuvent
   envoyer un message toutes les X secondes (les modérateur⋅rices ne sont pas limité⋅es)</li>\n\
   </ul>\n"

--- a/server/lib/configuration/channel/init.ts
+++ b/server/lib/configuration/channel/init.ts
@@ -4,7 +4,6 @@ import { fillVideoCustomFields } from '../../custom-fields'
 import { videoHasWebchat } from '../../../../shared/lib/video'
 import { updateProsodyRoom } from '../../prosody/api/manage-rooms'
 import { getChannelInfosById } from '../../database/channel'
-import { getChannelConfigurationOptions, getDefaultChannelConfigurationOptions } from './storage'
 
 /**
  * Register stuffs related to channel configuration
@@ -107,11 +106,8 @@ async function initChannelConfiguration (options: RegisterServerOptions): Promis
           // FIXME: this piece of code should not be in this file (nothing to do with initChannelConfiguration,
           //   but will be more efficient to add here, as we already tested hasChat).
           // Note: no need to await here, would only degrade performances.
-          const channelOptions = await getChannelConfigurationOptions(options, video.channelId) ??
-            getDefaultChannelConfigurationOptions(options)
           updateProsodyRoom(options, video.uuid, {
-            name: video.name,
-            slow_mode_duration: channelOptions.slowMode.duration
+            name: video.name
           }).then(
             () => {},
             (err) => logger.error(err)
@@ -137,11 +133,8 @@ async function initChannelConfiguration (options: RegisterServerOptions): Promis
       if (settings['prosody-room-type'] === 'channel') {
         const jid = 'channel.' + channel.id.toString()
         // Note: no need to await here, would only degrade performances.
-        const channelOptions = await getChannelConfigurationOptions(options, channel.id) ??
-          getDefaultChannelConfigurationOptions(options)
         updateProsodyRoom(options, jid, {
-          name: channel.displayName,
-          slow_mode_duration: channelOptions.slowMode.duration
+          name: channel.displayName
         }).then(
           () => {},
           (err) => logger.error(err)

--- a/server/lib/conversejs/params.ts
+++ b/server/lib/conversejs/params.ts
@@ -376,6 +376,8 @@ async function _localRoomJID (
   }
   room = room.replace(/{{CHANNEL_ID}}/g, `${channelId}`)
   if (room.includes('{{CHANNEL_NAME}}')) {
+    // FIXME: this should no more exists, since we removed options to include other chat server.
+    //  So we should remove this code. (and simplify the above code)
     const channelName = await getChannelNameById(options, channelId)
     if (channelName === null) {
       throw new Error('Channel not found')

--- a/server/lib/prosody/api/manage-rooms.ts
+++ b/server/lib/prosody/api/manage-rooms.ts
@@ -1,4 +1,5 @@
 import type { RegisterServerOptions } from '@peertube/peertube-types'
+import type { Affiliations } from '../config/affiliations'
 import { getCurrentProsody } from './host'
 import { getAPIKey } from '../../apikey'
 import { getProsodyDomain } from '../config/domain'
@@ -59,6 +60,8 @@ async function updateProsodyRoom (
   data: {
     name?: string
     slow_mode_duration?: number
+    addAffiliations?: Affiliations
+    removeAffiliationsFor?: string[]
   }
 ): Promise<boolean> {
   const logger = options.peertubeHelpers.logger
@@ -79,11 +82,17 @@ async function updateProsodyRoom (
   const apiData = {
     jid
   } as any
-  if ('name' in data) {
+  if (('name' in data) && data.name !== undefined) {
     apiData.name = data.name
   }
-  if ('slow_mode_duration' in data) {
+  if (('slow_mode_duration' in data) && data.slow_mode_duration !== undefined) {
     apiData.slow_mode_duration = data.slow_mode_duration
+  }
+  if (('addAffiliations' in data) && data.addAffiliations !== undefined) {
+    apiData.addAffiliations = data.addAffiliations
+  }
+  if (('removeAffiliationsFor' in data) && data.removeAffiliationsFor !== undefined) {
+    apiData.removeAffiliationsFor = data.removeAffiliationsFor
   }
   try {
     logger.debug('Calling update room API on url: ' + apiUrl + ', with data: ' + JSON.stringify(apiData))

--- a/server/lib/prosody/migration/migrateV10.ts
+++ b/server/lib/prosody/migration/migrateV10.ts
@@ -1,0 +1,113 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import { listProsodyRooms, updateProsodyRoom } from '../api/manage-rooms'
+import { Affiliations, getVideoAffiliations, getChannelAffiliations } from '../config/affiliations'
+import { getProsodyDomain } from '../config/domain'
+import * as path from 'path'
+import * as fs from 'fs'
+
+/**
+ * Livechat v10.0.0: we change the way MUC affiliations are handled.
+ * So we must remove all affiliations to peertube admin/owner (unless there are video/channel owners).
+ * For more info, see https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/385
+ *
+ * This script will only be launched one time.
+ */
+async function migrateMUCAffiliations (options: RegisterServerOptions): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+
+  // First, detect if we already run this script.
+  const doneFilePath = path.resolve(options.peertubeHelpers.plugin.getDataDirectoryPath(), 'fix-v10-affiliations')
+  if (fs.existsSync(doneFilePath)) {
+    logger.debug('[migratev10MUCAffiliations] MUC affiliations for v10 already migrated.')
+    return
+  }
+
+  logger.info('[migratev10MUCAffiliations] Migrating MUC affiliations for livechat v10...')
+
+  const prosodyDomain = await getProsodyDomain(options)
+  const rooms = await listProsodyRooms(options)
+  logger.debug('[migratev10MUCAffiliations] Found ' + rooms.length.toString() + ' rooms.')
+
+  logger.debug('[migratev10MUCAffiliations] loading peertube admins and moderators...')
+  const peertubeAff = await _getPeertubeAdminsAndModerators(options, prosodyDomain)
+
+  for (const room of rooms) {
+    try {
+      let affiliations: Affiliations
+      logger.info('[migratev10MUCAffiliations] Must migrate affiliations for room ' + room.localpart)
+      const matches = room.localpart.match(/^channel\.(\d+)$/)
+      if (matches?.[1]) {
+        // room associated to a channel
+        const channelId: number = parseInt(matches[1])
+        if (isNaN(channelId)) { throw new Error('Invalid channelId ' + room.localpart) }
+        affiliations = await getChannelAffiliations(options, channelId)
+      } else {
+        // room associated to a video
+        const video = await options.peertubeHelpers.videos.loadByIdOrUUID(room.localpart)
+        if (!video || video.remote) {
+          logger.info('[migratev10MUCAffiliations] Video ' + room.localpart + ' not found or remote, skipping')
+          continue
+        }
+        affiliations = await getVideoAffiliations(options, video)
+      }
+
+      const affiliationsToRemove: string[] = []
+      for (const jid in peertubeAff) {
+        if (jid in affiliations) {
+          continue
+        }
+        affiliationsToRemove.push(jid)
+      }
+
+      logger.debug(
+        '[migratev10MUCAffiliations] Room ' + room.localpart + ', affiliations to set: ' + JSON.stringify(affiliations)
+      )
+      logger.debug(
+        '[migratev10MUCAffiliations] Room ' +
+        room.localpart + ', affilations to remove: ' + JSON.stringify(affiliationsToRemove)
+      )
+      await updateProsodyRoom(options, room.jid, {
+        addAffiliations: affiliations,
+        removeAffiliationsFor: affiliationsToRemove
+      })
+    } catch (err) {
+      logger.error(
+        '[migratev10MUCAffiliations] Failed to handle room ' + room.localpart + ', skipping. Error: ' + (err as string)
+      )
+      continue
+    }
+  }
+
+  await fs.promises.writeFile(doneFilePath, '')
+}
+
+async function _getPeertubeAdminsAndModerators (
+  options: RegisterServerOptions,
+  prosodyDomain: string
+): Promise<Affiliations> {
+  // Get all admins and moderators
+  const [results] = await options.peertubeHelpers.database.query(
+    'SELECT "username" FROM "user"' +
+    ' WHERE "user"."role" IN (0, 1)'
+  )
+  if (!Array.isArray(results)) {
+    throw new Error('_getPeertubeAdminsAndModerators: query result is not an array.')
+  }
+  const r: Affiliations = {}
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (typeof result !== 'object') {
+      throw new Error('_getPeertubeAdminsAndModerators: query result is not an object')
+    }
+    if (!('username' in result)) {
+      throw new Error('_getPeertubeAdminsAndModerators: no username field in result')
+    }
+    const jid = (result.username as string) + '@' + prosodyDomain
+    r[jid] = 'member' // member, but in fact the migration will just remove the affilation.
+  }
+  return r
+}
+
+export {
+  migrateMUCAffiliations
+}

--- a/server/lib/routers/api.ts
+++ b/server/lib/routers/api.ts
@@ -8,6 +8,7 @@ import { initRoomApiRouter } from './api/room'
 import { initAuthApiRouter, initUserAuthApiRouter } from './api/auth'
 import { initFederationServerInfosApiRouter } from './api/federation-server-infos'
 import { initConfigurationApiRouter } from './api/configuration'
+import { initPromoteApiRouter } from './api/promote'
 
 /**
  * Initiate API routes
@@ -36,6 +37,7 @@ async function initApiRouter (options: RegisterServerOptions): Promise<Router> {
   await initFederationServerInfosApiRouter(options, router)
 
   await initConfigurationApiRouter(options, router)
+  await initPromoteApiRouter(options, router)
 
   if (isDebugMode(options)) {
     // Only add this route if the debug mode is enabled at time of the server launch.

--- a/server/lib/routers/api/promote.ts
+++ b/server/lib/routers/api/promote.ts
@@ -1,0 +1,53 @@
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import type { Router, Request, Response, NextFunction } from 'express'
+import type { Affiliations } from '../../prosody/config/affiliations'
+import { asyncMiddleware } from '../../middlewares/async'
+import { isUserAdminOrModerator } from '../../helpers'
+import { getProsodyDomain } from '../../prosody/config/domain'
+import { updateProsodyRoom } from '../../prosody/api/manage-rooms'
+
+async function initPromoteApiRouter (options: RegisterServerOptions, router: Router): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+
+  router.put('/promote/:roomJID', asyncMiddleware(
+    async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+      try {
+        const roomJIDLocalPart = req.params.roomJID
+        const user = await options.peertubeHelpers.user.getAuthUser(res)
+
+        if (!user || !await isUserAdminOrModerator(options, res)) {
+          logger.warn('Current user tries to access the promote API for which he has no right.')
+          res.sendStatus(403)
+          return
+        }
+
+        if (!/^(channel\.\d+|(\w|-)+)$/.test(roomJIDLocalPart)) { // just check if it looks alright.
+          logger.warn('Current user tries to access the promote API using an invalid room key.')
+          res.sendStatus(400)
+          return
+        }
+
+        const normalizedUsername = user.username.toLowerCase()
+        const prosodyDomain = await getProsodyDomain(options)
+        const jid = normalizedUsername + '@' + prosodyDomain
+
+        const mucJID = roomJIDLocalPart + '@' + 'room.' + prosodyDomain
+
+        logger.info('We must give owner affiliation to ' + jid + ' on ' + mucJID)
+        const addAffiliations: Affiliations = {}
+        addAffiliations[jid] = 'owner'
+        await updateProsodyRoom(options, mucJID, {
+          addAffiliations
+        })
+        res.sendStatus(200)
+      } catch (err) {
+        logger.error(err)
+        res.sendStatus(500)
+      }
+    }
+  ))
+}
+
+export {
+  initPromoteApiRouter
+}

--- a/support/documentation/content/en/documentation/user/streamers/moderation.md
+++ b/support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -9,6 +9,11 @@ chapter: false
 This section is still incomplete.
 {{% /notice %}}
 
+{{% notice warning %}}
+This page describes the behaviour of livechat versions >= 10.0.0.
+There were some changes in the way we manage access rights for Peertube administrators and moderators.
+{{% /notice %}}
+
 ## The chat bot
 
 You can use a chat bot, that will help you for moderation.
@@ -21,8 +26,14 @@ You can access room settings and moderation tools using the [chat dropdown menu]
 ![Chat menu](/peertube-plugin-livechat/images/top_menu.png?classes=shadow,border&height=200px)
 
 {{% notice tip %}}
-All instance moderators and admins will be owner of created chat rooms.
-The video owner will be admin in the chat room.
+The video owner will be owner of the chat room.
+This means he can configure the room, delete it, promote other users as admins, ...
+{{% /notice %}}
+
+{{% notice tip %}}
+Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.
+However, they have a special button available on top of the chat: "{{% livechat_label promote %}}".
+Clicking this button will give them owner access on the room.
 {{% /notice %}}
 
 You can use [ConverseJS moderation commands](https://conversejs.org/docs/html/features.html#moderating-chatrooms) to moderate the room.
@@ -47,3 +58,5 @@ You can delete old rooms: join the room, and use the menu on the top to destroy 
 As Peertube instance moderator or administrator, you will probably need to check that your users are not behaving badly.
 
 You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms».
+
+From there, you can also promote yourself as room moderator by using the "{{% livechat_label promote %}}" button on the right.

--- a/support/documentation/content/en/documentation/user/streamers/slow_mode.md
+++ b/support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -28,11 +28,13 @@ On the [channel configuration page](/peertube-plugin-livechat/documentation/user
 
 ![Channel configuration / Slow Mode](/peertube-plugin-livechat/images/slow_mode_channel_option.png?classes=shadow,border&height=400px)
 
-This value will apply to all your channel's chatrooms.
+This value will apply as a default value for all your channel's chatrooms.
 
 Setting the value to `0` will disable the feature.
 
 Setting the value to a positive integer will set the period during which users will not be able to post additional messages.
+
+To modify the value for an already existing room, just open the room "configuration" menu (on top of the chat window), and change the slow mode value in the configuration form.
 
 ## For viewers
 

--- a/support/documentation/po/livechat.ar.po
+++ b/support/documentation/po/livechat.ar.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-01-17 11:38+0000\n"
 "Last-Translator: ButterflyOfFire <butterflyoffire@protonmail.com>\n"
 "Language-Team: Arabic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ar/>\n"
@@ -2744,6 +2744,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2768,7 +2776,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2817,6 +2830,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2892,7 +2910,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2903,6 +2921,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ca.po
+++ b/support/documentation/po/livechat.ca.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ca/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.cs.po
+++ b/support/documentation/po/livechat.cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/cs/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.de.po
+++ b/support/documentation/po/livechat.de.po
@@ -7,12 +7,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-05-14 02:14+0000\n"
-"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>"
-"\n"
-"Language-Team: German <https://weblate.framasoft.org/projects/"
-"peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
+"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>\n"
+"Language-Team: German <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2809,6 +2807,14 @@ msgstr "Plugin peertube-plugin-livechat Erweiterte Moderationsfunktionen"
 msgid "This section is still incomplete."
 msgstr "Dieser Abschnitt ist noch unvollständig."
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2833,8 +2839,13 @@ msgstr "Über das [Chat Dropdown Menü](/peertube-plugin-livechat/de/documentati
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
-msgstr "Alle Instanzmoderatoren und Admins sind Eigentümer der erstellten Chaträume.  Der Eigentümer des Videos wird der Administrator des Chatraums sein."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2883,6 +2894,11 @@ msgstr "Als Moderator oder Administrator einer Peertube-Instanz müssen Sie wahr
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
 msgstr "Sie können alle bestehenden Chaträume auflisten: in den Einstellungen des Plugins gibt es eine Schaltfläche «Räume auflisten»."
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
+msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -2957,7 +2973,9 @@ msgstr "![Kanalkonfiguration / Langsamer Modus](/peertube-plugin-livechat/images
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+#, fuzzy
+#| msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr "Dieser Wert gilt für alle Chaträume deines Kanals."
 
 #. type: Plain text
@@ -2969,6 +2987,11 @@ msgstr "Wird der Wert auf \"0\" gesetzt, wird die Funktion deaktiviert."
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
 msgstr "Wenn Sie den Wert auf eine positive ganze Zahl setzen, wird der Zeitraum festgelegt, in dem die Benutzer keine weiteren Nachrichten senden können."
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
+msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -2996,8 +3019,7 @@ msgstr "Wenn sie eine Nachricht senden, wird das Eingabefeld für X Sekunden dea
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 #, no-wrap
 msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-"Sie können Aufgaben und Aufgabenlisten mit Ihrem Moderationsteam bearbeiten."
+msgstr "Sie können Aufgaben und Aufgabenlisten mit Ihrem Moderationsteam bearbeiten."
 
 #. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3008,17 +3030,12 @@ msgstr "Aufgaben / To-do-Listen"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "This feature comes with the livechat plugin version 10.0.0."
-msgstr ""
-"Diese Funktion wird mit dem Livechatplugin Version 10.0.0 verfügbar sein."
+msgstr "Diese Funktion wird mit dem Livechatplugin Version 10.0.0 verfügbar sein."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "The livechat plugin includes a Task Application: a kind of \"to-do list\" feature where you can create task lists and add tasks to them.  Every room's admins have access to these tasks, so you can edit them collaboratively."
-msgstr ""
-"Das Livechat Plugin enthält eine Aufgabenanwendung: eine Art \"To-Do-Liste\""
-", mit der Sie Aufgabenlisten erstellen und Aufgaben zu ihnen hinzufügen "
-"können.  Die Administratoren eines jeden Raums haben Zugriff auf diese "
-"Aufgaben, sodass Sie sie gemeinsam bearbeiten können."
+msgstr "Das Livechat Plugin enthält eine Aufgabenanwendung: eine Art \"To-Do-Liste\", mit der Sie Aufgabenlisten erstellen und Aufgaben zu ihnen hinzufügen können.  Die Administratoren eines jeden Raums haben Zugriff auf diese Aufgaben, sodass Sie sie gemeinsam bearbeiten können."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3028,16 +3045,12 @@ msgstr "Sie können die Aufgabenanwendung zum Beispiel verwenden, um:"
 #. type: Bullet: '* '
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "prepare a list of themes you want to discuss during your livestream, so you can be sure you won't forget anything"
-msgstr ""
-"eine Liste der Themen vorzubereiten, die Sie während Ihres Livestreams "
-"besprechen möchten, damit Sie nichts vergessen"
+msgstr "eine Liste der Themen vorzubereiten, die Sie während Ihres Livestreams besprechen möchten, damit Sie nichts vergessen"
 
 #. type: Bullet: '* '
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "highlight questions from your viewers, so you can come back to them later without forgetting to answer them"
-msgstr ""
-"Fragen Ihrer Zuschauer markieren, damit Sie später darauf zurückkommen "
-"können, ohne zu vergessen, sie zu beantworten"
+msgstr "Fragen Ihrer Zuschauer markieren, damit Sie später darauf zurückkommen können, ohne zu vergessen, sie zu beantworten"
 
 #. type: Bullet: '* '
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3059,51 +3072,37 @@ msgstr "Aufgabenanwendung öffnen"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "To open the Task Application, there is a \"{{% livechat_label \"tasks\" %}}\" button in the top chat menu:"
-msgstr ""
-"Um die Aufgabenanwendung zu öffnen, gibt es eine Schaltfläche \"{{% "
-"livechat_label \"Aufgaben\" %}}\" im oberen Chatmenü:"
+msgstr "Um die Aufgabenanwendung zu öffnen, gibt es eine Schaltfläche \"{{% livechat_label \"Aufgaben\" %}}\" im oberen Chatmenü:"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Opening the Task Application](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px)"
-msgstr ""
-"[Öffnen der Aufgabenanwendung](/peertube-plugin-livechat/images/"
-"task_open_app_video.png?classes=shadow,border&height=200px)"
+msgstr "[Öffnen der Aufgabenanwendung](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Opening the Task Application](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px)"
-msgstr ""
-"[Öffnen der Aufgabenanwendung](/peertube-plugin-livechat/images/"
-"task_open_app_fullpage.png?classes=shadow,border&height=200px)"
+msgstr "[Öffnen der Aufgabenanwendung](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Clicking this button will toggle the Task Application display:"
-msgstr ""
-"Wenn Sie auf diese Schaltfläche klicken, wird die Anzeige der "
-"Aufgabenanwendung umgeschaltet:"
+msgstr "Wenn Sie auf diese Schaltfläche klicken, wird die Anzeige der Aufgabenanwendung umgeschaltet:"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task Application](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabenanwendung](/peertube-plugin-livechat/images/task_app_video_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabenanwendung](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task Application](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabenanwendung](/peertube-plugin-livechat/images/task_app_fullpage_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabenanwendung](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "To have more space and better readability, open the chat in full-page mode."
-msgstr ""
-"Um mehr Platz und eine bessere Lesbarkeit zu erhalten, öffnen Sie den Chat "
-"im neuen Fenster."
+msgstr "Um mehr Platz und eine bessere Lesbarkeit zu erhalten, öffnen Sie den Chat im neuen Fenster."
 
 #. type: Title ###
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3114,18 +3113,12 @@ msgstr "Zugriffsrechte"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Every room's admins have access to the Task Application (read and write access)."
-msgstr ""
-"Die Administratoren eines jeden Raums haben Zugriff auf die "
-"Aufgabenanwendung (Lese- und Schreibzugriff)."
+msgstr "Die Administratoren eines jeden Raums haben Zugriff auf die Aufgabenanwendung (Lese- und Schreibzugriff)."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "When you promote someone as room admin or owner, they gets instant access to the Task Application.  When you remove admin or owner rights to someone, they instantly lose access to the Task Application."
-msgstr ""
-"Wenn Sie jemanden zum Raumadministrator oder -besitzer befördern, erhält "
-"dieser sofortigen Zugriff auf die Aufgabenanwendung.  Wenn Sie jemandem die "
-"Admin- oder Eigentümerrechte entziehen, verliert er sofort den Zugang zur "
-"Aufgabenanwendung."
+msgstr "Wenn Sie jemanden zum Raumadministrator oder -besitzer befördern, erhält dieser sofortigen Zugriff auf die Aufgabenanwendung.  Wenn Sie jemandem die Admin- oder Eigentümerrechte entziehen, verliert er sofort den Zugang zur Aufgabenanwendung."
 
 #. type: Title ###
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3136,18 +3129,12 @@ msgstr "Aufgabenlisten"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "By default, there is one task list that has the same name as your livestream."
-msgstr ""
-"Standardmäßig gibt es eine Aufgabenliste, die denselben Namen wie Ihr "
-"Livestream hat."
+msgstr "Standardmäßig gibt es eine Aufgabenliste, die denselben Namen wie Ihr Livestream hat."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "You can use the form at the bottom to create a new task list.  You can also edit existing task lists using the edit button, or delete any task list. Deleting a task list will also delete all its tasks."
-msgstr ""
-"Mit dem Formular am unteren Rand können Sie eine neue Aufgabenliste "
-"erstellen.  Sie können auch bestehende Aufgabenlisten über die Schaltfläche "
-"bearbeiten oder eine Aufgabenliste löschen. Wenn Sie eine Aufgabenliste "
-"löschen, werden auch alle dazugehörigen Aufgaben gelöscht."
+msgstr "Mit dem Formular am unteren Rand können Sie eine neue Aufgabenliste erstellen.  Sie können auch bestehende Aufgabenlisten über die Schaltfläche bearbeiten oder eine Aufgabenliste löschen. Wenn Sie eine Aufgabenliste löschen, werden auch alle dazugehörigen Aufgaben gelöscht."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3157,16 +3144,12 @@ msgstr "Die Aufgabenlisten sind alphabetisch sortiert."
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task lists](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabenlisten](/peertube-plugin-livechat/images/task_app_task_lists."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabenlisten](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "All modification are instantly visible in all your browser tabs, and for all room's admins."
-msgstr ""
-"Alle Änderungen sind sofort in allen Registerkarten Ihres Browsers und für "
-"alle Raumadministratoren sichtbar."
+msgstr "Alle Änderungen sind sofort in allen Registerkarten Ihres Browsers und für alle Raumadministratoren sichtbar."
 
 #. type: Title ###
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3183,24 +3166,17 @@ msgstr "Aufgaben erstellen"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "You can create a task using the button on the right of task lists.  This opens a form with two fields: a mandatory task name, and an optional description."
-msgstr ""
-"Sie können eine Aufgabe über die Schaltfläche rechts neben der Aufgabenliste "
-"erstellen.  Es öffnet sich ein Formular mit zwei Feldern: einem "
-"obligatorischen Aufgabennamen und einer optionalen Beschreibung."
+msgstr "Sie können eine Aufgabe über die Schaltfläche rechts neben der Aufgabenliste erstellen.  Es öffnet sich ein Formular mit zwei Feldern: einem obligatorischen Aufgabennamen und einer optionalen Beschreibung."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task form](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabenformular](/peertube-plugin-livechat/images/task_app_task_form."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabenformular](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task created](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabe erstellt](/peertube-plugin-livechat/images/task_app_task_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabe erstellt](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3211,23 +3187,17 @@ msgstr "Aufgaben bearbeiten"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Tasks can be edited by using the edit button on the right."
-msgstr ""
-"Aufgaben können über die Schaltfläche \"Bearbeiten\" auf der rechten Seite "
-"bearbeitet werden."
+msgstr "Aufgaben können über die Schaltfläche \"Bearbeiten\" auf der rechten Seite bearbeitet werden."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Tasks can be marked complete (or uncomplete) by clicking directly on the checkbox in the list."
-msgstr ""
-"Aufgaben können durch direktes Anklicken des Kontrollkästchens in der Liste "
-"als erledigt (oder nicht erledigt) markiert werden."
+msgstr "Aufgaben können durch direktes Anklicken des Kontrollkästchens in der Liste als erledigt (oder nicht erledigt) markiert werden."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Tasks](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgaben](/peertube-plugin-livechat/images/task_app_task_2."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgaben](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3238,24 +3208,17 @@ msgstr "Aufgaben sortieren / Aufgabenliste ändern"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "You can sort tasks, or move tasks from one list to another, simply using drag & drop."
-msgstr ""
-"Sie können Aufgaben sortieren oder von einer Liste in eine andere "
-"verschieben, indem Sie sie einfach per Drag & Drop ziehen."
+msgstr "Sie können Aufgaben sortieren oder von einer Liste in eine andere verschieben, indem Sie sie einfach per Drag & Drop ziehen."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Drag and drop to sort](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Drag und Drop zum Sortieren](/peertube-plugin-livechat/images/"
-"task_drag_drop.png?classes=shadow,border&height=200px)"
+msgstr "![Drag und Drop zum Sortieren](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Drag and drop to move to another list](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Drag und Drop zum Verschieben zu einer anderen Liste](/peertube-"
-"plugin-livechat/images/task_drag_drop_task_list."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Drag und Drop zum Verschieben zu einer anderen Liste](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3266,42 +3229,27 @@ msgstr "Erstellen einer Aufgabe aus einer Chat-Nachricht"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "You can create a task from a message in a chat, using the \"{{% livechat_label \"task_create\" %}}\" button in the dropdown menu at the right of the message.  This will open a dialog box where you can choose which task list you want to add the task into.  The task name will be the user nickname, and the task description the message content."
-msgstr ""
-"Sie können eine Aufgabe aus einer Nachricht in einem Chat erstellen, indem "
-"Sie die Schaltfläche \"{{% livechat_label \"task_create\" %}}\" im Dropdown-"
-"Menü rechts neben der Nachricht verwenden.  Daraufhin öffnet sich ein "
-"Dialogfeld, in dem Sie auswählen können, in welche Aufgabenliste Sie die "
-"Aufgabe aufnehmen möchten.  Der Aufgabenname ist der Spitzname des Benutzers "
-"und die Aufgabenbeschreibung der Inhalt der Nachricht."
+msgstr "Sie können eine Aufgabe aus einer Nachricht in einem Chat erstellen, indem Sie die Schaltfläche \"{{% livechat_label \"task_create\" %}}\" im Dropdown-Menü rechts neben der Nachricht verwenden.  Daraufhin öffnet sich ein Dialogfeld, in dem Sie auswählen können, in welche Aufgabenliste Sie die Aufgabe aufnehmen möchten.  Der Aufgabenname ist der Spitzname des Benutzers und die Aufgabenbeschreibung der Inhalt der Nachricht."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Create task from message](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabe aus einer Nachricht erstellen](/peertube-plugin-livechat/images/"
-"task_from_message_1.png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabe aus einer Nachricht erstellen](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Choose the task list](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabenliste auswählen](/peertube-plugin-livechat/images/"
-"task_from_message_2.png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabenliste auswählen](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task created](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Aufgabe erstellt](/peertube-plugin-livechat/images/task_from_message_3."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Aufgabe erstellt](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
-msgstr ""
-"Mit dieser Funktion können Sie z. B. Ihre Moderatoren bitten, alle Chat-"
-"Fragen zu markieren, damit Sie sie während Ihres Livestreams auf einen Blick "
-"sehen und als beantwortet markieren können."
+msgstr "Mit dieser Funktion können Sie z. B. Ihre Moderatoren bitten, alle Chat-Fragen zu markieren, damit Sie sie während Ihres Livestreams auf einen Blick sehen und als beantwortet markieren können."
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -3781,6 +3729,9 @@ msgstr "[Meilensteine auf Github](https://github.com/JohnXLivingston/peertube-pl
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Wenn Sie ein Webdesigner oder ein ConverseJS/Prosody/XMPP-Experte sind und helfen wollen, dieses Plugin zu verbessern, sind Sie gerne willkommen."
+
+#~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+#~ msgstr "Alle Instanzmoderatoren und Admins sind Eigentümer der erstellten Chaträume.  Der Eigentümer des Videos wird der Administrator des Chatraums sein."
 
 #~ msgid "So can also use provider such as Google, Facebook, ..."
 #~ msgstr "So können auch Anbieter wie Google, Facebook, ... genutzt werden."

--- a/support/documentation/po/livechat.el.po
+++ b/support/documentation/po/livechat.el.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/el/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.en.pot
+++ b/support/documentation/po/livechat.en.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3084,6 +3084,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, markdown-text, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, markdown-text, no-wrap
@@ -3111,7 +3119,13 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, markdown-text
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, markdown-text
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -3166,6 +3180,12 @@ msgstr ""
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, markdown-text
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, markdown-text
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -3251,7 +3271,7 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #, markdown-text
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -3264,6 +3284,12 @@ msgstr ""
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #, markdown-text
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, markdown-text
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.eo.po
+++ b/support/documentation/po/livechat.eo.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eo/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.es.po
+++ b/support/documentation/po/livechat.es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-04-16 21:38+0000\n"
 "Last-Translator: rnek0 <rnek0@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Spanish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/es/>\n"
@@ -2771,6 +2771,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2795,7 +2803,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2844,6 +2857,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2919,7 +2937,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2930,6 +2948,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.eu.po
+++ b/support/documentation/po/livechat.eu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eu/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fa.po
+++ b/support/documentation/po/livechat.fa.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fa/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fi.po
+++ b/support/documentation/po/livechat.fi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fi/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fr.po
+++ b/support/documentation/po/livechat.fr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-04-12 05:39+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: French <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fr/>\n"
@@ -2846,6 +2846,14 @@ msgstr "Fonctionnalités de modération avancées du plugin peertube-plugin-live
 msgid "This section is still incomplete."
 msgstr "Cette section est encore incomplète."
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2870,8 +2878,13 @@ msgstr "Vous pouvez accéder aux paramètres de la salle et aux outils de modér
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
-msgstr "Tous les modérateur⋅rices et administrateur⋅rices de l'instance seront propriétaires des salons de discussion créés. Le ou la propriétaire de la vidéo sera admin du salon."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2920,6 +2933,11 @@ msgstr "En tant que modérateur⋅rice ou administrateur⋅rice de l'instance Pe
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
 msgstr "Vous pouvez lister toutes les salles de discussion existantes : dans l'écran des paramètres du plugin, il y a un bouton \"Lister les salles\"."
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
+msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -2994,7 +3012,9 @@ msgstr "![Configuration de la chaîne / Mode lent](/peertube-plugin-livechat/ima
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+#, fuzzy
+#| msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr "Cette valeur va s'appliquer à tous les salons de discussion de votre chaîne."
 
 #. type: Plain text
@@ -3006,6 +3026,11 @@ msgstr "La valeur `0` désactive la fonctionnalité."
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
 msgstr "Positionner la valeur à un nombre entier positif permet de fixer la période pendant laquelle les utilisateur⋅rices ne pourront pas envoyer de messages supplémentaires."
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
+msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -3773,6 +3798,9 @@ msgstr "les [jalons sur github](https://github.com/JohnXLivingston/peertube-plug
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Si vous êtes webdesigner ou avez une expertise en ConverseJS/Prosody/XMPP et souhaitez participer à l'évolution de ce plugin, n'hésitez pas à me contacter."
+
+#~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+#~ msgstr "Tous les modérateur⋅rices et administrateur⋅rices de l'instance seront propriétaires des salons de discussion créés. Le ou la propriétaire de la vidéo sera admin du salon."
 
 #, no-wrap
 #~ msgid "Default channel value"

--- a/support/documentation/po/livechat.gd.po
+++ b/support/documentation/po/livechat.gd.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Gaelic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gd/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.gl.po
+++ b/support/documentation/po/livechat.gl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Galician <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gl/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.hr.po
+++ b/support/documentation/po/livechat.hr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-05-01 01:17+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hr/>\n"
@@ -2745,6 +2745,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2769,7 +2777,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2818,6 +2831,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2893,7 +2911,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2904,6 +2922,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.hu.po
+++ b/support/documentation/po/livechat.hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hu/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.is.po
+++ b/support/documentation/po/livechat.is.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Icelandic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/is/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.it.po
+++ b/support/documentation/po/livechat.it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 14:21+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: Italian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/it/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ja.po
+++ b/support/documentation/po/livechat.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2024-03-10 20:38+0000\n"
 "Last-Translator: \"T.S\" <fusen@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Japanese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ja/>\n"
@@ -2809,6 +2809,14 @@ msgstr "PeerTube ライブチャットプラグイン"
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2835,7 +2843,12 @@ msgstr "PeerTube ライブチャットプラグイン"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2884,6 +2897,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2962,7 +2980,7 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2973,6 +2991,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.kab.po
+++ b/support/documentation/po/livechat.kab.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Kabyle <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/kab/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nb.po
+++ b/support/documentation/po/livechat.nb.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nb_NO/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nl.po
+++ b/support/documentation/po/livechat.nl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nl/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nn.po
+++ b/support/documentation/po/livechat.nn.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Nynorsk <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nn/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.oc.po
+++ b/support/documentation/po/livechat.oc.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Occitan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/oc/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.pl.po
+++ b/support/documentation/po/livechat.pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pl/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.pt.po
+++ b/support/documentation/po/livechat.pt.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pt/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ru.po
+++ b/support/documentation/po/livechat.ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ru/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.sq.po
+++ b/support/documentation/po/livechat.sq.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Albanian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sq/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.sv.po
+++ b/support/documentation/po/livechat.sv.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sv/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.th.po
+++ b/support/documentation/po/livechat.th.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/th/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.tok.po
+++ b/support/documentation/po/livechat.tok.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Toki Pona <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/tok/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.tr.po
+++ b/support/documentation/po/livechat.tr.po
@@ -2722,6 +2722,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2746,7 +2754,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2795,6 +2808,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button List rooms."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2870,7 +2888,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2881,6 +2899,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.uk.po
+++ b/support/documentation/po/livechat.uk.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/uk/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.vi.po
+++ b/support/documentation/po/livechat.vi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Vietnamese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/vi/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.zh-Hans.po
+++ b/support/documentation/po/livechat.zh-Hans.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hans/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.zh-Hant.po
+++ b/support/documentation/po/livechat.zh-Hant.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-13 17:41+0200\n"
+"POT-Creation-Date: 2024-05-17 15:56+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hant/>\n"
@@ -2741,6 +2741,14 @@ msgstr ""
 msgid "This section is still incomplete."
 msgstr ""
 
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#, no-wrap
+msgid ""
+"This page describes the behaviour of livechat versions >= 10.0.0.\n"
+"There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
+msgstr ""
+
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 #, no-wrap
@@ -2765,7 +2773,12 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
+msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
 msgstr ""
 
 #. type: Plain text
@@ -2814,6 +2827,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "You can list all existing chatrooms: in the plugin settings screen, there is a button «List rooms»."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
@@ -2889,7 +2907,7 @@ msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "This value will apply to all your channel's chatrooms."
+msgid "This value will apply as a default value for all your channel's chatrooms."
 msgstr ""
 
 #. type: Plain text
@@ -2900,6 +2918,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "Setting the value to a positive integer will set the period during which users will not be able to post additional messages."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title


### PR DESCRIPTION
## Description

We change the way we give default access to chat rooms:

* video owner is MUC owner
* the bot is MUC owner
* the bot is admin on the MUC component
* Peertube moderators/admins have no more special access (by default)
* For Peertube moderators/admins, we add a button "Promote". Clicking on it will promote them as MUC owner.
* There is a migration script to update all existing rooms
* Documentation updated
* As a result, now streamers can access to room configuration. So the slow mode value in channel config could become a default value for new rooms.

## Related issues

#385 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [x] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [x] I added some documentation and I have run `npm run doc:translate` to generate translations files
