### PR TITLE
Adding the SPDX comment headers of copyright and licensing information

### DIFF
--- a/.eslintrc.json.license
+++ b/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ## Description
 
 <!-- Please include a summary of the change, with motivation and context -->

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: github pages
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 node_modules
 .cache
 dist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 stages:
   - build
   - deploy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 [submodule "documentation/themes/hugo-theme-learn"]
 	path = support/documentation/themes/hugo-theme-learn
 	url = https://github.com/matcornic/hugo-theme-learn.git

--- a/.markdownlint.jsonc.license
+++ b/.markdownlint.jsonc.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 .cache
 .vscode
 build

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -16,3 +16,7 @@ License: AGPL-3.0-only
 Files: support/documentation/po/*
 Copyright: 2024 John Livingston <https://www.john-livingston.fr/>
 License: AGPL-3.0-only
+
+Files: support/documentation/content/en/*
+Copyright: 2024 John Livingston <https://www.john-livingston.fr/>
+License: AGPL-3.0-only

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -8,3 +8,11 @@ Source: https://github.com/JohnXLivingston/peertube-plugin-livechat/
 # Files: src/*
 # Copyright: $YEAR $NAME <$CONTACT>
 # License: ...
+
+Files: languages/*
+Copyright: 2024 John Livingston <https://www.john-livingston.fr/>
+License: AGPL-3.0-only
+
+Files: support/documentation/po/*
+Copyright: 2024 John Livingston <https://www.john-livingston.fr/>
+License: AGPL-3.0-only

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,10 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: peertube-plugin-livechat
+Upstream-Contact: John Livingston <https://www.john-livingston.fr/>
+Source: https://github.com/JohnXLivingston/peertube-plugin-livechat/
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 'use strict';
 
 module.exports = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Changelog
 
 ## 10.0.2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Code Of Conduct
 
 Please refer to one of these:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Contributing
 
 Please refer to one of these:

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # peertube-plugin-livechat
 
 This Peertube plugin is published under the «GNU AFFERO GENERAL PUBLIC LICENSE version 3» license.

--- a/LICENSES/AGPL-3.0-only.txt
+++ b/LICENSES/AGPL-3.0-only.txt
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # PeerTube plugin livechat
 
 This [Peertube](https://joinpeertube.org/) plugin is meant to provide chat system for Peertube videos.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Roadmap
 
 Please refer to:

--- a/assets/images/avatars/abstract/accessorie_1.png.licence
+++ b/assets/images/avatars/abstract/accessorie_1.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/accessorie_1.png.license
+++ b/assets/images/avatars/abstract/accessorie_1.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_01.png.licence
+++ b/assets/images/avatars/abstract/body_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_01.png.license
+++ b/assets/images/avatars/abstract/body_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_02.png.licence
+++ b/assets/images/avatars/abstract/body_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_02.png.license
+++ b/assets/images/avatars/abstract/body_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_03.png.licence
+++ b/assets/images/avatars/abstract/body_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_03.png.license
+++ b/assets/images/avatars/abstract/body_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_04.png.licence
+++ b/assets/images/avatars/abstract/body_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_04.png.license
+++ b/assets/images/avatars/abstract/body_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_05.png.licence
+++ b/assets/images/avatars/abstract/body_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_05.png.license
+++ b/assets/images/avatars/abstract/body_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_06.png.licence
+++ b/assets/images/avatars/abstract/body_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_06.png.license
+++ b/assets/images/avatars/abstract/body_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_07.png.licence
+++ b/assets/images/avatars/abstract/body_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_07.png.license
+++ b/assets/images/avatars/abstract/body_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_08.png.licence
+++ b/assets/images/avatars/abstract/body_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_08.png.license
+++ b/assets/images/avatars/abstract/body_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_09.png.licence
+++ b/assets/images/avatars/abstract/body_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_09.png.license
+++ b/assets/images/avatars/abstract/body_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_10.png.licence
+++ b/assets/images/avatars/abstract/body_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_10.png.license
+++ b/assets/images/avatars/abstract/body_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_11.png.licence
+++ b/assets/images/avatars/abstract/body_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_11.png.license
+++ b/assets/images/avatars/abstract/body_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_12.png.licence
+++ b/assets/images/avatars/abstract/body_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_12.png.license
+++ b/assets/images/avatars/abstract/body_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_13.png.licence
+++ b/assets/images/avatars/abstract/body_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_13.png.license
+++ b/assets/images/avatars/abstract/body_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_14.png.licence
+++ b/assets/images/avatars/abstract/body_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_14.png.license
+++ b/assets/images/avatars/abstract/body_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/body_15.png.licence
+++ b/assets/images/avatars/abstract/body_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/body_15.png.license
+++ b/assets/images/avatars/abstract/body_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_01.png.licence
+++ b/assets/images/avatars/abstract/eyes_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_01.png.license
+++ b/assets/images/avatars/abstract/eyes_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_02.png.licence
+++ b/assets/images/avatars/abstract/eyes_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_02.png.license
+++ b/assets/images/avatars/abstract/eyes_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_03.png.licence
+++ b/assets/images/avatars/abstract/eyes_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_03.png.license
+++ b/assets/images/avatars/abstract/eyes_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_04.png.licence
+++ b/assets/images/avatars/abstract/eyes_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_04.png.license
+++ b/assets/images/avatars/abstract/eyes_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_05.png.licence
+++ b/assets/images/avatars/abstract/eyes_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_05.png.license
+++ b/assets/images/avatars/abstract/eyes_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_06.png.licence
+++ b/assets/images/avatars/abstract/eyes_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_06.png.license
+++ b/assets/images/avatars/abstract/eyes_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_07.png.licence
+++ b/assets/images/avatars/abstract/eyes_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_07.png.license
+++ b/assets/images/avatars/abstract/eyes_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_08.png.licence
+++ b/assets/images/avatars/abstract/eyes_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_08.png.license
+++ b/assets/images/avatars/abstract/eyes_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_09.png.licence
+++ b/assets/images/avatars/abstract/eyes_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_09.png.license
+++ b/assets/images/avatars/abstract/eyes_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_10.png.licence
+++ b/assets/images/avatars/abstract/eyes_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_10.png.license
+++ b/assets/images/avatars/abstract/eyes_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_11.png.licence
+++ b/assets/images/avatars/abstract/eyes_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_11.png.license
+++ b/assets/images/avatars/abstract/eyes_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_12.png.licence
+++ b/assets/images/avatars/abstract/eyes_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_12.png.license
+++ b/assets/images/avatars/abstract/eyes_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_13.png.licence
+++ b/assets/images/avatars/abstract/eyes_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_13.png.license
+++ b/assets/images/avatars/abstract/eyes_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_14.png.licence
+++ b/assets/images/avatars/abstract/eyes_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_14.png.license
+++ b/assets/images/avatars/abstract/eyes_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/eyes_15.png.licence
+++ b/assets/images/avatars/abstract/eyes_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/eyes_15.png.license
+++ b/assets/images/avatars/abstract/eyes_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_01.png.licence
+++ b/assets/images/avatars/abstract/fur_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_01.png.license
+++ b/assets/images/avatars/abstract/fur_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_02.png.licence
+++ b/assets/images/avatars/abstract/fur_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_02.png.license
+++ b/assets/images/avatars/abstract/fur_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_03.png.licence
+++ b/assets/images/avatars/abstract/fur_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_03.png.license
+++ b/assets/images/avatars/abstract/fur_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_04.png.licence
+++ b/assets/images/avatars/abstract/fur_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_04.png.license
+++ b/assets/images/avatars/abstract/fur_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_05.png.licence
+++ b/assets/images/avatars/abstract/fur_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_05.png.license
+++ b/assets/images/avatars/abstract/fur_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_06.png.licence
+++ b/assets/images/avatars/abstract/fur_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_06.png.license
+++ b/assets/images/avatars/abstract/fur_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_07.png.licence
+++ b/assets/images/avatars/abstract/fur_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_07.png.license
+++ b/assets/images/avatars/abstract/fur_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_08.png.licence
+++ b/assets/images/avatars/abstract/fur_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_08.png.license
+++ b/assets/images/avatars/abstract/fur_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_09.png.licence
+++ b/assets/images/avatars/abstract/fur_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_09.png.license
+++ b/assets/images/avatars/abstract/fur_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/fur_10.png.licence
+++ b/assets/images/avatars/abstract/fur_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/fur_10.png.license
+++ b/assets/images/avatars/abstract/fur_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_01.png.licence
+++ b/assets/images/avatars/abstract/mouth_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_01.png.license
+++ b/assets/images/avatars/abstract/mouth_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_02.png.licence
+++ b/assets/images/avatars/abstract/mouth_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_02.png.license
+++ b/assets/images/avatars/abstract/mouth_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_03.png.licence
+++ b/assets/images/avatars/abstract/mouth_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_03.png.license
+++ b/assets/images/avatars/abstract/mouth_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_04.png.licence
+++ b/assets/images/avatars/abstract/mouth_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_04.png.license
+++ b/assets/images/avatars/abstract/mouth_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_05.png.licence
+++ b/assets/images/avatars/abstract/mouth_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_05.png.license
+++ b/assets/images/avatars/abstract/mouth_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_06.png.licence
+++ b/assets/images/avatars/abstract/mouth_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_06.png.license
+++ b/assets/images/avatars/abstract/mouth_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_07.png.licence
+++ b/assets/images/avatars/abstract/mouth_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_07.png.license
+++ b/assets/images/avatars/abstract/mouth_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_08.png.licence
+++ b/assets/images/avatars/abstract/mouth_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_08.png.license
+++ b/assets/images/avatars/abstract/mouth_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_09.png.licence
+++ b/assets/images/avatars/abstract/mouth_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_09.png.license
+++ b/assets/images/avatars/abstract/mouth_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/abstract/mouth_10.png.licence
+++ b/assets/images/avatars/abstract/mouth_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/abstract/mouth_10.png.license
+++ b/assets/images/avatars/abstract/mouth_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_01.png.licence
+++ b/assets/images/avatars/bird/accessorie_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_01.png.license
+++ b/assets/images/avatars/bird/accessorie_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_02.png.licence
+++ b/assets/images/avatars/bird/accessorie_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_02.png.license
+++ b/assets/images/avatars/bird/accessorie_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_03.png.licence
+++ b/assets/images/avatars/bird/accessorie_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_03.png.license
+++ b/assets/images/avatars/bird/accessorie_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_04.png.licence
+++ b/assets/images/avatars/bird/accessorie_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_04.png.license
+++ b/assets/images/avatars/bird/accessorie_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_05.png.licence
+++ b/assets/images/avatars/bird/accessorie_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_05.png.license
+++ b/assets/images/avatars/bird/accessorie_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_06.png.licence
+++ b/assets/images/avatars/bird/accessorie_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_06.png.license
+++ b/assets/images/avatars/bird/accessorie_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_07.png.licence
+++ b/assets/images/avatars/bird/accessorie_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_07.png.license
+++ b/assets/images/avatars/bird/accessorie_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_08.png.licence
+++ b/assets/images/avatars/bird/accessorie_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_08.png.license
+++ b/assets/images/avatars/bird/accessorie_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_09.png.licence
+++ b/assets/images/avatars/bird/accessorie_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_09.png.license
+++ b/assets/images/avatars/bird/accessorie_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_10.png.licence
+++ b/assets/images/avatars/bird/accessorie_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_10.png.license
+++ b/assets/images/avatars/bird/accessorie_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_11.png.licence
+++ b/assets/images/avatars/bird/accessorie_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_11.png.license
+++ b/assets/images/avatars/bird/accessorie_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_12.png.licence
+++ b/assets/images/avatars/bird/accessorie_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_12.png.license
+++ b/assets/images/avatars/bird/accessorie_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_13.png.licence
+++ b/assets/images/avatars/bird/accessorie_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_13.png.license
+++ b/assets/images/avatars/bird/accessorie_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_14.png.licence
+++ b/assets/images/avatars/bird/accessorie_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_14.png.license
+++ b/assets/images/avatars/bird/accessorie_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_15.png.licence
+++ b/assets/images/avatars/bird/accessorie_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_15.png.license
+++ b/assets/images/avatars/bird/accessorie_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_16.png.licence
+++ b/assets/images/avatars/bird/accessorie_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_16.png.license
+++ b/assets/images/avatars/bird/accessorie_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_17.png.licence
+++ b/assets/images/avatars/bird/accessorie_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_17.png.license
+++ b/assets/images/avatars/bird/accessorie_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_18.png.licence
+++ b/assets/images/avatars/bird/accessorie_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_18.png.license
+++ b/assets/images/avatars/bird/accessorie_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_19.png.licence
+++ b/assets/images/avatars/bird/accessorie_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_19.png.license
+++ b/assets/images/avatars/bird/accessorie_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/accessorie_20.png.licence
+++ b/assets/images/avatars/bird/accessorie_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/accessorie_20.png.license
+++ b/assets/images/avatars/bird/accessorie_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_01.png.licence
+++ b/assets/images/avatars/bird/bec_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_01.png.license
+++ b/assets/images/avatars/bird/bec_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_02.png.licence
+++ b/assets/images/avatars/bird/bec_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_02.png.license
+++ b/assets/images/avatars/bird/bec_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_03.png.licence
+++ b/assets/images/avatars/bird/bec_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_03.png.license
+++ b/assets/images/avatars/bird/bec_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_04.png.licence
+++ b/assets/images/avatars/bird/bec_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_04.png.license
+++ b/assets/images/avatars/bird/bec_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_05.png.licence
+++ b/assets/images/avatars/bird/bec_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_05.png.license
+++ b/assets/images/avatars/bird/bec_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_06.png.licence
+++ b/assets/images/avatars/bird/bec_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_06.png.license
+++ b/assets/images/avatars/bird/bec_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_07.png.licence
+++ b/assets/images/avatars/bird/bec_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_07.png.license
+++ b/assets/images/avatars/bird/bec_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_08.png.licence
+++ b/assets/images/avatars/bird/bec_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_08.png.license
+++ b/assets/images/avatars/bird/bec_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/bec_09.png.licence
+++ b/assets/images/avatars/bird/bec_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/bec_09.png.license
+++ b/assets/images/avatars/bird/bec_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_01.png.licence
+++ b/assets/images/avatars/bird/body_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_01.png.license
+++ b/assets/images/avatars/bird/body_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_02.png.licence
+++ b/assets/images/avatars/bird/body_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_02.png.license
+++ b/assets/images/avatars/bird/body_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_03.png.licence
+++ b/assets/images/avatars/bird/body_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_03.png.license
+++ b/assets/images/avatars/bird/body_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_04.png.licence
+++ b/assets/images/avatars/bird/body_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_04.png.license
+++ b/assets/images/avatars/bird/body_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_05.png.licence
+++ b/assets/images/avatars/bird/body_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_05.png.license
+++ b/assets/images/avatars/bird/body_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_06.png.licence
+++ b/assets/images/avatars/bird/body_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_06.png.license
+++ b/assets/images/avatars/bird/body_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_07.png.licence
+++ b/assets/images/avatars/bird/body_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_07.png.license
+++ b/assets/images/avatars/bird/body_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_08.png.licence
+++ b/assets/images/avatars/bird/body_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_08.png.license
+++ b/assets/images/avatars/bird/body_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/body_09.png.licence
+++ b/assets/images/avatars/bird/body_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/body_09.png.license
+++ b/assets/images/avatars/bird/body_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_01.png.licence
+++ b/assets/images/avatars/bird/eyes_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_01.png.license
+++ b/assets/images/avatars/bird/eyes_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_02.png.licence
+++ b/assets/images/avatars/bird/eyes_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_02.png.license
+++ b/assets/images/avatars/bird/eyes_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_03.png.licence
+++ b/assets/images/avatars/bird/eyes_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_03.png.license
+++ b/assets/images/avatars/bird/eyes_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_04.png.licence
+++ b/assets/images/avatars/bird/eyes_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_04.png.license
+++ b/assets/images/avatars/bird/eyes_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_05.png.licence
+++ b/assets/images/avatars/bird/eyes_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_05.png.license
+++ b/assets/images/avatars/bird/eyes_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_06.png.licence
+++ b/assets/images/avatars/bird/eyes_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_06.png.license
+++ b/assets/images/avatars/bird/eyes_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_07.png.licence
+++ b/assets/images/avatars/bird/eyes_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_07.png.license
+++ b/assets/images/avatars/bird/eyes_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_08.png.licence
+++ b/assets/images/avatars/bird/eyes_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_08.png.license
+++ b/assets/images/avatars/bird/eyes_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/eyes_09.png.licence
+++ b/assets/images/avatars/bird/eyes_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/eyes_09.png.license
+++ b/assets/images/avatars/bird/eyes_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_01.png.licence
+++ b/assets/images/avatars/bird/hoop_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_01.png.license
+++ b/assets/images/avatars/bird/hoop_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_02.png.licence
+++ b/assets/images/avatars/bird/hoop_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_02.png.license
+++ b/assets/images/avatars/bird/hoop_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_03.png.licence
+++ b/assets/images/avatars/bird/hoop_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_03.png.license
+++ b/assets/images/avatars/bird/hoop_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_04.png.licence
+++ b/assets/images/avatars/bird/hoop_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_04.png.license
+++ b/assets/images/avatars/bird/hoop_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_05.png.licence
+++ b/assets/images/avatars/bird/hoop_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_05.png.license
+++ b/assets/images/avatars/bird/hoop_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_06.png.licence
+++ b/assets/images/avatars/bird/hoop_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_06.png.license
+++ b/assets/images/avatars/bird/hoop_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_07.png.licence
+++ b/assets/images/avatars/bird/hoop_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_07.png.license
+++ b/assets/images/avatars/bird/hoop_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_08.png.licence
+++ b/assets/images/avatars/bird/hoop_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_08.png.license
+++ b/assets/images/avatars/bird/hoop_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_09.png.licence
+++ b/assets/images/avatars/bird/hoop_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_09.png.license
+++ b/assets/images/avatars/bird/hoop_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/hoop_10.png.licence
+++ b/assets/images/avatars/bird/hoop_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/hoop_10.png.license
+++ b/assets/images/avatars/bird/hoop_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_01.png.licence
+++ b/assets/images/avatars/bird/tail_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_01.png.license
+++ b/assets/images/avatars/bird/tail_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_02.png.licence
+++ b/assets/images/avatars/bird/tail_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_02.png.license
+++ b/assets/images/avatars/bird/tail_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_03.png.licence
+++ b/assets/images/avatars/bird/tail_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_03.png.license
+++ b/assets/images/avatars/bird/tail_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_04.png.licence
+++ b/assets/images/avatars/bird/tail_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_04.png.license
+++ b/assets/images/avatars/bird/tail_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_05.png.licence
+++ b/assets/images/avatars/bird/tail_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_05.png.license
+++ b/assets/images/avatars/bird/tail_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_06.png.licence
+++ b/assets/images/avatars/bird/tail_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_06.png.license
+++ b/assets/images/avatars/bird/tail_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_07.png.licence
+++ b/assets/images/avatars/bird/tail_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_07.png.license
+++ b/assets/images/avatars/bird/tail_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_08.png.licence
+++ b/assets/images/avatars/bird/tail_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_08.png.license
+++ b/assets/images/avatars/bird/tail_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/tail_09.png.licence
+++ b/assets/images/avatars/bird/tail_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/tail_09.png.license
+++ b/assets/images/avatars/bird/tail_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_01.png.licence
+++ b/assets/images/avatars/bird/wing_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_01.png.license
+++ b/assets/images/avatars/bird/wing_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_02.png.licence
+++ b/assets/images/avatars/bird/wing_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_02.png.license
+++ b/assets/images/avatars/bird/wing_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_03.png.licence
+++ b/assets/images/avatars/bird/wing_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_03.png.license
+++ b/assets/images/avatars/bird/wing_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_04.png.licence
+++ b/assets/images/avatars/bird/wing_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_04.png.license
+++ b/assets/images/avatars/bird/wing_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_05.png.licence
+++ b/assets/images/avatars/bird/wing_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_05.png.license
+++ b/assets/images/avatars/bird/wing_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_06.png.licence
+++ b/assets/images/avatars/bird/wing_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_06.png.license
+++ b/assets/images/avatars/bird/wing_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_07.png.licence
+++ b/assets/images/avatars/bird/wing_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_07.png.license
+++ b/assets/images/avatars/bird/wing_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_08.png.licence
+++ b/assets/images/avatars/bird/wing_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_08.png.license
+++ b/assets/images/avatars/bird/wing_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/bird/wing_09.png.licence
+++ b/assets/images/avatars/bird/wing_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/bird/wing_09.png.license
+++ b/assets/images/avatars/bird/wing_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_01.png.licence
+++ b/assets/images/avatars/cat/accessorie_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_01.png.license
+++ b/assets/images/avatars/cat/accessorie_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_02.png.licence
+++ b/assets/images/avatars/cat/accessorie_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_02.png.license
+++ b/assets/images/avatars/cat/accessorie_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_03.png.licence
+++ b/assets/images/avatars/cat/accessorie_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_03.png.license
+++ b/assets/images/avatars/cat/accessorie_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_04.png.licence
+++ b/assets/images/avatars/cat/accessorie_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_04.png.license
+++ b/assets/images/avatars/cat/accessorie_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_05.png.licence
+++ b/assets/images/avatars/cat/accessorie_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_05.png.license
+++ b/assets/images/avatars/cat/accessorie_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_06.png.licence
+++ b/assets/images/avatars/cat/accessorie_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_06.png.license
+++ b/assets/images/avatars/cat/accessorie_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_07.png.licence
+++ b/assets/images/avatars/cat/accessorie_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_07.png.license
+++ b/assets/images/avatars/cat/accessorie_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_08.png.licence
+++ b/assets/images/avatars/cat/accessorie_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_08.png.license
+++ b/assets/images/avatars/cat/accessorie_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_09.png.licence
+++ b/assets/images/avatars/cat/accessorie_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_09.png.license
+++ b/assets/images/avatars/cat/accessorie_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_10.png.licence
+++ b/assets/images/avatars/cat/accessorie_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_10.png.license
+++ b/assets/images/avatars/cat/accessorie_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_11.png.licence
+++ b/assets/images/avatars/cat/accessorie_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_11.png.license
+++ b/assets/images/avatars/cat/accessorie_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_12.png.licence
+++ b/assets/images/avatars/cat/accessorie_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_12.png.license
+++ b/assets/images/avatars/cat/accessorie_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_13.png.licence
+++ b/assets/images/avatars/cat/accessorie_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_13.png.license
+++ b/assets/images/avatars/cat/accessorie_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_14.png.licence
+++ b/assets/images/avatars/cat/accessorie_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_14.png.license
+++ b/assets/images/avatars/cat/accessorie_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_15.png.licence
+++ b/assets/images/avatars/cat/accessorie_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_15.png.license
+++ b/assets/images/avatars/cat/accessorie_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_16.png.licence
+++ b/assets/images/avatars/cat/accessorie_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_16.png.license
+++ b/assets/images/avatars/cat/accessorie_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_17.png.licence
+++ b/assets/images/avatars/cat/accessorie_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_17.png.license
+++ b/assets/images/avatars/cat/accessorie_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_18.png.licence
+++ b/assets/images/avatars/cat/accessorie_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_18.png.license
+++ b/assets/images/avatars/cat/accessorie_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_19.png.licence
+++ b/assets/images/avatars/cat/accessorie_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_19.png.license
+++ b/assets/images/avatars/cat/accessorie_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/accessorie_20.png.licence
+++ b/assets/images/avatars/cat/accessorie_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/accessorie_20.png.license
+++ b/assets/images/avatars/cat/accessorie_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_01.png.licence
+++ b/assets/images/avatars/cat/body_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_01.png.license
+++ b/assets/images/avatars/cat/body_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_02.png.licence
+++ b/assets/images/avatars/cat/body_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_02.png.license
+++ b/assets/images/avatars/cat/body_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_03.png.licence
+++ b/assets/images/avatars/cat/body_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_03.png.license
+++ b/assets/images/avatars/cat/body_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_04.png.licence
+++ b/assets/images/avatars/cat/body_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_04.png.license
+++ b/assets/images/avatars/cat/body_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_05.png.licence
+++ b/assets/images/avatars/cat/body_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_05.png.license
+++ b/assets/images/avatars/cat/body_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_06.png.licence
+++ b/assets/images/avatars/cat/body_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_06.png.license
+++ b/assets/images/avatars/cat/body_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_07.png.licence
+++ b/assets/images/avatars/cat/body_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_07.png.license
+++ b/assets/images/avatars/cat/body_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_08.png.licence
+++ b/assets/images/avatars/cat/body_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_08.png.license
+++ b/assets/images/avatars/cat/body_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_09.png.licence
+++ b/assets/images/avatars/cat/body_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_09.png.license
+++ b/assets/images/avatars/cat/body_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_10.png.licence
+++ b/assets/images/avatars/cat/body_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_10.png.license
+++ b/assets/images/avatars/cat/body_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_11.png.licence
+++ b/assets/images/avatars/cat/body_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_11.png.license
+++ b/assets/images/avatars/cat/body_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_12.png.licence
+++ b/assets/images/avatars/cat/body_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_12.png.license
+++ b/assets/images/avatars/cat/body_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_13.png.licence
+++ b/assets/images/avatars/cat/body_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_13.png.license
+++ b/assets/images/avatars/cat/body_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_14.png.licence
+++ b/assets/images/avatars/cat/body_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_14.png.license
+++ b/assets/images/avatars/cat/body_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/body_15.png.licence
+++ b/assets/images/avatars/cat/body_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/body_15.png.license
+++ b/assets/images/avatars/cat/body_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_01.png.licence
+++ b/assets/images/avatars/cat/eyes_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_01.png.license
+++ b/assets/images/avatars/cat/eyes_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_02.png.licence
+++ b/assets/images/avatars/cat/eyes_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_02.png.license
+++ b/assets/images/avatars/cat/eyes_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_03.png.licence
+++ b/assets/images/avatars/cat/eyes_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_03.png.license
+++ b/assets/images/avatars/cat/eyes_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_04.png.licence
+++ b/assets/images/avatars/cat/eyes_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_04.png.license
+++ b/assets/images/avatars/cat/eyes_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_05.png.licence
+++ b/assets/images/avatars/cat/eyes_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_05.png.license
+++ b/assets/images/avatars/cat/eyes_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_06.png.licence
+++ b/assets/images/avatars/cat/eyes_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_06.png.license
+++ b/assets/images/avatars/cat/eyes_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_07.png.licence
+++ b/assets/images/avatars/cat/eyes_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_07.png.license
+++ b/assets/images/avatars/cat/eyes_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_08.png.licence
+++ b/assets/images/avatars/cat/eyes_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_08.png.license
+++ b/assets/images/avatars/cat/eyes_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_09.png.licence
+++ b/assets/images/avatars/cat/eyes_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_09.png.license
+++ b/assets/images/avatars/cat/eyes_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_10.png.licence
+++ b/assets/images/avatars/cat/eyes_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_10.png.license
+++ b/assets/images/avatars/cat/eyes_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_11.png.licence
+++ b/assets/images/avatars/cat/eyes_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_11.png.license
+++ b/assets/images/avatars/cat/eyes_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_12.png.licence
+++ b/assets/images/avatars/cat/eyes_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_12.png.license
+++ b/assets/images/avatars/cat/eyes_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_13.png.licence
+++ b/assets/images/avatars/cat/eyes_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_13.png.license
+++ b/assets/images/avatars/cat/eyes_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_14.png.licence
+++ b/assets/images/avatars/cat/eyes_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_14.png.license
+++ b/assets/images/avatars/cat/eyes_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/eyes_15.png.licence
+++ b/assets/images/avatars/cat/eyes_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/eyes_15.png.license
+++ b/assets/images/avatars/cat/eyes_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_01.png.licence
+++ b/assets/images/avatars/cat/fur_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_01.png.license
+++ b/assets/images/avatars/cat/fur_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_02.png.licence
+++ b/assets/images/avatars/cat/fur_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_02.png.license
+++ b/assets/images/avatars/cat/fur_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_03.png.licence
+++ b/assets/images/avatars/cat/fur_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_03.png.license
+++ b/assets/images/avatars/cat/fur_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_04.png.licence
+++ b/assets/images/avatars/cat/fur_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_04.png.license
+++ b/assets/images/avatars/cat/fur_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_05.png.licence
+++ b/assets/images/avatars/cat/fur_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_05.png.license
+++ b/assets/images/avatars/cat/fur_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_06.png.licence
+++ b/assets/images/avatars/cat/fur_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_06.png.license
+++ b/assets/images/avatars/cat/fur_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_07.png.licence
+++ b/assets/images/avatars/cat/fur_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_07.png.license
+++ b/assets/images/avatars/cat/fur_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_08.png.licence
+++ b/assets/images/avatars/cat/fur_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_08.png.license
+++ b/assets/images/avatars/cat/fur_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_09.png.licence
+++ b/assets/images/avatars/cat/fur_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_09.png.license
+++ b/assets/images/avatars/cat/fur_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/fur_10.png.licence
+++ b/assets/images/avatars/cat/fur_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/fur_10.png.license
+++ b/assets/images/avatars/cat/fur_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_01.png.licence
+++ b/assets/images/avatars/cat/mouth_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_01.png.license
+++ b/assets/images/avatars/cat/mouth_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_02.png.licence
+++ b/assets/images/avatars/cat/mouth_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_02.png.license
+++ b/assets/images/avatars/cat/mouth_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_03.png.licence
+++ b/assets/images/avatars/cat/mouth_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_03.png.license
+++ b/assets/images/avatars/cat/mouth_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_04.png.licence
+++ b/assets/images/avatars/cat/mouth_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_04.png.license
+++ b/assets/images/avatars/cat/mouth_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_05.png.licence
+++ b/assets/images/avatars/cat/mouth_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_05.png.license
+++ b/assets/images/avatars/cat/mouth_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_06.png.licence
+++ b/assets/images/avatars/cat/mouth_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_06.png.license
+++ b/assets/images/avatars/cat/mouth_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_07.png.licence
+++ b/assets/images/avatars/cat/mouth_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_07.png.license
+++ b/assets/images/avatars/cat/mouth_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_08.png.licence
+++ b/assets/images/avatars/cat/mouth_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_08.png.license
+++ b/assets/images/avatars/cat/mouth_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_09.png.licence
+++ b/assets/images/avatars/cat/mouth_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_09.png.license
+++ b/assets/images/avatars/cat/mouth_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/cat/mouth_10.png.licence
+++ b/assets/images/avatars/cat/mouth_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/cat/mouth_10.png.license
+++ b/assets/images/avatars/cat/mouth_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_01.png.licence
+++ b/assets/images/avatars/fenec/accessories_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_01.png.license
+++ b/assets/images/avatars/fenec/accessories_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_02.png.licence
+++ b/assets/images/avatars/fenec/accessories_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_02.png.license
+++ b/assets/images/avatars/fenec/accessories_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_03.png.licence
+++ b/assets/images/avatars/fenec/accessories_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_03.png.license
+++ b/assets/images/avatars/fenec/accessories_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_04.png.licence
+++ b/assets/images/avatars/fenec/accessories_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_04.png.license
+++ b/assets/images/avatars/fenec/accessories_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_05.png.licence
+++ b/assets/images/avatars/fenec/accessories_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_05.png.license
+++ b/assets/images/avatars/fenec/accessories_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_06.png.licence
+++ b/assets/images/avatars/fenec/accessories_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_06.png.license
+++ b/assets/images/avatars/fenec/accessories_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_07.png.licence
+++ b/assets/images/avatars/fenec/accessories_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_07.png.license
+++ b/assets/images/avatars/fenec/accessories_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_08.png.licence
+++ b/assets/images/avatars/fenec/accessories_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_08.png.license
+++ b/assets/images/avatars/fenec/accessories_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_09.png.licence
+++ b/assets/images/avatars/fenec/accessories_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_09.png.license
+++ b/assets/images/avatars/fenec/accessories_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_10.png.licence
+++ b/assets/images/avatars/fenec/accessories_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_10.png.license
+++ b/assets/images/avatars/fenec/accessories_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_11.png.licence
+++ b/assets/images/avatars/fenec/accessories_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_11.png.license
+++ b/assets/images/avatars/fenec/accessories_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_12.png.licence
+++ b/assets/images/avatars/fenec/accessories_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_12.png.license
+++ b/assets/images/avatars/fenec/accessories_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_13.png.licence
+++ b/assets/images/avatars/fenec/accessories_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_13.png.license
+++ b/assets/images/avatars/fenec/accessories_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_14.png.licence
+++ b/assets/images/avatars/fenec/accessories_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_14.png.license
+++ b/assets/images/avatars/fenec/accessories_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_15.png.licence
+++ b/assets/images/avatars/fenec/accessories_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_15.png.license
+++ b/assets/images/avatars/fenec/accessories_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_16.png.licence
+++ b/assets/images/avatars/fenec/accessories_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_16.png.license
+++ b/assets/images/avatars/fenec/accessories_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_17.png.licence
+++ b/assets/images/avatars/fenec/accessories_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_17.png.license
+++ b/assets/images/avatars/fenec/accessories_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_18.png.licence
+++ b/assets/images/avatars/fenec/accessories_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_18.png.license
+++ b/assets/images/avatars/fenec/accessories_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_19.png.licence
+++ b/assets/images/avatars/fenec/accessories_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_19.png.license
+++ b/assets/images/avatars/fenec/accessories_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/accessories_20.png.licence
+++ b/assets/images/avatars/fenec/accessories_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/accessories_20.png.license
+++ b/assets/images/avatars/fenec/accessories_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_01.png.licence
+++ b/assets/images/avatars/fenec/body_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_01.png.license
+++ b/assets/images/avatars/fenec/body_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_02.png.licence
+++ b/assets/images/avatars/fenec/body_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_02.png.license
+++ b/assets/images/avatars/fenec/body_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_03.png.licence
+++ b/assets/images/avatars/fenec/body_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_03.png.license
+++ b/assets/images/avatars/fenec/body_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_04.png.licence
+++ b/assets/images/avatars/fenec/body_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_04.png.license
+++ b/assets/images/avatars/fenec/body_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_05.png.licence
+++ b/assets/images/avatars/fenec/body_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_05.png.license
+++ b/assets/images/avatars/fenec/body_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_06.png.licence
+++ b/assets/images/avatars/fenec/body_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_06.png.license
+++ b/assets/images/avatars/fenec/body_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_07.png.licence
+++ b/assets/images/avatars/fenec/body_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_07.png.license
+++ b/assets/images/avatars/fenec/body_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_08.png.licence
+++ b/assets/images/avatars/fenec/body_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_08.png.license
+++ b/assets/images/avatars/fenec/body_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_09.png.licence
+++ b/assets/images/avatars/fenec/body_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_09.png.license
+++ b/assets/images/avatars/fenec/body_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_10.png.licence
+++ b/assets/images/avatars/fenec/body_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_10.png.license
+++ b/assets/images/avatars/fenec/body_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_11.png.licence
+++ b/assets/images/avatars/fenec/body_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_11.png.license
+++ b/assets/images/avatars/fenec/body_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_12.png.licence
+++ b/assets/images/avatars/fenec/body_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_12.png.license
+++ b/assets/images/avatars/fenec/body_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_13.png.licence
+++ b/assets/images/avatars/fenec/body_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_13.png.license
+++ b/assets/images/avatars/fenec/body_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_14.png.licence
+++ b/assets/images/avatars/fenec/body_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_14.png.license
+++ b/assets/images/avatars/fenec/body_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_15.png.licence
+++ b/assets/images/avatars/fenec/body_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_15.png.license
+++ b/assets/images/avatars/fenec/body_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_16.png.licence
+++ b/assets/images/avatars/fenec/body_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_16.png.license
+++ b/assets/images/avatars/fenec/body_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_17.png.licence
+++ b/assets/images/avatars/fenec/body_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_17.png.license
+++ b/assets/images/avatars/fenec/body_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_18.png.licence
+++ b/assets/images/avatars/fenec/body_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_18.png.license
+++ b/assets/images/avatars/fenec/body_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_19.png.licence
+++ b/assets/images/avatars/fenec/body_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_19.png.license
+++ b/assets/images/avatars/fenec/body_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_20.png.licence
+++ b/assets/images/avatars/fenec/body_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_20.png.license
+++ b/assets/images/avatars/fenec/body_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_21.png.licence
+++ b/assets/images/avatars/fenec/body_21.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_21.png.license
+++ b/assets/images/avatars/fenec/body_21.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_22.png.licence
+++ b/assets/images/avatars/fenec/body_22.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_22.png.license
+++ b/assets/images/avatars/fenec/body_22.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_23.png.licence
+++ b/assets/images/avatars/fenec/body_23.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_23.png.license
+++ b/assets/images/avatars/fenec/body_23.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_24.png.licence
+++ b/assets/images/avatars/fenec/body_24.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_24.png.license
+++ b/assets/images/avatars/fenec/body_24.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/body_25.png.licence
+++ b/assets/images/avatars/fenec/body_25.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/body_25.png.license
+++ b/assets/images/avatars/fenec/body_25.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_01.png.licence
+++ b/assets/images/avatars/fenec/eyes_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_01.png.license
+++ b/assets/images/avatars/fenec/eyes_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_02.png.licence
+++ b/assets/images/avatars/fenec/eyes_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_02.png.license
+++ b/assets/images/avatars/fenec/eyes_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_03.png.licence
+++ b/assets/images/avatars/fenec/eyes_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_03.png.license
+++ b/assets/images/avatars/fenec/eyes_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_04.png.licence
+++ b/assets/images/avatars/fenec/eyes_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_04.png.license
+++ b/assets/images/avatars/fenec/eyes_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_05.png.licence
+++ b/assets/images/avatars/fenec/eyes_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_05.png.license
+++ b/assets/images/avatars/fenec/eyes_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_06.png.licence
+++ b/assets/images/avatars/fenec/eyes_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_06.png.license
+++ b/assets/images/avatars/fenec/eyes_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_07.png.licence
+++ b/assets/images/avatars/fenec/eyes_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_07.png.license
+++ b/assets/images/avatars/fenec/eyes_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_08.png.licence
+++ b/assets/images/avatars/fenec/eyes_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_08.png.license
+++ b/assets/images/avatars/fenec/eyes_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_09.png.licence
+++ b/assets/images/avatars/fenec/eyes_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_09.png.license
+++ b/assets/images/avatars/fenec/eyes_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/eyes_10.png.licence
+++ b/assets/images/avatars/fenec/eyes_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/eyes_10.png.license
+++ b/assets/images/avatars/fenec/eyes_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_01.png.licence
+++ b/assets/images/avatars/fenec/hat_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_01.png.license
+++ b/assets/images/avatars/fenec/hat_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_02.png.licence
+++ b/assets/images/avatars/fenec/hat_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_02.png.license
+++ b/assets/images/avatars/fenec/hat_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_03.png.licence
+++ b/assets/images/avatars/fenec/hat_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_03.png.license
+++ b/assets/images/avatars/fenec/hat_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_04.png.licence
+++ b/assets/images/avatars/fenec/hat_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_04.png.license
+++ b/assets/images/avatars/fenec/hat_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_05.png.licence
+++ b/assets/images/avatars/fenec/hat_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_05.png.license
+++ b/assets/images/avatars/fenec/hat_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_06.png.licence
+++ b/assets/images/avatars/fenec/hat_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_06.png.license
+++ b/assets/images/avatars/fenec/hat_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_07.png.licence
+++ b/assets/images/avatars/fenec/hat_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_07.png.license
+++ b/assets/images/avatars/fenec/hat_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_08.png.licence
+++ b/assets/images/avatars/fenec/hat_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_08.png.license
+++ b/assets/images/avatars/fenec/hat_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_09.png.licence
+++ b/assets/images/avatars/fenec/hat_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_09.png.license
+++ b/assets/images/avatars/fenec/hat_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_10.png.licence
+++ b/assets/images/avatars/fenec/hat_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_10.png.license
+++ b/assets/images/avatars/fenec/hat_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_11.png.licence
+++ b/assets/images/avatars/fenec/hat_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_11.png.license
+++ b/assets/images/avatars/fenec/hat_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_12.png.licence
+++ b/assets/images/avatars/fenec/hat_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_12.png.license
+++ b/assets/images/avatars/fenec/hat_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_13.png.licence
+++ b/assets/images/avatars/fenec/hat_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_13.png.license
+++ b/assets/images/avatars/fenec/hat_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_14.png.licence
+++ b/assets/images/avatars/fenec/hat_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_14.png.license
+++ b/assets/images/avatars/fenec/hat_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_15.png.licence
+++ b/assets/images/avatars/fenec/hat_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_15.png.license
+++ b/assets/images/avatars/fenec/hat_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_16.png.licence
+++ b/assets/images/avatars/fenec/hat_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_16.png.license
+++ b/assets/images/avatars/fenec/hat_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_17.png.licence
+++ b/assets/images/avatars/fenec/hat_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_17.png.license
+++ b/assets/images/avatars/fenec/hat_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_18.png.licence
+++ b/assets/images/avatars/fenec/hat_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_18.png.license
+++ b/assets/images/avatars/fenec/hat_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_19.png.licence
+++ b/assets/images/avatars/fenec/hat_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_19.png.license
+++ b/assets/images/avatars/fenec/hat_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/hat_20.png.licence
+++ b/assets/images/avatars/fenec/hat_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/hat_20.png.license
+++ b/assets/images/avatars/fenec/hat_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_01.png.licence
+++ b/assets/images/avatars/fenec/misc_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_01.png.license
+++ b/assets/images/avatars/fenec/misc_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_02.png.licence
+++ b/assets/images/avatars/fenec/misc_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_02.png.license
+++ b/assets/images/avatars/fenec/misc_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_03.png.licence
+++ b/assets/images/avatars/fenec/misc_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_03.png.license
+++ b/assets/images/avatars/fenec/misc_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_04.png.licence
+++ b/assets/images/avatars/fenec/misc_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_04.png.license
+++ b/assets/images/avatars/fenec/misc_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_05.png.licence
+++ b/assets/images/avatars/fenec/misc_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_05.png.license
+++ b/assets/images/avatars/fenec/misc_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_06.png.licence
+++ b/assets/images/avatars/fenec/misc_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_06.png.license
+++ b/assets/images/avatars/fenec/misc_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_07.png.licence
+++ b/assets/images/avatars/fenec/misc_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_07.png.license
+++ b/assets/images/avatars/fenec/misc_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_08.png.licence
+++ b/assets/images/avatars/fenec/misc_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_08.png.license
+++ b/assets/images/avatars/fenec/misc_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_09.png.licence
+++ b/assets/images/avatars/fenec/misc_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_09.png.license
+++ b/assets/images/avatars/fenec/misc_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_10.png.licence
+++ b/assets/images/avatars/fenec/misc_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_10.png.license
+++ b/assets/images/avatars/fenec/misc_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_11.png.licence
+++ b/assets/images/avatars/fenec/misc_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_11.png.license
+++ b/assets/images/avatars/fenec/misc_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_12.png.licence
+++ b/assets/images/avatars/fenec/misc_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_12.png.license
+++ b/assets/images/avatars/fenec/misc_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_13.png.licence
+++ b/assets/images/avatars/fenec/misc_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_13.png.license
+++ b/assets/images/avatars/fenec/misc_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_14.png.licence
+++ b/assets/images/avatars/fenec/misc_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_14.png.license
+++ b/assets/images/avatars/fenec/misc_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_15.png.licence
+++ b/assets/images/avatars/fenec/misc_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_15.png.license
+++ b/assets/images/avatars/fenec/misc_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_16.png.licence
+++ b/assets/images/avatars/fenec/misc_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_16.png.license
+++ b/assets/images/avatars/fenec/misc_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_17.png.licence
+++ b/assets/images/avatars/fenec/misc_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_17.png.license
+++ b/assets/images/avatars/fenec/misc_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_18.png.licence
+++ b/assets/images/avatars/fenec/misc_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_18.png.license
+++ b/assets/images/avatars/fenec/misc_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_19.png.licence
+++ b/assets/images/avatars/fenec/misc_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_19.png.license
+++ b/assets/images/avatars/fenec/misc_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/misc_20.png.licence
+++ b/assets/images/avatars/fenec/misc_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/misc_20.png.license
+++ b/assets/images/avatars/fenec/misc_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_01.png.licence
+++ b/assets/images/avatars/fenec/mouth_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_01.png.license
+++ b/assets/images/avatars/fenec/mouth_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_02.png.licence
+++ b/assets/images/avatars/fenec/mouth_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_02.png.license
+++ b/assets/images/avatars/fenec/mouth_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_03.png.licence
+++ b/assets/images/avatars/fenec/mouth_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_03.png.license
+++ b/assets/images/avatars/fenec/mouth_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_04.png.licence
+++ b/assets/images/avatars/fenec/mouth_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_04.png.license
+++ b/assets/images/avatars/fenec/mouth_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_05.png.licence
+++ b/assets/images/avatars/fenec/mouth_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_05.png.license
+++ b/assets/images/avatars/fenec/mouth_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_06.png.licence
+++ b/assets/images/avatars/fenec/mouth_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_06.png.license
+++ b/assets/images/avatars/fenec/mouth_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_07.png.licence
+++ b/assets/images/avatars/fenec/mouth_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_07.png.license
+++ b/assets/images/avatars/fenec/mouth_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_08.png.licence
+++ b/assets/images/avatars/fenec/mouth_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_08.png.license
+++ b/assets/images/avatars/fenec/mouth_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_09.png.licence
+++ b/assets/images/avatars/fenec/mouth_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_09.png.license
+++ b/assets/images/avatars/fenec/mouth_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/mouth_10.png.licence
+++ b/assets/images/avatars/fenec/mouth_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/mouth_10.png.license
+++ b/assets/images/avatars/fenec/mouth_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_01.png.licence
+++ b/assets/images/avatars/fenec/nose_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_01.png.license
+++ b/assets/images/avatars/fenec/nose_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_02.png.licence
+++ b/assets/images/avatars/fenec/nose_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_02.png.license
+++ b/assets/images/avatars/fenec/nose_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_03.png.licence
+++ b/assets/images/avatars/fenec/nose_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_03.png.license
+++ b/assets/images/avatars/fenec/nose_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_04.png.licence
+++ b/assets/images/avatars/fenec/nose_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_04.png.license
+++ b/assets/images/avatars/fenec/nose_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_05.png.licence
+++ b/assets/images/avatars/fenec/nose_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_05.png.license
+++ b/assets/images/avatars/fenec/nose_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_06.png.licence
+++ b/assets/images/avatars/fenec/nose_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_06.png.license
+++ b/assets/images/avatars/fenec/nose_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_07.png.licence
+++ b/assets/images/avatars/fenec/nose_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_07.png.license
+++ b/assets/images/avatars/fenec/nose_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_08.png.licence
+++ b/assets/images/avatars/fenec/nose_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_08.png.license
+++ b/assets/images/avatars/fenec/nose_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_09.png.licence
+++ b/assets/images/avatars/fenec/nose_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_09.png.license
+++ b/assets/images/avatars/fenec/nose_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/nose_10.png.licence
+++ b/assets/images/avatars/fenec/nose_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/nose_10.png.license
+++ b/assets/images/avatars/fenec/nose_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/tail_01.png.licence
+++ b/assets/images/avatars/fenec/tail_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/tail_01.png.license
+++ b/assets/images/avatars/fenec/tail_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/tail_02.png.licence
+++ b/assets/images/avatars/fenec/tail_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/tail_02.png.license
+++ b/assets/images/avatars/fenec/tail_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/tail_03.png.licence
+++ b/assets/images/avatars/fenec/tail_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/tail_03.png.license
+++ b/assets/images/avatars/fenec/tail_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/tail_04.png.licence
+++ b/assets/images/avatars/fenec/tail_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/tail_04.png.license
+++ b/assets/images/avatars/fenec/tail_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/fenec/tail_05.png.licence
+++ b/assets/images/avatars/fenec/tail_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/fenec/tail_05.png.license
+++ b/assets/images/avatars/fenec/tail_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/1.svg.license
+++ b/assets/images/avatars/legacy/1.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/10.svg.license
+++ b/assets/images/avatars/legacy/10.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/2.svg.license
+++ b/assets/images/avatars/legacy/2.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/3.svg.license
+++ b/assets/images/avatars/legacy/3.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/4.svg.license
+++ b/assets/images/avatars/legacy/4.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/5.svg.license
+++ b/assets/images/avatars/legacy/5.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/6.svg.license
+++ b/assets/images/avatars/legacy/6.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/7.svg.license
+++ b/assets/images/avatars/legacy/7.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/8.svg.license
+++ b/assets/images/avatars/legacy/8.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/legacy/9.svg.license
+++ b/assets/images/avatars/legacy/9.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_01.png.licence
+++ b/assets/images/avatars/sepia/accessories_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_01.png.license
+++ b/assets/images/avatars/sepia/accessories_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_02.png.licence
+++ b/assets/images/avatars/sepia/accessories_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_02.png.license
+++ b/assets/images/avatars/sepia/accessories_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_03.png.licence
+++ b/assets/images/avatars/sepia/accessories_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_03.png.license
+++ b/assets/images/avatars/sepia/accessories_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_04.png.licence
+++ b/assets/images/avatars/sepia/accessories_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_04.png.license
+++ b/assets/images/avatars/sepia/accessories_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_05.png.licence
+++ b/assets/images/avatars/sepia/accessories_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_05.png.license
+++ b/assets/images/avatars/sepia/accessories_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_06.png.licence
+++ b/assets/images/avatars/sepia/accessories_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_06.png.license
+++ b/assets/images/avatars/sepia/accessories_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_07.png.licence
+++ b/assets/images/avatars/sepia/accessories_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_07.png.license
+++ b/assets/images/avatars/sepia/accessories_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_08.png.licence
+++ b/assets/images/avatars/sepia/accessories_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_08.png.license
+++ b/assets/images/avatars/sepia/accessories_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_09.png.licence
+++ b/assets/images/avatars/sepia/accessories_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_09.png.license
+++ b/assets/images/avatars/sepia/accessories_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_10.png.licence
+++ b/assets/images/avatars/sepia/accessories_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_10.png.license
+++ b/assets/images/avatars/sepia/accessories_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_11.png.licence
+++ b/assets/images/avatars/sepia/accessories_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_11.png.license
+++ b/assets/images/avatars/sepia/accessories_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_12.png.licence
+++ b/assets/images/avatars/sepia/accessories_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_12.png.license
+++ b/assets/images/avatars/sepia/accessories_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_13.png.licence
+++ b/assets/images/avatars/sepia/accessories_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_13.png.license
+++ b/assets/images/avatars/sepia/accessories_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_14.png.licence
+++ b/assets/images/avatars/sepia/accessories_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_14.png.license
+++ b/assets/images/avatars/sepia/accessories_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_15.png.licence
+++ b/assets/images/avatars/sepia/accessories_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_15.png.license
+++ b/assets/images/avatars/sepia/accessories_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_16.png.licence
+++ b/assets/images/avatars/sepia/accessories_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_16.png.license
+++ b/assets/images/avatars/sepia/accessories_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_17.png.licence
+++ b/assets/images/avatars/sepia/accessories_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_17.png.license
+++ b/assets/images/avatars/sepia/accessories_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_18.png.licence
+++ b/assets/images/avatars/sepia/accessories_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_18.png.license
+++ b/assets/images/avatars/sepia/accessories_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_19.png.licence
+++ b/assets/images/avatars/sepia/accessories_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_19.png.license
+++ b/assets/images/avatars/sepia/accessories_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/accessories_20.png.licence
+++ b/assets/images/avatars/sepia/accessories_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/accessories_20.png.license
+++ b/assets/images/avatars/sepia/accessories_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_01.png.licence
+++ b/assets/images/avatars/sepia/body_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_01.png.license
+++ b/assets/images/avatars/sepia/body_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_02.png.licence
+++ b/assets/images/avatars/sepia/body_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_02.png.license
+++ b/assets/images/avatars/sepia/body_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_03.png.licence
+++ b/assets/images/avatars/sepia/body_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_03.png.license
+++ b/assets/images/avatars/sepia/body_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_04.png.licence
+++ b/assets/images/avatars/sepia/body_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_04.png.license
+++ b/assets/images/avatars/sepia/body_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_05.png.licence
+++ b/assets/images/avatars/sepia/body_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_05.png.license
+++ b/assets/images/avatars/sepia/body_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_06.png.licence
+++ b/assets/images/avatars/sepia/body_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_06.png.license
+++ b/assets/images/avatars/sepia/body_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_07.png.licence
+++ b/assets/images/avatars/sepia/body_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_07.png.license
+++ b/assets/images/avatars/sepia/body_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_08.png.licence
+++ b/assets/images/avatars/sepia/body_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_08.png.license
+++ b/assets/images/avatars/sepia/body_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_09.png.licence
+++ b/assets/images/avatars/sepia/body_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_09.png.license
+++ b/assets/images/avatars/sepia/body_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_10.png.licence
+++ b/assets/images/avatars/sepia/body_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_10.png.license
+++ b/assets/images/avatars/sepia/body_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_11.png.licence
+++ b/assets/images/avatars/sepia/body_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_11.png.license
+++ b/assets/images/avatars/sepia/body_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_12.png.licence
+++ b/assets/images/avatars/sepia/body_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_12.png.license
+++ b/assets/images/avatars/sepia/body_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_13.png.licence
+++ b/assets/images/avatars/sepia/body_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_13.png.license
+++ b/assets/images/avatars/sepia/body_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_14.png.licence
+++ b/assets/images/avatars/sepia/body_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_14.png.license
+++ b/assets/images/avatars/sepia/body_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_15.png.licence
+++ b/assets/images/avatars/sepia/body_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_15.png.license
+++ b/assets/images/avatars/sepia/body_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_16.png.licence
+++ b/assets/images/avatars/sepia/body_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_16.png.license
+++ b/assets/images/avatars/sepia/body_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_17.png.licence
+++ b/assets/images/avatars/sepia/body_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_17.png.license
+++ b/assets/images/avatars/sepia/body_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_18.png.licence
+++ b/assets/images/avatars/sepia/body_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_18.png.license
+++ b/assets/images/avatars/sepia/body_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_19.png.licence
+++ b/assets/images/avatars/sepia/body_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_19.png.license
+++ b/assets/images/avatars/sepia/body_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_20.png.licence
+++ b/assets/images/avatars/sepia/body_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_20.png.license
+++ b/assets/images/avatars/sepia/body_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_21.png.licence
+++ b/assets/images/avatars/sepia/body_21.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_21.png.license
+++ b/assets/images/avatars/sepia/body_21.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_22.png.licence
+++ b/assets/images/avatars/sepia/body_22.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_22.png.license
+++ b/assets/images/avatars/sepia/body_22.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_23.png.licence
+++ b/assets/images/avatars/sepia/body_23.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_23.png.license
+++ b/assets/images/avatars/sepia/body_23.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_24.png.licence
+++ b/assets/images/avatars/sepia/body_24.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_24.png.license
+++ b/assets/images/avatars/sepia/body_24.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/body_25.png.licence
+++ b/assets/images/avatars/sepia/body_25.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/body_25.png.license
+++ b/assets/images/avatars/sepia/body_25.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_01.png.licence
+++ b/assets/images/avatars/sepia/eyes_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_01.png.license
+++ b/assets/images/avatars/sepia/eyes_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_02.png.licence
+++ b/assets/images/avatars/sepia/eyes_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_02.png.license
+++ b/assets/images/avatars/sepia/eyes_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_03.png.licence
+++ b/assets/images/avatars/sepia/eyes_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_03.png.license
+++ b/assets/images/avatars/sepia/eyes_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_04.png.licence
+++ b/assets/images/avatars/sepia/eyes_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_04.png.license
+++ b/assets/images/avatars/sepia/eyes_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_05.png.licence
+++ b/assets/images/avatars/sepia/eyes_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_05.png.license
+++ b/assets/images/avatars/sepia/eyes_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_06.png.licence
+++ b/assets/images/avatars/sepia/eyes_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_06.png.license
+++ b/assets/images/avatars/sepia/eyes_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_07.png.licence
+++ b/assets/images/avatars/sepia/eyes_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_07.png.license
+++ b/assets/images/avatars/sepia/eyes_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_08.png.licence
+++ b/assets/images/avatars/sepia/eyes_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_08.png.license
+++ b/assets/images/avatars/sepia/eyes_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_09.png.licence
+++ b/assets/images/avatars/sepia/eyes_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_09.png.license
+++ b/assets/images/avatars/sepia/eyes_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/eyes_10.png.licence
+++ b/assets/images/avatars/sepia/eyes_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/eyes_10.png.license
+++ b/assets/images/avatars/sepia/eyes_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_01.png.licence
+++ b/assets/images/avatars/sepia/hat_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_01.png.license
+++ b/assets/images/avatars/sepia/hat_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_02.png.licence
+++ b/assets/images/avatars/sepia/hat_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_02.png.license
+++ b/assets/images/avatars/sepia/hat_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_03.png.licence
+++ b/assets/images/avatars/sepia/hat_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_03.png.license
+++ b/assets/images/avatars/sepia/hat_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_04.png.licence
+++ b/assets/images/avatars/sepia/hat_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_04.png.license
+++ b/assets/images/avatars/sepia/hat_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_05.png.licence
+++ b/assets/images/avatars/sepia/hat_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_05.png.license
+++ b/assets/images/avatars/sepia/hat_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_06.png.licence
+++ b/assets/images/avatars/sepia/hat_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_06.png.license
+++ b/assets/images/avatars/sepia/hat_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_07.png.licence
+++ b/assets/images/avatars/sepia/hat_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_07.png.license
+++ b/assets/images/avatars/sepia/hat_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_08.png.licence
+++ b/assets/images/avatars/sepia/hat_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_08.png.license
+++ b/assets/images/avatars/sepia/hat_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_09.png.licence
+++ b/assets/images/avatars/sepia/hat_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_09.png.license
+++ b/assets/images/avatars/sepia/hat_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_10.png.licence
+++ b/assets/images/avatars/sepia/hat_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_10.png.license
+++ b/assets/images/avatars/sepia/hat_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_11.png.licence
+++ b/assets/images/avatars/sepia/hat_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_11.png.license
+++ b/assets/images/avatars/sepia/hat_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_12.png.licence
+++ b/assets/images/avatars/sepia/hat_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_12.png.license
+++ b/assets/images/avatars/sepia/hat_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_13.png.licence
+++ b/assets/images/avatars/sepia/hat_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_13.png.license
+++ b/assets/images/avatars/sepia/hat_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_14.png.licence
+++ b/assets/images/avatars/sepia/hat_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_14.png.license
+++ b/assets/images/avatars/sepia/hat_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_15.png.licence
+++ b/assets/images/avatars/sepia/hat_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_15.png.license
+++ b/assets/images/avatars/sepia/hat_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_16.png.licence
+++ b/assets/images/avatars/sepia/hat_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_16.png.license
+++ b/assets/images/avatars/sepia/hat_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_17.png.licence
+++ b/assets/images/avatars/sepia/hat_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_17.png.license
+++ b/assets/images/avatars/sepia/hat_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_18.png.licence
+++ b/assets/images/avatars/sepia/hat_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_18.png.license
+++ b/assets/images/avatars/sepia/hat_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_19.png.licence
+++ b/assets/images/avatars/sepia/hat_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_19.png.license
+++ b/assets/images/avatars/sepia/hat_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/hat_20.png.licence
+++ b/assets/images/avatars/sepia/hat_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/hat_20.png.license
+++ b/assets/images/avatars/sepia/hat_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_01.png.licence
+++ b/assets/images/avatars/sepia/misc_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_01.png.license
+++ b/assets/images/avatars/sepia/misc_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_02.png.licence
+++ b/assets/images/avatars/sepia/misc_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_02.png.license
+++ b/assets/images/avatars/sepia/misc_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_03.png.licence
+++ b/assets/images/avatars/sepia/misc_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_03.png.license
+++ b/assets/images/avatars/sepia/misc_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_04.png.licence
+++ b/assets/images/avatars/sepia/misc_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_04.png.license
+++ b/assets/images/avatars/sepia/misc_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_05.png.licence
+++ b/assets/images/avatars/sepia/misc_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_05.png.license
+++ b/assets/images/avatars/sepia/misc_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_06.png.licence
+++ b/assets/images/avatars/sepia/misc_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_06.png.license
+++ b/assets/images/avatars/sepia/misc_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_07.png.licence
+++ b/assets/images/avatars/sepia/misc_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_07.png.license
+++ b/assets/images/avatars/sepia/misc_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_08.png.licence
+++ b/assets/images/avatars/sepia/misc_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_08.png.license
+++ b/assets/images/avatars/sepia/misc_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_09.png.licence
+++ b/assets/images/avatars/sepia/misc_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_09.png.license
+++ b/assets/images/avatars/sepia/misc_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_10.png.licence
+++ b/assets/images/avatars/sepia/misc_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_10.png.license
+++ b/assets/images/avatars/sepia/misc_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_11.png.licence
+++ b/assets/images/avatars/sepia/misc_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_11.png.license
+++ b/assets/images/avatars/sepia/misc_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_12.png.licence
+++ b/assets/images/avatars/sepia/misc_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_12.png.license
+++ b/assets/images/avatars/sepia/misc_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_13.png.licence
+++ b/assets/images/avatars/sepia/misc_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_13.png.license
+++ b/assets/images/avatars/sepia/misc_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_14.png.licence
+++ b/assets/images/avatars/sepia/misc_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_14.png.license
+++ b/assets/images/avatars/sepia/misc_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_15.png.licence
+++ b/assets/images/avatars/sepia/misc_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_15.png.license
+++ b/assets/images/avatars/sepia/misc_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_16.png.licence
+++ b/assets/images/avatars/sepia/misc_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_16.png.license
+++ b/assets/images/avatars/sepia/misc_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_17.png.licence
+++ b/assets/images/avatars/sepia/misc_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_17.png.license
+++ b/assets/images/avatars/sepia/misc_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_18.png.licence
+++ b/assets/images/avatars/sepia/misc_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_18.png.license
+++ b/assets/images/avatars/sepia/misc_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_19.png.licence
+++ b/assets/images/avatars/sepia/misc_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_19.png.license
+++ b/assets/images/avatars/sepia/misc_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/misc_20.png.licence
+++ b/assets/images/avatars/sepia/misc_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/misc_20.png.license
+++ b/assets/images/avatars/sepia/misc_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_01.png.licence
+++ b/assets/images/avatars/sepia/mouth_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_01.png.license
+++ b/assets/images/avatars/sepia/mouth_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_02.png.licence
+++ b/assets/images/avatars/sepia/mouth_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_02.png.license
+++ b/assets/images/avatars/sepia/mouth_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_03.png.licence
+++ b/assets/images/avatars/sepia/mouth_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_03.png.license
+++ b/assets/images/avatars/sepia/mouth_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_04.png.licence
+++ b/assets/images/avatars/sepia/mouth_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_04.png.license
+++ b/assets/images/avatars/sepia/mouth_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_05.png.licence
+++ b/assets/images/avatars/sepia/mouth_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_05.png.license
+++ b/assets/images/avatars/sepia/mouth_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_06.png.licence
+++ b/assets/images/avatars/sepia/mouth_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_06.png.license
+++ b/assets/images/avatars/sepia/mouth_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_07.png.licence
+++ b/assets/images/avatars/sepia/mouth_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_07.png.license
+++ b/assets/images/avatars/sepia/mouth_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_08.png.licence
+++ b/assets/images/avatars/sepia/mouth_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_08.png.license
+++ b/assets/images/avatars/sepia/mouth_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_09.png.licence
+++ b/assets/images/avatars/sepia/mouth_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_09.png.license
+++ b/assets/images/avatars/sepia/mouth_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/mouth_10.png.licence
+++ b/assets/images/avatars/sepia/mouth_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/mouth_10.png.license
+++ b/assets/images/avatars/sepia/mouth_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_01.png.licence
+++ b/assets/images/avatars/sepia/pattern_01.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_01.png.license
+++ b/assets/images/avatars/sepia/pattern_01.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_02.png.licence
+++ b/assets/images/avatars/sepia/pattern_02.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_02.png.license
+++ b/assets/images/avatars/sepia/pattern_02.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_03.png.licence
+++ b/assets/images/avatars/sepia/pattern_03.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_03.png.license
+++ b/assets/images/avatars/sepia/pattern_03.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_04.png.licence
+++ b/assets/images/avatars/sepia/pattern_04.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_04.png.license
+++ b/assets/images/avatars/sepia/pattern_04.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_05.png.licence
+++ b/assets/images/avatars/sepia/pattern_05.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_05.png.license
+++ b/assets/images/avatars/sepia/pattern_05.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_06.png.licence
+++ b/assets/images/avatars/sepia/pattern_06.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_06.png.license
+++ b/assets/images/avatars/sepia/pattern_06.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_07.png.licence
+++ b/assets/images/avatars/sepia/pattern_07.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_07.png.license
+++ b/assets/images/avatars/sepia/pattern_07.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_08.png.licence
+++ b/assets/images/avatars/sepia/pattern_08.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_08.png.license
+++ b/assets/images/avatars/sepia/pattern_08.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_09.png.licence
+++ b/assets/images/avatars/sepia/pattern_09.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_09.png.license
+++ b/assets/images/avatars/sepia/pattern_09.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_10.png.licence
+++ b/assets/images/avatars/sepia/pattern_10.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_10.png.license
+++ b/assets/images/avatars/sepia/pattern_10.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_11.png.licence
+++ b/assets/images/avatars/sepia/pattern_11.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_11.png.license
+++ b/assets/images/avatars/sepia/pattern_11.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_12.png.licence
+++ b/assets/images/avatars/sepia/pattern_12.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_12.png.license
+++ b/assets/images/avatars/sepia/pattern_12.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_13.png.licence
+++ b/assets/images/avatars/sepia/pattern_13.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_13.png.license
+++ b/assets/images/avatars/sepia/pattern_13.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_14.png.licence
+++ b/assets/images/avatars/sepia/pattern_14.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_14.png.license
+++ b/assets/images/avatars/sepia/pattern_14.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_15.png.licence
+++ b/assets/images/avatars/sepia/pattern_15.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_15.png.license
+++ b/assets/images/avatars/sepia/pattern_15.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_16.png.licence
+++ b/assets/images/avatars/sepia/pattern_16.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_16.png.license
+++ b/assets/images/avatars/sepia/pattern_16.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_17.png.licence
+++ b/assets/images/avatars/sepia/pattern_17.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_17.png.license
+++ b/assets/images/avatars/sepia/pattern_17.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_18.png.licence
+++ b/assets/images/avatars/sepia/pattern_18.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_18.png.license
+++ b/assets/images/avatars/sepia/pattern_18.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_19.png.licence
+++ b/assets/images/avatars/sepia/pattern_19.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_19.png.license
+++ b/assets/images/avatars/sepia/pattern_19.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/avatars/sepia/pattern_20.png.licence
+++ b/assets/images/avatars/sepia/pattern_20.png.licence
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
-
-SPDX-License-Identifier: CC-by <https://creativecommons.org/licenses/by/4.0/>

--- a/assets/images/avatars/sepia/pattern_20.png.license
+++ b/assets/images/avatars/sepia/pattern_20.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 David Revoy <https://www.davidrevoy.com>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/assets/images/bye.svg.license
+++ b/assets/images/bye.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/help.svg.license
+++ b/assets/images/help.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/logo.svg.license
+++ b/assets/images/logo.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/moderator.svg.license
+++ b/assets/images/moderator.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/new-window.svg.license
+++ b/assets/images/new-window.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/talking-new-window.svg.license
+++ b/assets/images/talking-new-window.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/talking.svg.license
+++ b/assets/images/talking.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/images/url.svg.license
+++ b/assets/images/url.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/assets/styles/configuration.scss
+++ b/assets/styles/configuration.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 /* stylelint-disable custom-property-pattern */
 
 /*

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 #peertube-plugin-livechat-container {
   display: flex;
   flex-direction: column;

--- a/build-avatars.js
+++ b/build-avatars.js
@@ -1,4 +1,9 @@
 #!/bin/env node
+
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /* eslint-env es6 */
 
 const sharp = require('sharp')

--- a/build-client.js
+++ b/build-client.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const path = require('path')
 const esbuild = require('esbuild')
 const fs = require('fs')

--- a/build-languages.js
+++ b/build-languages.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * This script is used to build the translations files.
  *

--- a/build-prosody.sh
+++ b/build-prosody.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 set -euo pipefail
 # set -x
 

--- a/client/.eslintrc.json.license
+++ b/client/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/client/@types/global.d.ts
+++ b/client/@types/global.d.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 declare const PLUGIN_CHAT_PACKAGE_NAME: string
 declare const PLUGIN_CHAT_SHORT_NAME: string
 

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { Video } from '@peertube/peertube-types'
 import type { ProsodyListRoomsResult } from 'shared/lib/types'

--- a/client/common-client-plugin.ts
+++ b/client/common-client-plugin.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { RegisterClientFormFieldOptions } from '@peertube/peertube-types'
 import { registerConfiguration } from './common/configuration/register'

--- a/client/common/configuration/register.ts
+++ b/client/common/configuration/register.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import { renderConfigurationHome } from './templates/home'
 import { renderConfigurationChannel } from './templates/channel'

--- a/client/common/configuration/templates/channel.ts
+++ b/client/common/configuration/templates/channel.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import { localizedHelpUrl } from '../../../utils/help'
 import { helpButtonSVG } from '../../../videowatch/buttons'

--- a/client/common/configuration/templates/home.ts
+++ b/client/common/configuration/templates/home.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import { localizedHelpUrl } from '../../../utils/help'
 import { helpButtonSVG } from '../../../videowatch/buttons'

--- a/client/common/configuration/templates/logic/channel.ts
+++ b/client/common/configuration/templates/logic/channel.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { ChannelConfiguration, ChannelConfigurationOptions } from 'shared/lib/types'
 import { getBaseRoute } from '../../../../utils/uri'

--- a/client/common/room/register.ts
+++ b/client/common/room/register.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import { displayConverseJS } from '../../utils/conversejs'
 

--- a/client/settings.ts
+++ b/client/settings.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 interface MessageWithLevel {
   level: 'info' | 'warning' | 'error'
   message: string

--- a/client/tsconfig.json.license
+++ b/client/tsconfig.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/client/utils/colors.ts
+++ b/client/utils/colors.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { logger } from './logger'
 import { AutoColors, areAutoColorsValid } from 'shared/lib/autocolors'
 

--- a/client/utils/conversejs.ts
+++ b/client/utils/conversejs.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { InitConverseJSParams, ChatPeertubeIncludeMode } from 'shared/lib/types'
 import { computeAutoColors } from './colors'

--- a/client/utils/help.ts
+++ b/client/utils/help.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import { helpUrl } from 'shared/lib/help'
 

--- a/client/utils/logger.ts
+++ b/client/utils/logger.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const logger = {
   log: (s: string) => console.log('[peertube-plugin-livechat] ' + s),
   info: (s: string) => console.info('[peertube-plugin-livechat] ' + s),

--- a/client/utils/uri.ts
+++ b/client/utils/uri.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 
 function getBaseRoute ({ peertubeHelpers }: RegisterClientOptions, permanent: boolean = false): string {

--- a/client/videowatch-client-plugin.ts
+++ b/client/videowatch-client-plugin.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Video } from '@peertube/peertube-types'
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { InitConverseJSParams } from 'shared/lib/types'

--- a/client/videowatch/button.ts
+++ b/client/videowatch/button.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { SVGButton } from './buttons'
 import { logger } from '../utils/logger'
 

--- a/client/videowatch/buttons.ts
+++ b/client/videowatch/buttons.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /* eslint-disable max-len */
 type SVGButton = () => string
 

--- a/client/videowatch/share.ts
+++ b/client/videowatch/share.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { Video } from '@peertube/peertube-types'
 import { helpButtonSVG } from './buttons'

--- a/client/videowatch/uri.ts
+++ b/client/videowatch/uri.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterClientOptions } from '@peertube/peertube-types/client'
 import type { Video } from '@peertube/peertube-types'
 import { AutoColors, isAutoColorsAvailable } from 'shared/lib/autocolors'

--- a/conversejs/.eslintrc.json.license
+++ b/conversejs/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/conversejs/build-conversejs-patch-i18n.js
+++ b/conversejs/build-conversejs-patch-i18n.js
@@ -1,4 +1,9 @@
 #!/bin/env node
+
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const fs = require('node:fs')
 const path = require('node:path')
 const YAML = require('yaml')

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 NO_CONVERSEJS_LOC=""
 if [ "$1" = "no-loc" ]; then
   echo "We won't generate ConverseJS localization files!"

--- a/conversejs/builtin.ts
+++ b/conversejs/builtin.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { InitConverseJSParams, ChatIncludeMode, ExternalAuthResult } from 'shared/lib/types'
 import { inIframe } from './lib/utils'
 import { initDom } from './lib/dom'

--- a/conversejs/custom/entry.js
+++ b/conversejs/custom/entry.js
@@ -1,2 +1,6 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import '../src/entry.js'
 export * from '../src/entry.js'

--- a/conversejs/custom/index.js
+++ b/conversejs/custom/index.js
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2013-2018 JC Brand <https://github.com/conversejs/converse.js/>
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * @description This files will override the original ConverseJS index.js file.
  */

--- a/conversejs/custom/livechat-external-login-content.js
+++ b/conversejs/custom/livechat-external-login-content.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { api } from '@converse/headless/core.js'
 import { CustomElement } from 'shared/components/element.js'
 import { tplExternalLoginModal } from 'templates/livechat-external-login-modal.js'

--- a/conversejs/custom/plugins/size/index.js
+++ b/conversejs/custom/plugins/size/index.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { _converse, converse, api } from '../../../src/headless/core.js'
 
 /**

--- a/conversejs/custom/plugins/tasks/components/muc-task-app-view.js
+++ b/conversejs/custom/plugins/tasks/components/muc-task-app-view.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { api } from '@converse/headless/core'
 import { CustomElement } from 'shared/components/element.js'
 import { tplMUCTaskApp } from '../templates/muc-task-app.js'

--- a/conversejs/custom/plugins/tasks/components/muc-task-list-view.js
+++ b/conversejs/custom/plugins/tasks/components/muc-task-list-view.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { CustomElement } from 'shared/components/element.js'
 import { api } from '@converse/headless/core'
 import tplMucTaskList from '../templates/muc-task-list'

--- a/conversejs/custom/plugins/tasks/components/muc-task-lists-view.js
+++ b/conversejs/custom/plugins/tasks/components/muc-task-lists-view.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { CustomElement } from 'shared/components/element.js'
 import { api } from '@converse/headless/core'
 import tplMucTaskLists from '../templates/muc-task-lists'

--- a/conversejs/custom/plugins/tasks/components/muc-task-view.js
+++ b/conversejs/custom/plugins/tasks/components/muc-task-view.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { CustomElement } from 'shared/components/element.js'
 import { api } from '@converse/headless/core'
 import { tplMucTask } from '../templates/muc-task'

--- a/conversejs/custom/plugins/tasks/constants.js
+++ b/conversejs/custom/plugins/tasks/constants.js
@@ -1,2 +1,6 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const XMLNS_TASKLIST = 'urn:peertube-plugin-livechat:tasklist'
 export const XMLNS_TASK = 'urn:peertube-plugin-livechat:task'

--- a/conversejs/custom/plugins/tasks/index.js
+++ b/conversejs/custom/plugins/tasks/index.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { _converse, converse } from '../../../src/headless/core.js'
 import { ChatRoomTaskLists } from './task-lists.js'
 import { ChatRoomTaskList } from './task-list.js'

--- a/conversejs/custom/plugins/tasks/modals/pick-task-list.js
+++ b/conversejs/custom/plugins/tasks/modals/pick-task-list.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import BaseModal from 'plugins/modal/modal.js'
 import tplPickTaskList from './templates/pick-task-list.js'
 import { api } from '@converse/headless/core'

--- a/conversejs/custom/plugins/tasks/modals/templates/pick-task-list.js
+++ b/conversejs/custom/plugins/tasks/modals/templates/pick-task-list.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { html } from 'lit'
 import { repeat } from 'lit/directives/repeat.js'
 import { __ } from 'i18n'

--- a/conversejs/custom/plugins/tasks/styles/muc-task-app.scss
+++ b/conversejs/custom/plugins/tasks/styles/muc-task-app.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 .conversejs {
   livechat-converse-muc-task-app {
     border: var(--occupants-border-left);

--- a/conversejs/custom/plugins/tasks/styles/muc-task-drag.scss
+++ b/conversejs/custom/plugins/tasks/styles/muc-task-drag.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 .conversejs {
   livechat-converse-muc-task {
     &.livechat-drag-bottom-half .task-line {

--- a/conversejs/custom/plugins/tasks/styles/muc-task-lists.scss
+++ b/conversejs/custom/plugins/tasks/styles/muc-task-lists.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 .conversejs {
   livechat-converse-muc-task-lists {
     padding: 1em;

--- a/conversejs/custom/plugins/tasks/styles/muc-tasks.scss
+++ b/conversejs/custom/plugins/tasks/styles/muc-tasks.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 .conversejs {
   livechat-converse-muc-task {
     padding: 0;

--- a/conversejs/custom/plugins/tasks/task-list.js
+++ b/conversejs/custom/plugins/tasks/task-list.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Model } from '@converse/skeletor/src/model.js'
 
 /**

--- a/conversejs/custom/plugins/tasks/task-lists.js
+++ b/conversejs/custom/plugins/tasks/task-lists.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Collection } from '@converse/skeletor/src/collection.js'
 import { ChatRoomTaskList } from './task-list'
 import { initStorage } from '@converse/headless/utils/storage.js'

--- a/conversejs/custom/plugins/tasks/task.js
+++ b/conversejs/custom/plugins/tasks/task.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Model } from '@converse/skeletor/src/model.js'
 
 /**

--- a/conversejs/custom/plugins/tasks/tasks.js
+++ b/conversejs/custom/plugins/tasks/tasks.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Collection } from '@converse/skeletor/src/collection.js'
 import { ChatRoomTask } from './task'
 import { initStorage } from '@converse/headless/utils/storage.js'

--- a/conversejs/custom/plugins/tasks/templates/muc-task-app.js
+++ b/conversejs/custom/plugins/tasks/templates/muc-task-app.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { converseLocalizedHelpUrl } from '../../../shared/lib/help'
 import { html } from 'lit'
 import { __ } from 'i18n'

--- a/conversejs/custom/plugins/tasks/templates/muc-task-list.js
+++ b/conversejs/custom/plugins/tasks/templates/muc-task-list.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { html } from 'lit'
 import { repeat } from 'lit/directives/repeat.js'
 import { __ } from 'i18n'

--- a/conversejs/custom/plugins/tasks/templates/muc-task-lists.js
+++ b/conversejs/custom/plugins/tasks/templates/muc-task-lists.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { html } from 'lit'
 import { repeat } from 'lit/directives/repeat.js'
 import { __ } from 'i18n'

--- a/conversejs/custom/plugins/tasks/templates/muc-task.js
+++ b/conversejs/custom/plugins/tasks/templates/muc-task.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { html } from 'lit'
 import { __ } from 'i18n'
 

--- a/conversejs/custom/plugins/tasks/utils.js
+++ b/conversejs/custom/plugins/tasks/utils.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { XMLNS_TASKLIST, XMLNS_TASK } from './constants.js'
 import { PubSubManager } from '../../shared/lib/pubsub-manager.js'
 import { converse, _converse, api } from '../../../src/headless/core.js'

--- a/conversejs/custom/shared/components/font-awesome.js
+++ b/conversejs/custom/shared/components/font-awesome.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /* eslint-disable max-len */
 import { html } from 'lit'
 import tplIcons from '../../../src/shared/templates/icons.js'

--- a/conversejs/custom/shared/lib/help.js
+++ b/conversejs/custom/shared/lib/help.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { __ } from 'i18n'
 
 /**

--- a/conversejs/custom/shared/lib/pubsub-manager.js
+++ b/conversejs/custom/shared/lib/pubsub-manager.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { converse, _converse, api } from '../../../src/headless/core.js'
 const { $build, Strophe, $iq, sizzle } = converse.env
 

--- a/conversejs/custom/shared/modals/livechat-external-login.js
+++ b/conversejs/custom/shared/modals/livechat-external-login.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { __ } from 'i18n'
 import BaseModal from 'plugins/modal/modal.js'
 import { api } from '@converse/headless/core'

--- a/conversejs/custom/shared/styles/_peertubetheme.scss
+++ b/conversejs/custom/shared/styles/_peertubetheme.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 #conversejs.theme-peertube {
   .dropdown-menu {
     // Fixing all dropdown colors

--- a/conversejs/custom/shared/styles/_variables.scss
+++ b/conversejs/custom/shared/styles/_variables.scss
@@ -1,3 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2013-2018 JC Brand <https://github.com/conversejs/converse.js/>
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 :root {
   // we add --livechat-transparent variable, so that users can customize transparent background in OBS (for example).
   --livechat-transparent: rgba(0 0 0 / 0%);

--- a/conversejs/custom/shared/styles/livechat.scss
+++ b/conversejs/custom/shared/styles/livechat.scss
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 @import "./variables";
 @import "shared/styles/index";
 @import "./peertubetheme";

--- a/conversejs/custom/templates/background_logo.js
+++ b/conversejs/custom/templates/background_logo.js
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2013-2018 JC Brand <https://github.com/conversejs/converse.js/>
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { html } from 'lit'
 import { api } from '@converse/headless/core.js'
 

--- a/conversejs/custom/templates/livechat-external-login-modal.js
+++ b/conversejs/custom/templates/livechat-external-login-modal.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { _converse, api } from '@converse/headless/core'
 import { __ } from 'i18n'
 import { html } from 'lit'

--- a/conversejs/custom/templates/muc-bottom-panel.js
+++ b/conversejs/custom/templates/muc-bottom-panel.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { __ } from 'i18n'
 import { _converse, api } from '@converse/headless/core'
 import { html } from 'lit'

--- a/conversejs/custom/templates/muc-chatarea.js
+++ b/conversejs/custom/templates/muc-chatarea.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { api } from '@converse/headless/core'
 import tplMUCChatarea from '../../src/plugins/muc-views/templates/muc-chatarea.js'
 import { html } from 'lit'

--- a/conversejs/custom/templates/muc-head.js
+++ b/conversejs/custom/templates/muc-head.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { html } from 'lit'
 import { api } from '@converse/headless/core'

--- a/conversejs/custom/webpack.livechat.js
+++ b/conversejs/custom/webpack.livechat.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const prod = require('./webpack/webpack.build.js')
 const { merge } = require('webpack-merge')
 const webpack = require('webpack')

--- a/conversejs/index.html.license
+++ b/conversejs/index.html.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/conversejs/lib/auth.ts
+++ b/conversejs/lib/auth.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 interface AuthentInfos {
   type: 'peertube' | 'oidc'
   jid: string

--- a/conversejs/lib/converse-params.ts
+++ b/conversejs/lib/converse-params.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { InitConverseJSParams } from 'shared/lib/types'
 import type { AuthentInfos } from './auth'
 

--- a/conversejs/lib/dom.ts
+++ b/conversejs/lib/dom.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { InitConverseJSParams } from 'shared/lib/types'
 
 function initDom ({ forceReadonly, transparent }: InitConverseJSParams, isInIframe: boolean): void {

--- a/conversejs/lib/nick.ts
+++ b/conversejs/lib/nick.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * Generates a random nickname.
  * @param base Nickname prefix

--- a/conversejs/lib/plugins/livechat-mini-muc-head.ts
+++ b/conversejs/lib/plugins/livechat-mini-muc-head.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * Plugin to add buttons (help, close, open in another window) in the muc menu,
  * when we are embedded in Peertube.

--- a/conversejs/lib/plugins/livechat-specific.ts
+++ b/conversejs/lib/plugins/livechat-specific.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const livechatSpecificsPlugin = {
   dependencies: ['converse-muc', 'converse-muc-views'],
   initialize: function (this: any) {

--- a/conversejs/lib/plugins/livechat-viewer-mode.ts
+++ b/conversejs/lib/plugins/livechat-viewer-mode.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { randomNick, getPreviousAnonymousNick, setPreviousAnonymousNick } from '../nick'
 
 export const livechatViewerModePlugin = {

--- a/conversejs/lib/plugins/slow-mode.ts
+++ b/conversejs/lib/plugins/slow-mode.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * Slow Mode plugin definition.
  * This code should be published to ConverseJS upstream once the XEP for the slow mode feature is proposed.

--- a/conversejs/lib/plugins/window-title.ts
+++ b/conversejs/lib/plugins/window-title.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const windowTitlePlugin = {
   dependencies: ['converse-muc-views'],
   overrides: {

--- a/conversejs/lib/utils.ts
+++ b/conversejs/lib/utils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function inIframe (): boolean {
   try {
     return window.self !== window.top

--- a/conversejs/loc.keys.js
+++ b/conversejs/loc.keys.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Localization keys to inject in ConverseJS:
  *  these keys are used to:
  *  - inject needed localization strings in ConverseJS language files

--- a/conversejs/tsconfig.json.license
+++ b/conversejs/tsconfig.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/doc-translate.sh
+++ b/doc-translate.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 set -euo pipefail
 
 po4afile="support/documentation/po/po4a.conf"

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This folder is deprecated**
 
 We only keep files in this folder to avoid dead links

--- a/documentation/admin.md
+++ b/documentation/admin.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/admin/).

--- a/documentation/installation.de.md
+++ b/documentation/installation.de.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/de/documentation/installation/).

--- a/documentation/installation.fr.md
+++ b/documentation/installation.fr.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/fr/documentation/installation/).

--- a/documentation/installation.ja.md
+++ b/documentation/installation.ja.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/ja/documentation/installation/).

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/installation/).

--- a/documentation/user.md
+++ b/documentation/user.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 **This page as moved, please refer to one of these:**
 
 * [Plugin Livechat Documentation on Github](https://johnxlivingston.github.io/peertube-plugin-livechat/documentation/user/).

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/package.json
+++ b/package.json
@@ -109,9 +109,10 @@
     "build:styles": "sass assets/styles:dist/assets/styles",
     "build:languages": "node ./build-languages.js",
     "build": "npm-run-all -s clean:light build:languages check:client:tsc -s build:client build:server build:images build:styles build:avatars build:serverconverse build:prosodymodules build:converse build:prosody",
-    "lint": "npm-run-all -s lint:script lint:styles",
+    "lint": "npm-run-all -s lint:script lint:styles lint:reuse",
     "lint:script": "npx eslint --ext .js --ext .ts .",
     "lint:styles": "stylelint 'conversejs/**/*.scss' 'assets/styles/**/*.scss'",
+    "lint:reuse": "reuse lint",
     "show:npmfiles": "npx npm-packlist",
     "doc:translate": "bash doc-translate.sh"
   },

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/prosody-modules/mod_auth_http/README.markdown
+++ b/prosody-modules/mod_auth_http/README.markdown
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2008-2013 Matthew Wild
+SPDX-FileCopyrightText: 2008-2013 Waqas Hussain
+SPDX-FileCopyrightText: 2014 Kim Alvefur
+SPDX-License-Identifier: MIT
+-->
 ---
 labels:
 - Stage-Alpha

--- a/prosody-modules/mod_auth_http/mod_auth_http.lua
+++ b/prosody-modules/mod_auth_http/mod_auth_http.lua
@@ -5,7 +5,7 @@
 --
 -- This project is MIT/X11 licensed. Please see the
 -- COPYING file in the source package for more information.
---
+-- SPDX-License-Identifier: MIT
 
 local new_sasl = require "util.sasl".new;
 local base64 = require "util.encodings".base64.encode;

--- a/prosody-modules/mod_auth_peertubelivechat_bot/README.md
+++ b/prosody-modules/mod_auth_peertubelivechat_bot/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_bot_peertubelivechat
 
 This module is a custom module for the Peertube livechat plugin, that handle bots authentication.

--- a/prosody-modules/mod_auth_peertubelivechat_bot/mod_auth_peertubelivechat_bot.lua
+++ b/prosody-modules/mod_auth_peertubelivechat_bot/mod_auth_peertubelivechat_bot.lua
@@ -1,11 +1,10 @@
--- Prosody IM
--- Copyright (C) 2008-2013 Matthew Wild
--- Copyright (C) 2008-2013 Waqas Hussain
--- Copyright (C) 2014 Kim Alvefur
+-- SPDX-FileCopyrightText: 2008-2013 Matthew Wild
+-- SPDX-FileCopyrightText: 2008-2013 Waqas Hussain
+-- SPDX-FileCopyrightText: 2014 Kim Alvefur
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
 --
--- This project is MIT/X11 licensed. Please see the
--- COPYING file in the source package for more information.
---
+-- SPDX-License-Identifier: MIT
+-- SPDX-License-Identifier: AGPL-3.0-only
 
 local new_sasl = require "util.sasl".new;
 local path = require "util.paths";

--- a/prosody-modules/mod_http_peertubelivechat_manage_rooms/README.md
+++ b/prosody-modules/mod_http_peertubelivechat_manage_rooms/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_http_peertubelivechat_manage_rooms
 
 This module is a custom module that allows Peertube server to list chat rooms, and update some meta data.

--- a/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
+++ b/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 local json = require "util.json";
 local jid_split = require"util.jid".split;
 local jid_prep = require"util.jid".prep;

--- a/prosody-modules/mod_http_peertubelivechat_manage_users/README.md
+++ b/prosody-modules/mod_http_peertubelivechat_manage_users/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_http_peertubelivechat_manage_users
 
 This module is a custom module that allows Peertube server to manage users for some virtualhosts.

--- a/prosody-modules/mod_http_peertubelivechat_manage_users/mod_http_peertubelivechat_manage_users.lua
+++ b/prosody-modules/mod_http_peertubelivechat_manage_users/mod_http_peertubelivechat_manage_users.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 local json = require "util.json";
 local jid_split = require"util.jid".split;
 local usermanager = require "core.usermanager";

--- a/prosody-modules/mod_http_peertubelivechat_test/README.md
+++ b/prosody-modules/mod_http_peertubelivechat_test/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_http_peertubelivechat_test
 
 This module is a custom module that allows Peertube to test communication with Prosody.

--- a/prosody-modules/mod_http_peertubelivechat_test/mod_http_peertubelivechat_test.lua
+++ b/prosody-modules/mod_http_peertubelivechat_test/mod_http_peertubelivechat_test.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 local json = require "util.json";
 local async = require "util.async";
 local http = require "net.http";

--- a/prosody-modules/mod_muc_ban_ip/README.markdown
+++ b/prosody-modules/mod_muc_ban_ip/README.markdown
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: Prosody Modules <https://hg.prosody.im/prosody-modules>
+SPDX-License-Identifier: MIT
+-->
 ---
 labels:
 - 'Stage-Alpha'

--- a/prosody-modules/mod_muc_ban_ip/mod_muc_ban_ip.lua
+++ b/prosody-modules/mod_muc_ban_ip/mod_muc_ban_ip.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Prosody Modules <https://hg.prosody.im/prosody-modules>
+-- SPDX-License-Identifier: MIT
+
 module:set_global();
 
 local jid_bare, jid_host = require "util.jid".bare, require "util.jid".host;

--- a/prosody-modules/mod_muc_http_defaults/README.markdown
+++ b/prosody-modules/mod_muc_http_defaults/README.markdown
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2021 Kim Alvefur
+SPDX-License-Identifier: MIT
+-->
 ---
 summary: Seed MUC configuration from JSON REST API
 ---

--- a/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
+++ b/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
@@ -1,8 +1,8 @@
--- Copyright (C) 2021 Kim Alvefur
--- Copyright (C) 2024 John Livingston
+-- SPDX-FileCopyrightText: 2021 Kim Alvefur
+-- SPDX-FileCopyrightText: 2024 John Livingston
 --
--- This file is MIT licensed. Please see the
--- COPYING file in the source package for more information.
+-- SPDX-License-Identifier: MIT
+-- SPDX-License-Identifier: AGPL-3.0-only
 --
 -- This version contains a modification to take into account new config option "slow_mode_duration".
 -- This option is introduced in the Peertube livechat plugin, by mod_muc_slow_mode.

--- a/prosody-modules/mod_muc_moderation/README.markdown
+++ b/prosody-modules/mod_muc_moderation/README.markdown
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2015-2021 Kim Alvefur
+SPDX-License-Identifier: MIT
+-->
 # Introduction
 
 This module implements [XEP-0425: Message Moderation].

--- a/prosody-modules/mod_muc_moderation/mod_muc_moderation.lua
+++ b/prosody-modules/mod_muc_moderation/mod_muc_moderation.lua
@@ -1,8 +1,8 @@
 -- mod_muc_moderation
 --
--- Copyright (C) 2015-2021 Kim Alvefur
+-- SPDX-FileCopyrightText: 2015-2021 Kim Alvefur
 --
--- This file is MIT licensed.
+-- SPDX-License-Identifier: MIT
 --
 -- Implements: XEP-0425: Message Moderation
 --

--- a/prosody-modules/mod_muc_slow_mode/README.md
+++ b/prosody-modules/mod_muc_slow_mode/README.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
 # mod_muc_slow_mode
 
 This module is a custom module that allows slow mode for MUC rooms.

--- a/prosody-modules/mod_muc_slow_mode/mod_muc_slow_mode.lua
+++ b/prosody-modules/mod_muc_slow_mode/mod_muc_slow_mode.lua
@@ -1,6 +1,7 @@
 -- mod_muc_slow_mode
 --
--- Copyright (C) 2024 John Livingston
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+-- SPDX-License-Identifier: AGPL-3.0-only
 --
 -- This file is AGPL-v3 licensed.
 -- Please see the Peertube livechat plugin copyright information.

--- a/prosody-modules/mod_pubsub_peertubelivechat/README.md
+++ b/prosody-modules/mod_pubsub_peertubelivechat/README.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
 # mod_pubsub_peertubelivechat
 
 This module is a custom module that provide some pubsub services associated to a MUC room.

--- a/prosody-modules/mod_pubsub_peertubelivechat/mod_pubsub_peertubelivechat.lua
+++ b/prosody-modules/mod_pubsub_peertubelivechat/mod_pubsub_peertubelivechat.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 -- This module create sort of a MEP equivalent to PEP, but for MUC chatrooms.
 -- This idea is described in https://xmpp.org/extensions/xep-0316.html
 -- but here there are some differences:

--- a/prosody-modules/mod_random_vcard_peertubelivechat/README.md
+++ b/prosody-modules/mod_random_vcard_peertubelivechat/README.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
 # mod_random_vcard_peertubelivechat
 
 This module is a custom module that allows Prosody to generate random vCards avatars for anonymous users.

--- a/prosody-modules/mod_random_vcard_peertubelivechat/mod_random_vcard_peertubelivechat.lua
+++ b/prosody-modules/mod_random_vcard_peertubelivechat/mod_random_vcard_peertubelivechat.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 local st = require "util.stanza";
 local path = require "util.paths";
 local b64 = require "util.encodings".base64.encode;

--- a/prosody-modules/mod_s2s_peertubelivechat/README.md
+++ b/prosody-modules/mod_s2s_peertubelivechat/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_s2s_peertubelivechat
 
 This module is part of peertube-plugin-livechat, and is under the same LICENSE.

--- a/prosody-modules/mod_s2s_peertubelivechat/mod_s2s_peertubelivechat.lua
+++ b/prosody-modules/mod_s2s_peertubelivechat/mod_s2s_peertubelivechat.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 module:set_global();
 
 local path = require "util.paths";

--- a/prosody-modules/mod_vcard_peertubelivechat/README.md
+++ b/prosody-modules/mod_vcard_peertubelivechat/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_vcard_peertubelivechat
 
 This module is a custom module that allows Prosody to load vCards from Peertube.

--- a/prosody-modules/mod_vcard_peertubelivechat/mod_vcard_peertubelivechat.lua
+++ b/prosody-modules/mod_vcard_peertubelivechat/mod_vcard_peertubelivechat.lua
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 local st = require "util.stanza";
 local http = require "net.http";
 local gettime = require 'socket'.gettime;

--- a/prosody-modules/mod_websocket_s2s_peertubelivechat/README.md
+++ b/prosody-modules/mod_websocket_s2s_peertubelivechat/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # mod_websocket_s2s_peertubelivechat
 
 This module is part of peertube-plugin-livechat, and is under the same LICENSE.

--- a/prosody-modules/mod_websocket_s2s_peertubelivechat/mod_websocket_s2s_peertubelivechat.lua
+++ b/prosody-modules/mod_websocket_s2s_peertubelivechat/mod_websocket_s2s_peertubelivechat.lua
@@ -1,7 +1,8 @@
--- Prosody IM
--- Copyright (C) 2012-2014 Florian Zeitz
--- Copyright (C) 2023 John Livingston
--- Copied from original Prosody mod_websocket module (MIT/X11 licensed). Provided with Peertube Livechat plugin (AGPL-v3).
+-- SPDX-FileCopyrightText: 2012-2014 Florian Zeitz
+-- SPDX-FileCopyrightText: 2023-2024 John Livingston <https://www.john-livingston.fr/>
+--
+-- SPDX-License-Identifier: MIT
+-- SPDX-License-Identifier: AGPL-3.0-only
 
 module:set_global();
 

--- a/server/.eslintrc.json.license
+++ b/server/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/server/lib/apikey.ts
+++ b/server/lib/apikey.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 /*
 For internal API, we will generate an api Key that must be provided as

--- a/server/lib/bots/ctl.ts
+++ b/server/lib/bots/ctl.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Config as XMPPChatBotConfig } from 'xmppjs-chat-bot'
 import { BotConfiguration } from '../configuration/bot'

--- a/server/lib/configuration/bot.ts
+++ b/server/lib/configuration/bot.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { RoomConf, Config } from 'xmppjs-chat-bot'
 import { getProsodyDomain } from '../prosody/config/domain'

--- a/server/lib/configuration/channel/init.ts
+++ b/server/lib/configuration/channel/init.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, MVideoFullLight, VideoChannel } from '@peertube/peertube-types'
 import { RoomChannel } from '../../room-channel'
 import { fillVideoCustomFields } from '../../custom-fields'

--- a/server/lib/configuration/channel/sanitize.ts
+++ b/server/lib/configuration/channel/sanitize.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ChannelConfigurationOptions } from '../../../../shared/lib/types'
 

--- a/server/lib/configuration/channel/storage.ts
+++ b/server/lib/configuration/channel/storage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ChannelConfigurationOptions } from '../../../../shared/lib/types'
 import type { ChannelCommonRoomConf } from '../../configuration/bot'

--- a/server/lib/conversejs/params.ts
+++ b/server/lib/conversejs/params.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, MVideoThumbnail, SettingEntries } from '@peertube/peertube-types'
 import type { ConverseJSTheme, InitConverseJSParams, InitConverseJSParamsError } from '../../../shared/lib/types'
 import type { RegisterServerOptionsV5 } from '../helpers'

--- a/server/lib/custom-fields.ts
+++ b/server/lib/custom-fields.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, Video, MVideoThumbnail } from '@peertube/peertube-types'
 import { getVideoLiveChatInfos } from './federation/storage'
 import { anonymousConnectionInfos, compatibleRemoteAuthenticatedConnectionEnabled } from './federation/connection-infos'

--- a/server/lib/database/channel.ts
+++ b/server/lib/database/channel.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 
 async function getChannelNameById (options: RegisterServerOptions, channelId: number): Promise<string | null> {

--- a/server/lib/debug.ts
+++ b/server/lib/debug.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import * as path from 'path'
 import * as fs from 'fs'

--- a/server/lib/diagnostic/backend.ts
+++ b/server/lib/diagnostic/backend.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { newResult, TestResult } from './utils'
 

--- a/server/lib/diagnostic/debug.ts
+++ b/server/lib/diagnostic/debug.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { newResult, TestResult } from './utils'
 import { isDebugMode } from '../../lib/debug'

--- a/server/lib/diagnostic/external-auth-oidc.ts
+++ b/server/lib/diagnostic/external-auth-oidc.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { newResult, TestResult } from './utils'
 import { ExternalAuthOIDC, ExternalAuthOIDCType } from '../external-auth/oidc'

--- a/server/lib/diagnostic/index.ts
+++ b/server/lib/diagnostic/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { diagBackend } from './backend'
 import { TestResult, newResult } from './utils'

--- a/server/lib/diagnostic/prosody.ts
+++ b/server/lib/diagnostic/prosody.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { getProsodyConfig, getProsodyConfigContentForDiagnostic, getWorkingDir } from '../prosody/config'
 import { checkProsody, getProsodyAbout, testProsodyCorrectlyRunning } from '../prosody/ctl'

--- a/server/lib/diagnostic/utils.ts
+++ b/server/lib/diagnostic/utils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 type NextValue = 'backend' | 'debug' | 'webchat-video' | 'prosody'
 | 'external-auth-custom-oidc' | 'external-auth-google-oidc' | 'external-auth-facebook-oidc'
 | 'everything-ok'

--- a/server/lib/diagnostic/video.ts
+++ b/server/lib/diagnostic/video.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { newResult, TestResult } from './utils'
 

--- a/server/lib/external-auth/error.ts
+++ b/server/lib/external-auth/error.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * This class handles some errors related to external authentication, where message must be displayed to end user.

--- a/server/lib/external-auth/oidc.ts
+++ b/server/lib/external-auth/oidc.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Request, Response, CookieOptions } from 'express'
 import type { ExternalAccountInfos, AcceptableAvatarMimeType } from './types'

--- a/server/lib/external-auth/types.ts
+++ b/server/lib/external-auth/types.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 type AcceptableAvatarMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
 
 interface ExternalAccountInfos {

--- a/server/lib/federation/connection-infos.ts
+++ b/server/lib/federation/connection-infos.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { LiveChatJSONLDAttributeV1 } from './types'
 
 interface AnonymousConnectionInfos {

--- a/server/lib/federation/fetch-infos.ts
+++ b/server/lib/federation/fetch-infos.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { hasRemoteServerInfos, storeRemoteServerInfos } from './storage'
 import { getBaseRouterRoute } from '../helpers'

--- a/server/lib/federation/incoming.ts
+++ b/server/lib/federation/incoming.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { RemoteVideoHandlerParams } from './types'
 import { storeVideoLiveChatInfos, storeRemoteServerInfos } from './storage'

--- a/server/lib/federation/init.ts
+++ b/server/lib/federation/init.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, VideoObject } from '@peertube/peertube-types'
 import type { VideoBuildResultContext, RemoteVideoHandlerParams } from './types'
 import { videoBuildJSONLD, videoContextBuildJSONLD } from './outgoing'

--- a/server/lib/federation/outgoing.ts
+++ b/server/lib/federation/outgoing.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, VideoObject, SettingValue } from '@peertube/peertube-types'
 import type {
   LiveChatVideoObject,

--- a/server/lib/federation/sanitize.ts
+++ b/server/lib/federation/sanitize.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { LiveChatJSONLDAttributeV1, PeertubeXMPPServerInfos } from './types'
 import { URL } from 'url'

--- a/server/lib/federation/storage.ts
+++ b/server/lib/federation/storage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, MVideoFullLight, MVideoAP, Video, MVideoThumbnail } from '@peertube/peertube-types'
 import type { LiveChatJSONLDAttribute, LiveChatJSONLDAttributeV1, PeertubeXMPPServerInfos } from './types'
 import { sanitizePeertubeLiveChatInfos, sanitizeXMPPHostFromInstanceUrl } from './sanitize'

--- a/server/lib/federation/types.ts
+++ b/server/lib/federation/types.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { VideoObject, MVideoAP, MVideoFullLight } from '@peertube/peertube-types'
 
 interface VideoBuildResultContext {

--- a/server/lib/helpers.ts
+++ b/server/lib/helpers.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, PeerTubeHelpers } from '@peertube/peertube-types'
 import type { Response } from 'express'
 import type { IncomingMessage } from 'http'

--- a/server/lib/loc.ts
+++ b/server/lib/loc.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { resolve } from 'path'
 import { existsSync, promises as fsPromises } from 'fs'
 

--- a/server/lib/middlewares/apikey.ts
+++ b/server/lib/middlewares/apikey.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Request, Response, NextFunction } from 'express'
 import { getAPIKey } from '../apikey'

--- a/server/lib/middlewares/async.ts
+++ b/server/lib/middlewares/async.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { eachSeries } from 'async'
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 

--- a/server/lib/middlewares/configuration/channel.ts
+++ b/server/lib/middlewares/configuration/channel.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Request, Response, NextFunction } from 'express'
 import type { RequestPromiseHandler } from '../async'

--- a/server/lib/middlewares/configuration/configuration.ts
+++ b/server/lib/middlewares/configuration/configuration.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Request, Response, NextFunction } from 'express'
 import type { RequestPromiseHandler } from '../async'

--- a/server/lib/migration/settings.ts
+++ b/server/lib/migration/settings.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 
 async function migrateSettings (options: RegisterServerOptions): Promise<void> {

--- a/server/lib/prosody/api/host.ts
+++ b/server/lib/prosody/api/host.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 interface ProsodyHost {
   host: string
   port: string

--- a/server/lib/prosody/api/manage-rooms.ts
+++ b/server/lib/prosody/api/manage-rooms.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Affiliations } from '../config/affiliations'
 import { getCurrentProsody } from './host'

--- a/server/lib/prosody/api/manage-users.ts
+++ b/server/lib/prosody/api/manage-users.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ExternalAccountInfos } from '../../external-auth/types'
 import { getCurrentProsody } from './host'

--- a/server/lib/prosody/auth.ts
+++ b/server/lib/prosody/auth.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /*
 This module provides user credential for the builtin prosody module.
 */

--- a/server/lib/prosody/certificates.ts
+++ b/server/lib/prosody/certificates.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ProsodyConfig } from './config'
 import { debugNumericParameter, isDebugMode } from '../debug'

--- a/server/lib/prosody/config.ts
+++ b/server/lib/prosody/config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Config as XMPPBotConfig } from 'xmppjs-chat-bot'
 import type { ProsodyLogLevel } from './config/content'

--- a/server/lib/prosody/config/affiliations.ts
+++ b/server/lib/prosody/config/affiliations.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, MVideoThumbnail } from '@peertube/peertube-types'
 import { getProsodyDomain } from './domain'
 import { getUserNameByChannelId } from '../../database/channel'

--- a/server/lib/prosody/config/components.ts
+++ b/server/lib/prosody/config/components.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 interface ExternalComponent {
   name: string
   secret: string

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ProsodyFilePaths } from './paths'
 import type { ExternalComponent } from './components'
 import { BotConfiguration } from '../../configuration/bot'

--- a/server/lib/prosody/config/domain.ts
+++ b/server/lib/prosody/config/domain.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 
 async function getProsodyDomain (options: RegisterServerOptions): Promise<string> {

--- a/server/lib/prosody/config/paths.ts
+++ b/server/lib/prosody/config/paths.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 interface ProsodyFilePaths {
   dir: string
   pid: string

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { getProsodyConfig, getProsodyFilePaths, writeProsodyConfig } from './config'
 import { startProsodyLogRotate, stopProsodyLogRotate } from './logrotate'

--- a/server/lib/prosody/fix-room-subject.ts
+++ b/server/lib/prosody/fix-room-subject.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { ProsodyFilePaths } from './config/paths'
 import * as path from 'path'

--- a/server/lib/prosody/logrotate.ts
+++ b/server/lib/prosody/logrotate.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ProsodyFilePaths } from './config/paths'
 import { debugNumericParameter } from '../debug'

--- a/server/lib/prosody/migration/migrateV10.ts
+++ b/server/lib/prosody/migration/migrateV10.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { listProsodyRooms, updateProsodyRoom } from '../api/manage-rooms'
 import { Affiliations, getVideoAffiliations, getChannelAffiliations } from '../config/affiliations'

--- a/server/lib/room-channel/index.ts
+++ b/server/lib/room-channel/index.ts
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export * from './room-channel-class'

--- a/server/lib/room-channel/room-channel-class.ts
+++ b/server/lib/room-channel/room-channel-class.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { RoomConf } from 'xmppjs-chat-bot'
 import { getProsodyDomain } from '../prosody/config/domain'

--- a/server/lib/routers/api.ts
+++ b/server/lib/routers/api.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import { asyncMiddleware } from '../middlewares/async'

--- a/server/lib/routers/api/auth.ts
+++ b/server/lib/routers/api/auth.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import { asyncMiddleware } from '../../middlewares/async'

--- a/server/lib/routers/api/configuration.ts
+++ b/server/lib/routers/api/configuration.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import type { ChannelInfos } from '../../../../shared/lib/types'

--- a/server/lib/routers/api/federation-server-infos.ts
+++ b/server/lib/routers/api/federation-server-infos.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import { asyncMiddleware } from '../../middlewares/async'

--- a/server/lib/routers/api/promote.ts
+++ b/server/lib/routers/api/promote.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import type { Affiliations } from '../../prosody/config/affiliations'

--- a/server/lib/routers/api/room.ts
+++ b/server/lib/routers/api/room.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import { videoHasWebchat } from '../../../../shared/lib/video'

--- a/server/lib/routers/index.ts
+++ b/server/lib/routers/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { NextFunction, Request, Response } from 'express'
 import { initWebchatRouter } from './webchat'

--- a/server/lib/routers/oidc.ts
+++ b/server/lib/routers/oidc.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import type { ExternalAuthResult } from '../../../shared/lib/types'

--- a/server/lib/routers/settings.ts
+++ b/server/lib/routers/settings.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import { diag } from '../diagnostic'

--- a/server/lib/routers/webchat.ts
+++ b/server/lib/routers/webchat.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { Router, Request, Response, NextFunction } from 'express'
 import type {

--- a/server/lib/rss/init.ts
+++ b/server/lib/rss/init.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, Video } from '@peertube/peertube-types'
 import type { CustomTag } from '@peertube/feed/lib/typings'
 import { videoHasWebchat } from '../../../shared/lib/video'

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import type { ConverseJSTheme } from '../../shared/lib/types'
 import { ensureProsodyRunning } from './prosody/ctl'

--- a/server/lib/uri/canonicalize.ts
+++ b/server/lib/uri/canonicalize.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { pluginVersionWordBreakRegex } from '../helpers'
 import * as url from 'url'

--- a/server/lib/uri/webchat.ts
+++ b/server/lib/uri/webchat.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions, VideoObject, Video } from '@peertube/peertube-types'
 import { getBaseRouterRoute, getBaseWebSocketRoute } from '../helpers'
 import { canonicalizePluginUri } from './canonicalize'

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { RegisterServerOptions } from '@peertube/peertube-types'
 import { migrateSettings } from './lib/migration/settings'
 import { initSettings } from './lib/settings'

--- a/server/tsconfig.json.license
+++ b/server/tsconfig.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/shared/.eslintrc.json.license
+++ b/shared/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/shared/lib/autocolors.ts
+++ b/shared/lib/autocolors.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const validateColor = require('validate-color').default
 
 type AutoColorValue = string

--- a/shared/lib/config.ts
+++ b/shared/lib/config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function parseConfigUUIDs (s: string): string[] {
   if (!s) {
     return []

--- a/shared/lib/help.ts
+++ b/shared/lib/help.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function helpUrl (options: {
   lang?: string
   page?: string

--- a/shared/lib/types.ts
+++ b/shared/lib/types.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 type ConverseJSTheme = 'peertube' | 'default' | 'concord'
 
 interface InitConverseJSParams {

--- a/shared/lib/video.ts
+++ b/shared/lib/video.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { parseConfigUUIDs } from './config'
 
 interface VideoHasWebchatSettings {

--- a/support/documentation/archetypes/default.md
+++ b/support/documentation/archetypes/default.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}

--- a/support/documentation/config.toml
+++ b/support/documentation/config.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 baseURL = "http://localhost:1313/peertube-plugin-livechat/" # this will be overrind in CI/CD.
 languageCode = "en-us"
 defaultContentLanguage = "en"

--- a/support/documentation/content/en/_index.md
+++ b/support/documentation/content/en/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 # PeerTube plugin livechat
 
 {{% notice tip %}}

--- a/support/documentation/content/en/_index.md
+++ b/support/documentation/content/en/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # PeerTube plugin livechat
 
 {{% notice tip %}}

--- a/support/documentation/content/en/contact/_index.md
+++ b/support/documentation/content/en/contact/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Contact me"
 description: "Contact the author"

--- a/support/documentation/content/en/contact/_index.md
+++ b/support/documentation/content/en/contact/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Contact me"
 description: "Contact the author"

--- a/support/documentation/content/en/contributing/_index.md
+++ b/support/documentation/content/en/contributing/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Contributing"
 description: "Contributing"

--- a/support/documentation/content/en/contributing/_index.md
+++ b/support/documentation/content/en/contributing/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Contributing"
 description: "Contributing"

--- a/support/documentation/content/en/contributing/codeofconduct/_index.md
+++ b/support/documentation/content/en/contributing/codeofconduct/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Code of Conduct"
 description: "Contributor Covenant Code of Conduct"

--- a/support/documentation/content/en/contributing/codeofconduct/_index.md
+++ b/support/documentation/content/en/contributing/codeofconduct/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Code of Conduct"
 description: "Contributor Covenant Code of Conduct"

--- a/support/documentation/content/en/contributing/develop/_index.md
+++ b/support/documentation/content/en/contributing/develop/_index.md
@@ -37,6 +37,7 @@ To build the plugin, you must have following packages:
 * `build-essential`
 * `coreutils`
 * `wget`
+* `reuse`
 
 Please note that this plugin needs an AppImage for the Prosody XMPP server.
 This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.
@@ -81,6 +82,12 @@ You can build the plugin with extra debug features simply by using:
 ```bash
 NODE_ENV=dev npm run build
 ```
+
+This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.
+More information on the [REUSE](https://reuse.software/) website.
+You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.
+The `npm run lint` command will use the `reuse` command to check compliance.
+Don't forget to add your copyright information in SPDX headers when you modify some code.
 
 ## ESBuild vs Typescript
 

--- a/support/documentation/content/en/contributing/develop/_index.md
+++ b/support/documentation/content/en/contributing/develop/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Develop"
 description: "Develop"

--- a/support/documentation/content/en/contributing/develop/_index.md
+++ b/support/documentation/content/en/contributing/develop/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Develop"
 description: "Develop"

--- a/support/documentation/content/en/contributing/document/_index.md
+++ b/support/documentation/content/en/contributing/document/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Documentation"
 description: "Document the plugin, or translate the documentation."

--- a/support/documentation/content/en/contributing/document/_index.md
+++ b/support/documentation/content/en/contributing/document/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Documentation"
 description: "Document the plugin, or translate the documentation."

--- a/support/documentation/content/en/contributing/feedback/_index.md
+++ b/support/documentation/content/en/contributing/feedback/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Give your feedback"
 description: "Give your feedback"

--- a/support/documentation/content/en/contributing/feedback/_index.md
+++ b/support/documentation/content/en/contributing/feedback/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Give your feedback"
 description: "Give your feedback"

--- a/support/documentation/content/en/contributing/translate/_index.md
+++ b/support/documentation/content/en/contributing/translate/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Translate"
 description: "Translate the plugin"

--- a/support/documentation/content/en/contributing/translate/_index.md
+++ b/support/documentation/content/en/contributing/translate/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Translate"
 description: "Translate the plugin"

--- a/support/documentation/content/en/credits/_index.md
+++ b/support/documentation/content/en/credits/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Credits"
 description: "Plugin Credits"

--- a/support/documentation/content/en/credits/_index.md
+++ b/support/documentation/content/en/credits/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Credits"
 description: "Plugin Credits"

--- a/support/documentation/content/en/documentation/_index.md
+++ b/support/documentation/content/en/documentation/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Documentation"
 description: "Plugin documentation"

--- a/support/documentation/content/en/documentation/_index.md
+++ b/support/documentation/content/en/documentation/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Documentation"
 description: "Plugin documentation"

--- a/support/documentation/content/en/documentation/admin/_index.md
+++ b/support/documentation/content/en/documentation/admin/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Admin documentation"
 description: "Plugin Peertube Livechat administration"

--- a/support/documentation/content/en/documentation/admin/_index.md
+++ b/support/documentation/content/en/documentation/admin/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Admin documentation"
 description: "Plugin Peertube Livechat administration"

--- a/support/documentation/content/en/documentation/admin/advanced/_index.md
+++ b/support/documentation/content/en/documentation/admin/advanced/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Advanced usage"
 description: "Some advanced features"

--- a/support/documentation/content/en/documentation/admin/advanced/_index.md
+++ b/support/documentation/content/en/documentation/admin/advanced/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Advanced usage"
 description: "Some advanced features"

--- a/support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+++ b/support/documentation/content/en/documentation/admin/advanced/matterbridge.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Using Matterbridge"
 description: "Using Matterbridge to bridge with other chats"

--- a/support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+++ b/support/documentation/content/en/documentation/admin/advanced/matterbridge.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Using Matterbridge"
 description: "Using Matterbridge to bridge with other chats"

--- a/support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+++ b/support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "XMPP clients"
 description: "Allow connections using XMPP clients"

--- a/support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+++ b/support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "XMPP clients"
 description: "Allow connections using XMPP clients"

--- a/support/documentation/content/en/documentation/admin/external_auth.md
+++ b/support/documentation/content/en/documentation/admin/external_auth.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "External Authentication"
 description: "Plugin Peertube Livechat settings - External Authentication"

--- a/support/documentation/content/en/documentation/admin/external_auth.md
+++ b/support/documentation/content/en/documentation/admin/external_auth.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "External Authentication"
 description: "Plugin Peertube Livechat settings - External Authentication"

--- a/support/documentation/content/en/documentation/admin/settings.md
+++ b/support/documentation/content/en/documentation/admin/settings.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Settings"
 description: "Plugin Peertube Livechat settings"

--- a/support/documentation/content/en/documentation/admin/settings.md
+++ b/support/documentation/content/en/documentation/admin/settings.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Settings"
 description: "Plugin Peertube Livechat settings"

--- a/support/documentation/content/en/documentation/installation/_index.md
+++ b/support/documentation/content/en/documentation/installation/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Installation guide"
 description: "Plugin peertube-plugin-livechat installation guide"

--- a/support/documentation/content/en/documentation/installation/_index.md
+++ b/support/documentation/content/en/documentation/installation/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Installation guide"
 description: "Plugin peertube-plugin-livechat installation guide"

--- a/support/documentation/content/en/documentation/installation/cpu_compatibility.md
+++ b/support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Known issues: CPU Compatibility"
 description: "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."

--- a/support/documentation/content/en/documentation/installation/cpu_compatibility.md
+++ b/support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Known issues: CPU Compatibility"
 description: "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."

--- a/support/documentation/content/en/documentation/installation/troubleshooting.md
+++ b/support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Troubleshooting"
 description: "Some classic mistakes and workarounds."

--- a/support/documentation/content/en/documentation/installation/troubleshooting.md
+++ b/support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Troubleshooting"
 description: "Some classic mistakes and workarounds."

--- a/support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+++ b/support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Upgrade from version older than 6.0.0"
 description: "Important notes when upgrading for an older version."

--- a/support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+++ b/support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Upgrade from version older than 6.0.0"
 description: "Important notes when upgrading for an older version."

--- a/support/documentation/content/en/documentation/user/_index.md
+++ b/support/documentation/content/en/documentation/user/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "User documentation"
 description: "Plugin peertube-plugin-livechat user documentation"

--- a/support/documentation/content/en/documentation/user/_index.md
+++ b/support/documentation/content/en/documentation/user/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "User documentation"
 description: "Plugin peertube-plugin-livechat user documentation"

--- a/support/documentation/content/en/documentation/user/obs.md
+++ b/support/documentation/content/en/documentation/user/obs.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "OBS"
 description: "Documentation to stream the chat content using OBS."

--- a/support/documentation/content/en/documentation/user/obs.md
+++ b/support/documentation/content/en/documentation/user/obs.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "OBS"
 description: "Documentation to stream the chat content using OBS."

--- a/support/documentation/content/en/documentation/user/streamers/_index.md
+++ b/support/documentation/content/en/documentation/user/streamers/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "For streamers"
 description: "How to setup the chat for your live stream"

--- a/support/documentation/content/en/documentation/user/streamers/_index.md
+++ b/support/documentation/content/en/documentation/user/streamers/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "For streamers"
 description: "How to setup the chat for your live stream"

--- a/support/documentation/content/en/documentation/user/streamers/basics.md
+++ b/support/documentation/content/en/documentation/user/streamers/basics.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Some basics"
 description: "Some basics about how to setup and use the chat for your live stream"

--- a/support/documentation/content/en/documentation/user/streamers/basics.md
+++ b/support/documentation/content/en/documentation/user/streamers/basics.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Some basics"
 description: "Some basics about how to setup and use the chat for your live stream"

--- a/support/documentation/content/en/documentation/user/streamers/bot/_index.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Chat bot"
 description: "Chat bot setup"

--- a/support/documentation/content/en/documentation/user/streamers/bot/_index.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Chat bot"
 description: "Chat bot setup"

--- a/support/documentation/content/en/documentation/user/streamers/bot/commands.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/commands.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Commands"
 description: "The bot can respond to several commands."

--- a/support/documentation/content/en/documentation/user/streamers/bot/commands.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/commands.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Commands"
 description: "The bot can respond to several commands."

--- a/support/documentation/content/en/documentation/user/streamers/bot/forbidden_words.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/forbidden_words.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Forbidden words"
 description: "The bot can automatically moderate messages containing forbidden words."

--- a/support/documentation/content/en/documentation/user/streamers/bot/forbidden_words.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/forbidden_words.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Forbidden words"
 description: "The bot can automatically moderate messages containing forbidden words."

--- a/support/documentation/content/en/documentation/user/streamers/bot/quotes.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/quotes.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Timers"
 description: "The bot can send periodically some messages."

--- a/support/documentation/content/en/documentation/user/streamers/bot/quotes.md
+++ b/support/documentation/content/en/documentation/user/streamers/bot/quotes.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Timers"
 description: "The bot can send periodically some messages."

--- a/support/documentation/content/en/documentation/user/streamers/channel.md
+++ b/support/documentation/content/en/documentation/user/streamers/channel.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Channel configuration"
 description: "Peertube channel chatrooms configuration"

--- a/support/documentation/content/en/documentation/user/streamers/channel.md
+++ b/support/documentation/content/en/documentation/user/streamers/channel.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Channel configuration"
 description: "Peertube channel chatrooms configuration"

--- a/support/documentation/content/en/documentation/user/streamers/moderation.md
+++ b/support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Moderation"
 description: "Plugin peertube-plugin-livechat advanced moderation features"

--- a/support/documentation/content/en/documentation/user/streamers/moderation.md
+++ b/support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Moderation"
 description: "Plugin peertube-plugin-livechat advanced moderation features"

--- a/support/documentation/content/en/documentation/user/streamers/slow_mode.md
+++ b/support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Slow mode"
 description: "Plugin peertube-plugin-livechat slow mode"

--- a/support/documentation/content/en/documentation/user/streamers/slow_mode.md
+++ b/support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Slow mode"
 description: "Plugin peertube-plugin-livechat slow mode"

--- a/support/documentation/content/en/documentation/user/streamers/tasks.md
+++ b/support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Tasks / To-do lists"
 description: "You can handle tasks and task lists with your moderation team."

--- a/support/documentation/content/en/documentation/user/streamers/tasks.md
+++ b/support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Tasks / To-do lists"
 description: "You can handle tasks and task lists with your moderation team."

--- a/support/documentation/content/en/documentation/user/viewers.md
+++ b/support/documentation/content/en/documentation/user/viewers.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "For viewers"
 description: "How to chat for stream viewers"

--- a/support/documentation/content/en/documentation/user/viewers.md
+++ b/support/documentation/content/en/documentation/user/viewers.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "For viewers"
 description: "How to chat for stream viewers"

--- a/support/documentation/content/en/documentation/user/xmpp_clients.md
+++ b/support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "XMPP Clients"
 description: "Connect to chat using a XMPP client"

--- a/support/documentation/content/en/documentation/user/xmpp_clients.md
+++ b/support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "XMPP Clients"
 description: "Connect to chat using a XMPP client"

--- a/support/documentation/content/en/images/avatar_abstract.png.license
+++ b/support/documentation/content/en/images/avatar_abstract.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/avatar_bird.png.license
+++ b/support/documentation/content/en/images/avatar_bird.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/avatar_cat.png.license
+++ b/support/documentation/content/en/images/avatar_cat.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/avatar_fenec.png.license
+++ b/support/documentation/content/en/images/avatar_fenec.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/avatar_legacy.jpg.license
+++ b/support/documentation/content/en/images/avatar_legacy.jpg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/avatar_sepia.png.license
+++ b/support/documentation/content/en/images/avatar_sepia.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/bot_commands.png.license
+++ b/support/documentation/content/en/images/bot_commands.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/bot_deleted_message.png.license
+++ b/support/documentation/content/en/images/bot_deleted_message.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/bot_forbidden_words.png.license
+++ b/support/documentation/content/en/images/bot_forbidden_words.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/bot_quotes.png.license
+++ b/support/documentation/content/en/images/bot_quotes.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/channel_configuration.png.license
+++ b/support/documentation/content/en/images/channel_configuration.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/chat.png.license
+++ b/support/documentation/content/en/images/chat.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/chat_anonymous.png.license
+++ b/support/documentation/content/en/images/chat_anonymous.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/chat_with_anonymous.png.license
+++ b/support/documentation/content/en/images/chat_with_anonymous.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/chatrooms_menu.png.license
+++ b/support/documentation/content/en/images/chatrooms_menu.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/configure.png.license
+++ b/support/documentation/content/en/images/configure.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/diagnostic.png.license
+++ b/support/documentation/content/en/images/diagnostic.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/embed_chat_in_livestream.png.license
+++ b/support/documentation/content/en/images/embed_chat_in_livestream.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/embed_chat_in_obs.png.license
+++ b/support/documentation/content/en/images/embed_chat_in_obs.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/external_login_button.png.license
+++ b/support/documentation/content/en/images/external_login_button.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/external_login_dialog.png.license
+++ b/support/documentation/content/en/images/external_login_dialog.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/external_login_dialog_oidc.png.license
+++ b/support/documentation/content/en/images/external_login_dialog_oidc.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/fullscreen.png.license
+++ b/support/documentation/content/en/images/fullscreen.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/installation.png.license
+++ b/support/documentation/content/en/images/installation.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/launch_diagnostic.png.license
+++ b/support/documentation/content/en/images/launch_diagnostic.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/new_live.png.license
+++ b/support/documentation/content/en/images/new_live.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/new_live_activate_chat.png.license
+++ b/support/documentation/content/en/images/new_live_activate_chat.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/open_participants_list.png.license
+++ b/support/documentation/content/en/images/open_participants_list.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/share_button.png.license
+++ b/support/documentation/content/en/images/share_button.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/share_readonly.png.license
+++ b/support/documentation/content/en/images/share_readonly.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/share_xmpp_dialog.png.license
+++ b/support/documentation/content/en/images/share_xmpp_dialog.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/slow_mode.png.license
+++ b/support/documentation/content/en/images/slow_mode.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/slow_mode_channel_option.png.license
+++ b/support/documentation/content/en/images/slow_mode_channel_option.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_fullpage_1.png.license
+++ b/support/documentation/content/en/images/task_app_fullpage_1.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_task_1.png.license
+++ b/support/documentation/content/en/images/task_app_task_1.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_task_2.png.license
+++ b/support/documentation/content/en/images/task_app_task_2.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_task_form.png.license
+++ b/support/documentation/content/en/images/task_app_task_form.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_task_lists.png.license
+++ b/support/documentation/content/en/images/task_app_task_lists.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_app_video_1.png.license
+++ b/support/documentation/content/en/images/task_app_video_1.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_drag_drop.png.license
+++ b/support/documentation/content/en/images/task_drag_drop.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_drag_drop_task_list.png.license
+++ b/support/documentation/content/en/images/task_drag_drop_task_list.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_from_message_1.png.license
+++ b/support/documentation/content/en/images/task_from_message_1.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_from_message_2.png.license
+++ b/support/documentation/content/en/images/task_from_message_2.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_from_message_3.png.license
+++ b/support/documentation/content/en/images/task_from_message_3.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_open_app_fullpage.png.license
+++ b/support/documentation/content/en/images/task_open_app_fullpage.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/task_open_app_video.png.license
+++ b/support/documentation/content/en/images/task_open_app_video.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/images/top_menu.png.license
+++ b/support/documentation/content/en/images/top_menu.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/content/en/intro/_index.md
+++ b/support/documentation/content/en/intro/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Introduction"
 description: "Introduction"

--- a/support/documentation/content/en/intro/_index.md
+++ b/support/documentation/content/en/intro/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Introduction"
 description: "Introduction"

--- a/support/documentation/content/en/issues/_index.md
+++ b/support/documentation/content/en/issues/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Bug tracking & new features"
 description: "Bug tracking / New features requests"

--- a/support/documentation/content/en/issues/_index.md
+++ b/support/documentation/content/en/issues/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Bug tracking & new features"
 description: "Bug tracking / New features requests"

--- a/support/documentation/content/en/technical/_index.md
+++ b/support/documentation/content/en/technical/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Technical documentation"
 description: "Technical documentation"

--- a/support/documentation/content/en/technical/_index.md
+++ b/support/documentation/content/en/technical/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Technical documentation"
 description: "Technical documentation"

--- a/support/documentation/content/en/technical/data/_index.md
+++ b/support/documentation/content/en/technical/data/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Plugin storage"
 description: "Data files and folders used on the server"

--- a/support/documentation/content/en/technical/data/_index.md
+++ b/support/documentation/content/en/technical/data/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Plugin storage"
 description: "Data files and folders used on the server"

--- a/support/documentation/content/en/technical/slow_mode.md
+++ b/support/documentation/content/en/technical/slow_mode.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "MUC Slow mode"
 description: "MUC Slow mode XEP"

--- a/support/documentation/content/en/technical/slow_mode.md
+++ b/support/documentation/content/en/technical/slow_mode.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "MUC Slow mode"
 description: "MUC Slow mode XEP"

--- a/support/documentation/content/en/technical/sourcecode/_index.md
+++ b/support/documentation/content/en/technical/sourcecode/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Source code"
 description: "Source code organization"

--- a/support/documentation/content/en/technical/sourcecode/_index.md
+++ b/support/documentation/content/en/technical/sourcecode/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Source code"
 description: "Source code organization"

--- a/support/documentation/content/en/technical/tasks.md
+++ b/support/documentation/content/en/technical/tasks.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Tasks overview"
 description: "Task Application technical overview"

--- a/support/documentation/content/en/technical/tasks.md
+++ b/support/documentation/content/en/technical/tasks.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Tasks overview"
 description: "Task Application technical overview"

--- a/support/documentation/content/en/technical/thirdparty/_index.md
+++ b/support/documentation/content/en/technical/thirdparty/_index.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 ---
 title: "Third party"
 description: "Displaying the livechat with 3rd party software."

--- a/support/documentation/content/en/technical/thirdparty/_index.md
+++ b/support/documentation/content/en/technical/thirdparty/_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 ---
 title: "Third party"
 description: "Displaying the livechat with 3rd party software."

--- a/support/documentation/layouts/partials/logo.html.license
+++ b/support/documentation/layouts/partials/logo.html.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/layouts/shortcodes/livechat_codeofconduct.html.license
+++ b/support/documentation/layouts/shortcodes/livechat_codeofconduct.html.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/layouts/shortcodes/livechat_label.html.license
+++ b/support/documentation/layouts/shortcodes/livechat_label.html.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/documentation/po/livechat.ar.po
+++ b/support/documentation/po/livechat.ar.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-01-17 11:38+0000\n"
 "Last-Translator: ButterflyOfFire <butterflyoffire@protonmail.com>\n"
 "Language-Team: Arabic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ar/>\n"
@@ -17,17 +17,96 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.3.1\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
-msgstr "الاتصال بالمؤلف"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "الاتصال بي"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -39,28 +118,20 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "قواعد السلوك"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "التطوير"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -143,10 +214,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "التطوير"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,18 +466,10 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
-msgstr "المستندات"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -593,39 +672,30 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
-msgstr "عبّر عن رأيك"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
-msgstr "المساهمة"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr "ترجمة الإضافة"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
-msgstr "ترجمة"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -872,16 +942,9 @@ msgstr "معلومات عامة"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -929,28 +992,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -958,16 +1007,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1488,10 +1530,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1501,17 +1542,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1677,28 +1710,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1721,6 +1740,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1937,22 +1962,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2062,16 +2079,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2090,10 +2100,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2187,16 +2196,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2220,28 +2222,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2328,16 +2316,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2430,7 +2411,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2517,16 +2497,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2539,16 +2512,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2606,17 +2572,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2651,16 +2609,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2673,18 +2624,10 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, fuzzy, no-wrap
-#| msgid "General information"
-msgid "Channel configuration"
-msgstr "معلومات عامة"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2721,22 +2664,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2837,16 +2772,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2854,10 +2782,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "مقدمة"
@@ -2928,9 +2855,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2950,16 +2876,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3186,10 +3105,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3395,16 +3313,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3481,6 +3392,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3566,6 +3482,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3628,17 +3550,10 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr "متعقّب الأخطاء \\ طلبات الميزات الجديدة"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
-msgstr "متعقّب الأخطاء والميزات الجديدة"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3664,3 +3579,48 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "الاتصال بالمؤلف"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "الاتصال بي"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "قواعد السلوك"
+
+#, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "المستندات"
+
+#, no-wrap
+#~ msgid "Give your feedback"
+#~ msgstr "عبّر عن رأيك"
+
+#, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "المساهمة"
+
+#, no-wrap
+#~ msgid "Translate the plugin"
+#~ msgstr "ترجمة الإضافة"
+
+#, no-wrap
+#~ msgid "Translate"
+#~ msgstr "ترجمة"
+
+#, fuzzy, no-wrap
+#~| msgid "General information"
+#~ msgid "Channel configuration"
+#~ msgstr "معلومات عامة"
+
+#, no-wrap
+#~ msgid "Bug tracking / New features requests"
+#~ msgstr "متعقّب الأخطاء \\ طلبات الميزات الجديدة"
+
+#, no-wrap
+#~ msgid "Bug tracking & new features"
+#~ msgstr "متعقّب الأخطاء والميزات الجديدة"

--- a/support/documentation/po/livechat.ar.po
+++ b/support/documentation/po/livechat.ar.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-01-17 11:38+0000\n"
 "Last-Translator: ButterflyOfFire <butterflyoffire@protonmail.com>\n"
 "Language-Team: Arabic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ar/>\n"
@@ -17,96 +17,17 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.3.1\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "الاتصال بالمؤلف"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+msgid "Contact me"
+msgstr "الاتصال بي"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -118,20 +39,28 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "قواعد السلوك"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "التطوير"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -223,12 +152,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "التطوير"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -466,10 +389,18 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
+msgstr "المستندات"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -672,30 +603,39 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Give your feedback"
+msgstr "عبّر عن رأيك"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributing"
+msgstr "المساهمة"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Translate the plugin"
+msgstr "ترجمة الإضافة"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
+msgstr "ترجمة"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -942,9 +882,16 @@ msgstr "معلومات عامة"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -992,14 +939,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1007,9 +968,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1530,9 +1498,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1542,9 +1511,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1710,14 +1687,29 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, fuzzy, no-wrap
+#| msgid "Documentation"
+msgid "Admin documentation"
+msgstr "المستندات"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1740,12 +1732,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1962,14 +1948,23 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, fuzzy, no-wrap
+#| msgid "Documentation"
+msgid "Plugin documentation"
+msgstr "المستندات"
+
+#. type: Yaml Front Matter Hash Value: description
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2079,9 +2074,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2100,9 +2102,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2196,9 +2199,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2222,14 +2232,29 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, fuzzy, no-wrap
+#| msgid "Documentation"
+msgid "User documentation"
+msgstr "المستندات"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2316,9 +2341,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2411,6 +2443,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2497,9 +2530,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2512,9 +2552,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2572,9 +2619,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2609,9 +2664,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2624,10 +2686,19 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "General information"
+msgid "Peertube channel chatrooms configuration"
+msgstr "معلومات عامة"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, fuzzy, no-wrap
+#| msgid "General information"
+msgid "Channel configuration"
+msgstr "معلومات عامة"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2664,14 +2735,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2772,9 +2851,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2782,9 +2868,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "مقدمة"
@@ -2855,8 +2942,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2876,9 +2964,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3105,9 +3200,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3313,9 +3409,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3392,11 +3495,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3482,12 +3580,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3550,10 +3642,17 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr "متعقّب الأخطاء \\ طلبات الميزات الجديدة"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
+msgstr "متعقّب الأخطاء والميزات الجديدة"
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3579,48 +3678,3 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
-
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "الاتصال بالمؤلف"
-
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "الاتصال بي"
-
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "قواعد السلوك"
-
-#, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "المستندات"
-
-#, no-wrap
-#~ msgid "Give your feedback"
-#~ msgstr "عبّر عن رأيك"
-
-#, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "المساهمة"
-
-#, no-wrap
-#~ msgid "Translate the plugin"
-#~ msgstr "ترجمة الإضافة"
-
-#, no-wrap
-#~ msgid "Translate"
-#~ msgstr "ترجمة"
-
-#, fuzzy, no-wrap
-#~| msgid "General information"
-#~ msgid "Channel configuration"
-#~ msgstr "معلومات عامة"
-
-#, no-wrap
-#~ msgid "Bug tracking / New features requests"
-#~ msgstr "متعقّب الأخطاء \\ طلبات الميزات الجديدة"
-
-#, no-wrap
-#~ msgid "Bug tracking & new features"
-#~ msgstr "متعقّب الأخطاء والميزات الجديدة"

--- a/support/documentation/po/livechat.ca.po
+++ b/support/documentation/po/livechat.ca.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ca/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.ca.po
+++ b/support/documentation/po/livechat.ca.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ca/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.cs.po
+++ b/support/documentation/po/livechat.cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/cs/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.cs.po
+++ b/support/documentation/po/livechat.cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/cs/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.de.po
+++ b/support/documentation/po/livechat.de.po
@@ -7,12 +7,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-05-18 04:24+0000\n"
-"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>"
-"\n"
-"Language-Team: German <https://weblate.framasoft.org/projects/"
-"peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
+"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>\n"
+"Language-Team: German <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,17 +18,97 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.5.5\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
-#, no-wrap
-msgid "Contact the author"
-msgstr "Den Autor kontaktieren"
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
+#, fuzzy, no-wrap
+#| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr "Das Plugin wird von [John Livingston](https://www.john-livingston.fr/) betrieben."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "Kontaktieren Sie mich"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -42,28 +120,20 @@ msgstr "Wenn Sie eine Frage haben oder über dieses Plugin sprechen möchten, k�
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Wenn Sie das Projekt finanziell unterstützen möchten, können Sie mich per E-Mail unter git.[at].john-livingston.fr kontaktieren oder mein [Liberapay-Profil](https://liberapay.com/JohnLivingston/) ansehen."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr "Vereinbarung über Verhaltenskodex für Mitwirkende"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "Verhaltenskodex"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Dieser Verhaltenskodex basiert auf dem [Contributor Covenant](https://www.contributor-covenant.org), Version 2.1, verfügbar unter [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Übersetzungen sind unter [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations) verfügbar. Fälle von beleidigendem, belästigendem oder anderweitig inakzeptablem Verhalten können den für die Durchsetzung verantwortlichen Gemeinschaftsleitern per E-Mail an git.[at].john-livingston.fr gemeldet werden."
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Entwickeln"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -146,10 +216,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Bitte beachten Sie, dass dieses Plugin ein AppImage für den Prosody XMPP Server benötigt.  Dieses AppImage wird vom [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) Seitenprojekt bereitgestellt.  Das Skript `build-prosody.sh` lädt Binärdateien herunter, die an dieses entfernte Repository angehängt sind, und überprüft, ob ihre sha256-Hashsumme korrekt ist."
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "Entwickeln"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -225,6 +306,11 @@ msgstr "Sie können das Plugin mit zusätzlichen Debug-Funktionen bauen, indem S
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
 msgstr "NODE_ENV=dev npm run build\n"
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -408,18 +494,12 @@ msgstr "Leistungstests"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "Das [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) Repository enthält einige Werkzeuge zur Durchführung von Leistungstests.  Sie können verwendet werden, um Code-Verbesserungen zu bewerten oder Engpässe zu finden."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+#, fuzzy
+#| msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr "Dokumentieren Sie das Plugin, oder übersetzen Sie die Dokumentation."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
-msgstr "Dokumentation"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -622,39 +702,30 @@ msgstr "Veröffentlichung"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "Die Veröffentlichung der Dokumentation erfolgt automatisch, sobald die Änderungen in den `documentation` Zweig eingefügt wurden."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
-msgstr "Geben Sie Ihr Feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "Sie müssen keine Programmierkenntnisse haben, um zu diesem Plugin beizutragen! Andere Beiträge sind auch sehr wertvoll, darunter: Sie können die Software testen und Fehler melden, Sie können Feedback geben, Funktionen die Sie interessieren, Benutzeroberfläche, Design, ..."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
-msgstr "Beitragen"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Interessiert beizutragen? Super!"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr "Das Plugin übersetzen"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
-msgstr "Übersätzen"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -906,17 +977,10 @@ msgstr "Allgemeine Empfehlungen"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr "Bitte formulieren Sie umfassend und beachten Sie den [Verhaltenskodex](/peertube-plugin-livechat/de/contributing/codeofconduct/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr "Impressum des Plugins"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
-msgstr "Impressum"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -963,46 +1027,25 @@ msgstr "Vielen Dank an [Octopuce](https://www.octopuce.fr/) für die finanzielle
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr "Und vielen Dank an alle Einzelspender, die über meine [Liberapay Seite] (https://liberapay.com/JohnLivingston/) gespendet haben."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
-msgstr "Einige erweiterte Funktionen"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr "Fortgeschrittene Nutzung"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr "Matterbridge als Brücke zu anderen Chats nutzen"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
-msgstr "Matterbridge benutzen"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr "Hier ist ein Tutorial um Matterbridge mit diesem Plugin zu benutzen (nur auf englisch): <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr "Verbindungen über XMPP-Clients zulassen"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
-msgstr "XMPP-Clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1544,10 +1587,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "Fehlerbehebung"
@@ -1557,18 +1599,12 @@ msgstr "Fehlerbehebung"
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr "Wenn Sie es nicht hinbekommen, können Sie das Diagnosetool verwenden (es gibt eine Schaltfläche oben auf der Seite mit den Plugin-Einstellungen) und sich den Abschnitt «Prosody check» genau ansehen."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
+#, fuzzy
+#| msgid "Plugin Peertube Livechat settings - External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr "Plugin Peertube Livechat Einstellungen - Externe Authentifizierung"
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
-msgstr "Externe Authentifizierung"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1735,29 +1771,15 @@ msgstr "Weiteres folgt"
 msgid "Other authentication methods will be implemented in the future."
 msgstr "Andere Authentifizierungsmethoden werden in Zukunft implementiert werden."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
-msgstr "Plugin Peertube Livechat Administation"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr "Admin Dokumentation"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr "Plugin Peertube Livechat Einstellungen"
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
-msgstr "Einstellungen"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1780,6 +1802,12 @@ msgstr "Föderation"
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
 msgstr "Die folgenden Einstellungen betreffen die Föderation mit anderen Peertube Instanzen und anderer Fediverse-Software."
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
+msgstr "Externe Authentifizierung"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1998,23 +2026,17 @@ msgstr "Diese Funktion könnte für die Verbindung von Brücken oder Bots genutz
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr "Weitere Informationen zu den externen Komponenten von Prosody finden Sie [hier](https://prosody.im/doc/components)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
-msgstr "Plugin Dokumentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+#, fuzzy
+#| msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr "Derzeit funktioniert das Plugin standartmäßig nur für x86_64 CPU Architekturen. Hier sind einige Anleitungen für andere CPU Architekturen."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
-msgstr "Bekannte Probleme: CPU Kompatibilität"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -2128,17 +2150,10 @@ msgstr "Dies wird bereits von der Yunohost Peertube Anwendung gemacht, da es fü
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr "Es kann aber sein, dass es in naher Zukunft entfernt wird (um die Nachteile dieser Methode zu vermeiden). Ich muss mit dem Yunohost Team diskutieren, um zu entscheiden, wie wir die Nachteile minimieren können, und die Kompatibilität zu maximieren."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr "Plugin peertube-plugin-livechat Installationsanleitung"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
-msgstr "Installationsanleitung"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
@@ -2156,11 +2171,10 @@ msgstr "Um das Plugin zu installieren oder zu aktualisieren **einfach das Peertu
 msgid "Here are some other more specific instructions:"
 msgstr "Hier sind weitere, spezifischere Anweisungen:"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
-msgstr "Einige klassische Fehler und Umgehungsmöglichkeiten."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2253,17 +2267,10 @@ msgstr "Sie können bestätigen, dass es sich um ein Websocket-Problem handelt, 
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr "Wenn Sie dies nicht sofort beheben können, können Sie Websocket deaktivieren, indem Sie das Häkchen bei \"{{% livechat_label disable_websocket_label %}}\" auf der Plugin Einstellungsseite entfernen.  In diesem Fall sollten Sie auch das Häkchen bei \"{{% livechat_label federation_dont_publish_remotely_label %}}\" setzen, da die Chat-Föderation ohne Websocket nicht funktioniert."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr "Wichtige Hinweise zum aktualisieren von älteren Versionen."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
-msgstr "Aktualisieren von Versionen vor 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -2286,29 +2293,19 @@ msgstr "Falls Sie dieses Plugin vor dieser Version benutzt haben und Sie Prosody
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr "Falls Sie ein eigenes Peertube Docker Paket genutzt haben, welches Prosody eingebettet hatte, können Sie zu den offiziellen Peertube Paketen zurück wechseln."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
-msgstr "Plugin peertube-plugin-livechat Benutzer Dokumentation"
+#, fuzzy
+#| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+msgstr "Für die Benutzerdokumentation, siehe [Benutzerdokumentation](/peertube-plugin-livechat/de/documentation/user/viewers/)"
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr "Benutzer Dokumentation"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
+#, fuzzy
+#| msgid "Documentation to stream the chat content using OBS."
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr "Dokumentation zum Streamen des Chat-Inhalts mit OBS."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
-msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2394,17 +2391,12 @@ msgstr "Mischen mehrerer Chats in Ihrem Live-Stream"
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr "Sie können die [social_stream Browsererweiterung](https://github.com/steveseguin/social_stream#readme) verwenden, um mehrere Chat-Quellen (von Peertube, Twitch, Youtube, Facebook, ...) zu mischen und deren Inhalte in Ihren Live-Stream einzubinden. Die Kompatibilität mit diesem Plugin wurde in den letzten Versionen hinzugefügt."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
+#, fuzzy
+#| msgid "Some basics about how to setup and use the chat for your live stream"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr "Einige grundlegende Informationen zur Einrichtung und Nutzung des Chats für Ihren Livestream"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
-msgstr "Einige Grundlagen"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2496,7 +2488,6 @@ msgstr "Das \"{{% livechat_label share_chat_link %}}\" Popup-Fenster kann auch e
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2583,17 +2574,10 @@ msgstr "Wenn Sie den Inhalt des Chats löschen möchten, [öffnen Sie deas Dropd
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr "Der Chat wird automatisch neu erstellt, wenn jemand versucht, ihm beizutreten, solange das Video existiert und die Funktion \"{{% livechat_label use_chat %}}\" aktiviert ist."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr "Der Chatbot kann auf verschiedene Befehle reagieren."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
-msgstr "Befehle"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
@@ -2605,17 +2589,12 @@ msgstr "![Befehlskonfiguration](/peertube-plugin-livechat/images/bot_commands.pn
 msgid "You can setup several commands."
 msgstr "Sie können mehrere Befehle einrichten."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
+#, fuzzy
+#| msgid "The bot can automatically moderate messages containing forbidden words."
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr "Der Chatbot kann automatisch Nachrichten moderieren, die verbotene Wörter enthalten."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
-msgstr "Verbotene Wörter"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
@@ -2672,18 +2651,10 @@ msgstr "Diese Funktion ist noch experimentell.  Es könnte einige Probleme mit n
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr "Wenn Sie diese Option aktivieren, wird jede Zeile des Feldes \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" als [regulärer Ausdruck](https://de.wikipedia.org/wiki/Regul%C3%A4rer_Ausdruck) betrachtet."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr "Chatbot Einrichtung"
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr "Chatbot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2717,17 +2688,12 @@ msgstr "Dort können Sie den Chatbot aktivieren und verschiedene Optionen einste
 msgid "The bot will reload instantly when you save the page."
 msgstr "Der Chatbot wird sofort neu geladen, wenn Sie die Seite speichern."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
+#, fuzzy
+#| msgid "The bot can send periodically some messages."
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr "Der Chatbot kann in regelmäßigen Abständen einige Nachrichten senden."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
-msgstr "Timer"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
@@ -2739,17 +2705,10 @@ msgstr "Wenn sich kein Benutzer im Chatraum befindet, sendet der Chatbot keine N
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "[Konfiguration der Timer](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr "Peertube Kanal Chaträume Konfiguration"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
-msgstr "Kanalkonfiguration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2786,22 +2745,16 @@ msgstr "[Den Chatbot](/peertube-plugin-livechat/de/documentation/user/streamers/
 msgid "More features to come..."
 msgstr "Weitere Funktionen werden folgen..."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
-msgstr "So richten Sie den Chat für Ihren Live-Stream ein"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr "Für Streamer"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#, fuzzy
+#| msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr "Plugin peertube-plugin-livechat Erweiterte Moderationsfunktionen"
 
 #. type: Plain text
@@ -2817,8 +2770,7 @@ msgid ""
 "There were some changes in the way we manage access rights for Peertube administrators and moderators.\n"
 msgstr ""
 "Diese Seite beschreibt das Verhalten von Livechat-Versionen >= 10.0.0.\n"
-"Es gab einige Änderungen in der Art und Weise, wie wir die Zugriffsrechte "
-"für Peertube-Administratoren und -Moderatoren verwalten.\n"
+"Es gab einige Änderungen in der Art und Weise, wie wir die Zugriffsrechte für Peertube-Administratoren und -Moderatoren verwalten.\n"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2845,20 +2797,12 @@ msgstr "Über das [Chat Dropdown Menü](/peertube-plugin-livechat/de/documentati
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "The video owner will be owner of the chat room.  This means he can configure the room, delete it, promote other users as admins, ..."
-msgstr ""
-"Der Videobesitzer ist der Besitzer des Chatraums.  Das bedeutet, er kann den "
-"Raum konfigurieren, löschen, andere Benutzer als Administratoren befördern, "
-"..."
+msgstr "Der Videobesitzer ist der Besitzer des Chatraums.  Das bedeutet, er kann den Raum konfigurieren, löschen, andere Benutzer als Administratoren befördern, ..."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "Starting with livechat v10.0.0, Peertube instance's admins and moderators have no special rights on rooms by default.  However, they have a special button available on top of the chat: \"{{% livechat_label promote %}}\".  Clicking this button will give them owner access on the room."
-msgstr ""
-"Ab livechat v10.0.0 haben Admins und Moderatoren der Peertube-Instanz "
-"standardmäßig keine besonderen Rechte für Räume.  Sie haben jedoch einen "
-"speziellen Button oben im Chat zur Verfügung: \"{{% livechat_label promote "
-"%}}\".  Wenn sie auf diese Schaltfläche klicken, erhalten sie Besitzerrechte "
-"für den Raum."
+msgstr "Ab livechat v10.0.0 haben Admins und Moderatoren der Peertube-Instanz standardmäßig keine besonderen Rechte für Räume.  Sie haben jedoch einen speziellen Button oben im Chat zur Verfügung: \"{{% livechat_label promote %}}\".  Wenn sie auf diese Schaltfläche klicken, erhalten sie Besitzerrechte für den Raum."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2911,32 +2855,21 @@ msgstr "Sie können alle bestehenden Chaträume auflisten: in den Einstellungen 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
+msgstr "Von dort aus kannst du dich auch als Moderator des Raums bewerben, indem du die Schaltfläche \"{{% livechat_label promote %}}\" auf der rechten Seite benutzt."
+
+#. type: Plain text
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
-"Von dort aus kannst du dich auch als Moderator des Raums bewerben, indem du "
-"die Schaltfläche \"{{% livechat_label promote %}}\" auf der rechten Seite "
-"benutzt."
-
-#. type: Yaml Front Matter Hash Value: description
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr "Plugin peertube-plugin-livechat Langsamer Modus"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
-msgstr "Langsamer Modus"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr "Diese Funktion wird mit dem Livechatplugin Version 8.3.0 verfügbar sein."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "Einführung"
@@ -3005,14 +2938,10 @@ msgstr "Wenn Sie den Wert auf eine positive ganze Zahl setzen, wird der Zeitraum
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
-msgstr ""
-"Um den Wert für einen bereits existierenden Raum zu ändern, öffnen Sie "
-"einfach das Raum-Konfigurationsmenü (oben im Chatfenster) und ändern Sie den "
-"Wert für den langsamen Modus im Konfigurationsformular."
+msgstr "Um den Wert für einen bereits existierenden Raum zu ändern, öffnen Sie einfach das Raum-Konfigurationsmenü (oben im Chatfenster) und ändern Sie den Wert für den langsamen Modus im Konfigurationsformular."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr "Für Zuschauer"
@@ -3032,17 +2961,12 @@ msgstr "![Infobox Langsamer Modus](/peertube-plugin-livechat/images/slow_mode.pn
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr "Wenn sie eine Nachricht senden, wird das Eingabefeld für X Sekunden deaktiviert (wobei X die Dauer des langsamen Modus ist)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
+#, fuzzy
+#| msgid "You can handle tasks and task lists with your moderation team."
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr "Sie können Aufgaben und Aufgabenlisten mit Ihrem Moderationsteam bearbeiten."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
-msgstr "Aufgaben / To-do-Listen"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3268,11 +3192,10 @@ msgstr "![Aufgabe erstellt](/peertube-plugin-livechat/images/task_from_message_3
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr "Mit dieser Funktion können Sie z. B. Ihre Moderatoren bitten, alle Chat-Fragen zu markieren, damit Sie sie während Ihres Livestreams auf einen Blick sehen und als beantwortet markieren können."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
-msgstr "Wie man chattet für Live-Stream Zuschauer"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -3477,17 +3400,10 @@ msgstr "Sie können Ihren Spitznamen ändern, indem Sie `/nick ihr_neuer_spitzna
 msgid "You can also change your nickname using the chat menu."
 msgstr "Sie können Ihren Spitznamen auch über das Chatmenü ändern."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr "Verbindung zum Chat über einen XMPP-Client"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
-msgstr "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -3564,6 +3480,11 @@ msgstr "Um einen Einblick in die Fähigkeiten dieses Plugins zu bekommen, schaue
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
 msgstr "Sie können das Suchfeld im linken Menü verwenden, um bestimmte Teile der Dokumentation schnell zu finden."
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/intro/_index.md
@@ -3648,6 +3569,12 @@ msgstr "Damit der Zusammenschluss funktioniert, muss das Plugin natürlich auf b
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr "Manchmal muss man seine Community vor bösen Menschen schützen.  Als Instanzadministrator können Sie die Föderation für das Livechat-Plugin deaktivieren.  Wenn sich entfernte Akteure schlecht benehmen, können Streamer, Moderatoren und Administratoren Nutzer sperren oder stummschalten."
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr "Chatbot"
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3710,17 +3637,10 @@ msgstr "Auf der Instanzebene können Administratoren jedoch den Chat für alle V
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr "Sie können den Chat sogar für bestimmte VOD-Videos aktivieren.  So funktioniert die [Demonstrationsseite](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae): Es handelt sich nicht um einen Live-Stream, aber ich habe den Chat speziell für dieses Video aktiviert."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr "Fehler (Bugs) / Neue Funktionsanfragen"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
-msgstr "Fehlerverfolgung (Bug tracking) und neue Funktionen"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3746,6 +3666,198 @@ msgstr "[Meilensteine auf Github](https://github.com/JohnXLivingston/peertube-pl
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Wenn Sie ein Webdesigner oder ein ConverseJS/Prosody/XMPP-Experte sind und helfen wollen, dieses Plugin zu verbessern, sind Sie gerne willkommen."
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "Den Autor kontaktieren"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "Kontaktieren Sie mich"
+
+#, no-wrap
+#~ msgid "Contributor Covenant Code of Conduct"
+#~ msgstr "Vereinbarung über Verhaltenskodex für Mitwirkende"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "Verhaltenskodex"
+
+#, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "Dokumentation"
+
+#, no-wrap
+#~ msgid "Give your feedback"
+#~ msgstr "Geben Sie Ihr Feedback"
+
+#, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "Beitragen"
+
+#, no-wrap
+#~ msgid "Translate the plugin"
+#~ msgstr "Das Plugin übersetzen"
+
+#, no-wrap
+#~ msgid "Translate"
+#~ msgstr "Übersätzen"
+
+#, no-wrap
+#~ msgid "Plugin Credits"
+#~ msgstr "Impressum des Plugins"
+
+#, no-wrap
+#~ msgid "Credits"
+#~ msgstr "Impressum"
+
+#, no-wrap
+#~ msgid "Some advanced features"
+#~ msgstr "Einige erweiterte Funktionen"
+
+#, no-wrap
+#~ msgid "Advanced usage"
+#~ msgstr "Fortgeschrittene Nutzung"
+
+#, no-wrap
+#~ msgid "Using Matterbridge to bridge with other chats"
+#~ msgstr "Matterbridge als Brücke zu anderen Chats nutzen"
+
+#, no-wrap
+#~ msgid "Using Matterbridge"
+#~ msgstr "Matterbridge benutzen"
+
+#, no-wrap
+#~ msgid "Allow connections using XMPP clients"
+#~ msgstr "Verbindungen über XMPP-Clients zulassen"
+
+#, no-wrap
+#~ msgid "XMPP clients"
+#~ msgstr "XMPP-Clients"
+
+#, no-wrap
+#~ msgid "Plugin Peertube Livechat administration"
+#~ msgstr "Plugin Peertube Livechat Administation"
+
+#, no-wrap
+#~ msgid "Admin documentation"
+#~ msgstr "Admin Dokumentation"
+
+#, no-wrap
+#~ msgid "Plugin Peertube Livechat settings"
+#~ msgstr "Plugin Peertube Livechat Einstellungen"
+
+#, no-wrap
+#~ msgid "Settings"
+#~ msgstr "Einstellungen"
+
+#, no-wrap
+#~ msgid "Plugin documentation"
+#~ msgstr "Plugin Dokumentation"
+
+#, no-wrap
+#~ msgid "Known issues: CPU Compatibility"
+#~ msgstr "Bekannte Probleme: CPU Kompatibilität"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat installation guide"
+#~ msgstr "Plugin peertube-plugin-livechat Installationsanleitung"
+
+#, no-wrap
+#~ msgid "Installation guide"
+#~ msgstr "Installationsanleitung"
+
+#, no-wrap
+#~ msgid "Some classic mistakes and workarounds."
+#~ msgstr "Einige klassische Fehler und Umgehungsmöglichkeiten."
+
+#, no-wrap
+#~ msgid "Important notes when upgrading for an older version."
+#~ msgstr "Wichtige Hinweise zum aktualisieren von älteren Versionen."
+
+#, no-wrap
+#~ msgid "Upgrade from version older than 6.0.0"
+#~ msgstr "Aktualisieren von Versionen vor 6.0.0"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat user documentation"
+#~ msgstr "Plugin peertube-plugin-livechat Benutzer Dokumentation"
+
+#, no-wrap
+#~ msgid "User documentation"
+#~ msgstr "Benutzer Dokumentation"
+
+#, no-wrap
+#~ msgid "Some basics"
+#~ msgstr "Einige Grundlagen"
+
+#, no-wrap
+#~ msgid "The bot can respond to several commands."
+#~ msgstr "Der Chatbot kann auf verschiedene Befehle reagieren."
+
+#, no-wrap
+#~ msgid "Commands"
+#~ msgstr "Befehle"
+
+#, no-wrap
+#~ msgid "Forbidden words"
+#~ msgstr "Verbotene Wörter"
+
+#, no-wrap
+#~ msgid "Chat bot setup"
+#~ msgstr "Chatbot Einrichtung"
+
+#, no-wrap
+#~ msgid "Timers"
+#~ msgstr "Timer"
+
+#, no-wrap
+#~ msgid "Peertube channel chatrooms configuration"
+#~ msgstr "Peertube Kanal Chaträume Konfiguration"
+
+#, no-wrap
+#~ msgid "Channel configuration"
+#~ msgstr "Kanalkonfiguration"
+
+#, no-wrap
+#~ msgid "How to setup the chat for your live stream"
+#~ msgstr "So richten Sie den Chat für Ihren Live-Stream ein"
+
+#, no-wrap
+#~ msgid "For streamers"
+#~ msgstr "Für Streamer"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat slow mode"
+#~ msgstr "Plugin peertube-plugin-livechat Langsamer Modus"
+
+#, no-wrap
+#~ msgid "Slow mode"
+#~ msgstr "Langsamer Modus"
+
+#, no-wrap
+#~ msgid "Tasks / To-do lists"
+#~ msgstr "Aufgaben / To-do-Listen"
+
+#, no-wrap
+#~ msgid "How to chat for stream viewers"
+#~ msgstr "Wie man chattet für Live-Stream Zuschauer"
+
+#, no-wrap
+#~ msgid "Connect to chat using a XMPP client"
+#~ msgstr "Verbindung zum Chat über einen XMPP-Client"
+
+#, no-wrap
+#~ msgid "XMPP Clients"
+#~ msgstr "XMPP Clients"
+
+#, no-wrap
+#~ msgid "Bug tracking / New features requests"
+#~ msgstr "Fehler (Bugs) / Neue Funktionsanfragen"
+
+#, no-wrap
+#~ msgid "Bug tracking & new features"
+#~ msgstr "Fehlerverfolgung (Bug tracking) und neue Funktionen"
 
 #~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
 #~ msgstr "Alle Instanzmoderatoren und Admins sind Eigentümer der erstellten Chaträume.  Der Eigentümer des Videos wird der Administrator des Chatraums sein."

--- a/support/documentation/po/livechat.de.po
+++ b/support/documentation/po/livechat.de.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-05-18 04:24+0000\n"
 "Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: German <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
@@ -18,97 +18,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.5.5\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
-#, fuzzy, no-wrap
-#| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr "Das Plugin wird von [John Livingston](https://www.john-livingston.fr/) betrieben."
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "Den Autor kontaktieren"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contact me"
+msgstr "Kontaktieren Sie mich"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -120,20 +40,28 @@ msgstr "Wenn Sie eine Frage haben oder über dieses Plugin sprechen möchten, k�
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Wenn Sie das Projekt finanziell unterstützen möchten, können Sie mich per E-Mail unter git.[at].john-livingston.fr kontaktieren oder mein [Liberapay-Profil](https://liberapay.com/JohnLivingston/) ansehen."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr "Vereinbarung über Verhaltenskodex für Mitwirkende"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "Verhaltenskodex"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Dieser Verhaltenskodex basiert auf dem [Contributor Covenant](https://www.contributor-covenant.org), Version 2.1, verfügbar unter [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Übersetzungen sind unter [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations) verfügbar. Fälle von beleidigendem, belästigendem oder anderweitig inakzeptablem Verhalten können den für die Durchsetzung verantwortlichen Gemeinschaftsleitern per E-Mail an git.[at].john-livingston.fr gemeldet werden."
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "Entwickeln"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -225,12 +153,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Bitte beachten Sie, dass dieses Plugin ein AppImage für den Prosody XMPP Server benötigt.  Dieses AppImage wird vom [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) Seitenprojekt bereitgestellt.  Das Skript `build-prosody.sh` lädt Binärdateien herunter, die an dieses entfernte Repository angehängt sind, und überprüft, ob ihre sha256-Hashsumme korrekt ist."
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Entwickeln"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -494,12 +416,19 @@ msgstr "Leistungstests"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "Das [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) Repository enthält einige Werkzeuge zur Durchführung von Leistungstests.  Sie können verwendet werden, um Code-Verbesserungen zu bewerten oder Engpässe zu finden."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "Document the plugin, or translate the documentation."
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+msgid "Document the plugin, or translate the documentation."
 msgstr "Dokumentieren Sie das Plugin, oder übersetzen Sie die Dokumentation."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
+msgstr "Dokumentation"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -702,30 +631,39 @@ msgstr "Veröffentlichung"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "Die Veröffentlichung der Dokumentation erfolgt automatisch, sobald die Änderungen in den `documentation` Zweig eingefügt wurden."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Give your feedback"
+msgstr "Geben Sie Ihr Feedback"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "Sie müssen keine Programmierkenntnisse haben, um zu diesem Plugin beizutragen! Andere Beiträge sind auch sehr wertvoll, darunter: Sie können die Software testen und Fehler melden, Sie können Feedback geben, Funktionen die Sie interessieren, Benutzeroberfläche, Design, ..."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributing"
+msgstr "Beitragen"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Interessiert beizutragen? Super!"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Translate the plugin"
+msgstr "Das Plugin übersetzen"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
+msgstr "Übersätzen"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -977,10 +915,17 @@ msgstr "Allgemeine Empfehlungen"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr "Bitte formulieren Sie umfassend und beachten Sie den [Verhaltenskodex](/peertube-plugin-livechat/de/contributing/codeofconduct/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Credits"
+msgstr "Impressum des Plugins"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
+msgstr "Impressum"
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -1027,25 +972,46 @@ msgstr "Vielen Dank an [Octopuce](https://www.octopuce.fr/) für die finanzielle
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr "Und vielen Dank an alle Einzelspender, die über meine [Liberapay Seite] (https://liberapay.com/JohnLivingston/) gespendet haben."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Some advanced features"
+msgstr "Einige erweiterte Funktionen"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr "Fortgeschrittene Nutzung"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr "Matterbridge als Brücke zu anderen Chats nutzen"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
+msgstr "Matterbridge benutzen"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr "Hier ist ein Tutorial um Matterbridge mit diesem Plugin zu benutzen (nur auf englisch): <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr "Verbindungen über XMPP-Clients zulassen"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
+msgstr "XMPP-Clients"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1587,9 +1553,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "Fehlerbehebung"
@@ -1599,12 +1566,19 @@ msgstr "Fehlerbehebung"
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr "Wenn Sie es nicht hinbekommen, können Sie das Diagnosetool verwenden (es gibt eine Schaltfläche oben auf der Seite mit den Plugin-Einstellungen) und sich den Abschnitt «Prosody check» genau ansehen."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, fuzzy
-#| msgid "Plugin Peertube Livechat settings - External Authentication"
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
-msgstr "Plugin Peertube Livechat Einstellungen - Externe Authentifizierung"
+#, fuzzy, no-wrap
+#| msgid "Plugin Peertube Livechat settings"
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr "Plugin Peertube Livechat Einstellungen"
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
+msgstr "Externe Authentifizierung"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1771,15 +1745,29 @@ msgstr "Weiteres folgt"
 msgid "Other authentication methods will be implemented in the future."
 msgstr "Andere Authentifizierungsmethoden werden in Zukunft implementiert werden."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
+msgstr "Plugin Peertube Livechat Administation"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr "Admin Dokumentation"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr "Plugin Peertube Livechat Einstellungen"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
+msgstr "Einstellungen"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1802,12 +1790,6 @@ msgstr "Föderation"
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
 msgstr "Die folgenden Einstellungen betreffen die Föderation mit anderen Peertube Instanzen und anderer Fediverse-Software."
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
-msgstr "Externe Authentifizierung"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2026,17 +2008,24 @@ msgstr "Diese Funktion könnte für die Verbindung von Brücken oder Bots genutz
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr "Weitere Informationen zu den externen Komponenten von Prosody finden Sie [hier](https://prosody.im/doc/components)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin documentation"
+msgstr "Plugin Dokumentation"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr "Derzeit funktioniert das Plugin standartmäßig nur für x86_64 CPU Architekturen. Hier sind einige Anleitungen für andere CPU Architekturen."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
+msgstr "Bekannte Probleme: CPU Kompatibilität"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -2150,10 +2139,17 @@ msgstr "Dies wird bereits von der Yunohost Peertube Anwendung gemacht, da es fü
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr "Es kann aber sein, dass es in naher Zukunft entfernt wird (um die Nachteile dieser Methode zu vermeiden). Ich muss mit dem Yunohost Team diskutieren, um zu entscheiden, wie wir die Nachteile minimieren können, und die Kompatibilität zu maximieren."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr "Plugin peertube-plugin-livechat Installationsanleitung"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
+msgstr "Installationsanleitung"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
@@ -2171,10 +2167,11 @@ msgstr "Um das Plugin zu installieren oder zu aktualisieren **einfach das Peertu
 msgid "Here are some other more specific instructions:"
 msgstr "Hier sind weitere, spezifischere Anweisungen:"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
+msgstr "Einige klassische Fehler und Umgehungsmöglichkeiten."
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2267,10 +2264,17 @@ msgstr "Sie können bestätigen, dass es sich um ein Websocket-Problem handelt, 
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr "Wenn Sie dies nicht sofort beheben können, können Sie Websocket deaktivieren, indem Sie das Häkchen bei \"{{% livechat_label disable_websocket_label %}}\" auf der Plugin Einstellungsseite entfernen.  In diesem Fall sollten Sie auch das Häkchen bei \"{{% livechat_label federation_dont_publish_remotely_label %}}\" setzen, da die Chat-Föderation ohne Websocket nicht funktioniert."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr "Wichtige Hinweise zum aktualisieren von älteren Versionen."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
+msgstr "Aktualisieren von Versionen vor 6.0.0"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -2293,19 +2297,30 @@ msgstr "Falls Sie dieses Plugin vor dieser Version benutzt haben und Sie Prosody
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr "Falls Sie ein eigenes Peertube Docker Paket genutzt haben, welches Prosody eingebettet hatte, können Sie zu den offiziellen Peertube Paketen zurück wechseln."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-#, fuzzy
-#| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
-msgstr "Für die Benutzerdokumentation, siehe [Benutzerdokumentation](/peertube-plugin-livechat/de/documentation/user/viewers/)"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
+msgstr "Plugin peertube-plugin-livechat Benutzer Dokumentation"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr "Benutzer Dokumentation"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "Documentation to stream the chat content using OBS."
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+msgid "Documentation to stream the chat content using OBS."
 msgstr "Dokumentation zum Streamen des Chat-Inhalts mit OBS."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2391,12 +2406,18 @@ msgstr "Mischen mehrerer Chats in Ihrem Live-Stream"
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr "Sie können die [social_stream Browsererweiterung](https://github.com/steveseguin/social_stream#readme) verwenden, um mehrere Chat-Quellen (von Peertube, Twitch, Youtube, Facebook, ...) zu mischen und deren Inhalte in Ihren Live-Stream einzubinden. Die Kompatibilität mit diesem Plugin wurde in den letzten Versionen hinzugefügt."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, fuzzy
-#| msgid "Some basics about how to setup and use the chat for your live stream"
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
-msgstr "Einige grundlegende Informationen zur Einrichtung und Nutzung des Chats für Ihren Livestream"
+#, fuzzy, no-wrap
+#| msgid "How to setup the chat for your live stream"
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr "So richten Sie den Chat für Ihren Live-Stream ein"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
+msgstr "Einige Grundlagen"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2488,6 +2509,7 @@ msgstr "Das \"{{% livechat_label share_chat_link %}}\" Popup-Fenster kann auch e
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2574,10 +2596,17 @@ msgstr "Wenn Sie den Inhalt des Chats löschen möchten, [öffnen Sie deas Dropd
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr "Der Chat wird automatisch neu erstellt, wenn jemand versucht, ihm beizutreten, solange das Video existiert und die Funktion \"{{% livechat_label use_chat %}}\" aktiviert ist."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr "Der Chatbot kann auf verschiedene Befehle reagieren."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
+msgstr "Befehle"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
@@ -2589,12 +2618,18 @@ msgstr "![Befehlskonfiguration](/peertube-plugin-livechat/images/bot_commands.pn
 msgid "You can setup several commands."
 msgstr "Sie können mehrere Befehle einrichten."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "The bot can automatically moderate messages containing forbidden words."
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+msgid "The bot can automatically moderate messages containing forbidden words."
 msgstr "Der Chatbot kann automatisch Nachrichten moderieren, die verbotene Wörter enthalten."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
+msgstr "Verbotene Wörter"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
@@ -2651,10 +2686,18 @@ msgstr "Diese Funktion ist noch experimentell.  Es könnte einige Probleme mit n
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr "Wenn Sie diese Option aktivieren, wird jede Zeile des Feldes \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" als [regulärer Ausdruck](https://de.wikipedia.org/wiki/Regul%C3%A4rer_Ausdruck) betrachtet."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Chat bot setup"
+msgstr "Chatbot Einrichtung"
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr "Chatbot"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2688,12 +2731,18 @@ msgstr "Dort können Sie den Chatbot aktivieren und verschiedene Optionen einste
 msgid "The bot will reload instantly when you save the page."
 msgstr "Der Chatbot wird sofort neu geladen, wenn Sie die Seite speichern."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, fuzzy
-#| msgid "The bot can send periodically some messages."
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
-msgstr "Der Chatbot kann in regelmäßigen Abständen einige Nachrichten senden."
+#, fuzzy, no-wrap
+#| msgid "The bot can respond to several commands."
+msgid "The bot can send periodically some messages."
+msgstr "Der Chatbot kann auf verschiedene Befehle reagieren."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
+msgstr "Timer"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
@@ -2705,10 +2754,17 @@ msgstr "Wenn sich kein Benutzer im Chatraum befindet, sendet der Chatbot keine N
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "[Konfiguration der Timer](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr "Peertube Kanal Chaträume Konfiguration"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
+msgstr "Kanalkonfiguration"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2745,17 +2801,24 @@ msgstr "[Den Chatbot](/peertube-plugin-livechat/de/documentation/user/streamers/
 msgid "More features to come..."
 msgstr "Weitere Funktionen werden folgen..."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "How to setup the chat for your live stream"
+msgstr "So richten Sie den Chat für Ihren Live-Stream ein"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr "Für Streamer"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, fuzzy
-#| msgid "Plugin peertube-plugin-livechat advanced moderation features"
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
-msgstr "Plugin peertube-plugin-livechat Erweiterte Moderationsfunktionen"
+#, fuzzy, no-wrap
+#| msgid "Plugin peertube-plugin-livechat installation guide"
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgstr "Plugin peertube-plugin-livechat Installationsanleitung"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2857,19 +2920,27 @@ msgstr "Sie können alle bestehenden Chaträume auflisten: in den Einstellungen 
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr "Von dort aus kannst du dich auch als Moderator des Raums bewerben, indem du die Schaltfläche \"{{% livechat_label promote %}}\" auf der rechten Seite benutzt."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr "Plugin peertube-plugin-livechat Langsamer Modus"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
+msgstr "Langsamer Modus"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr "Diese Funktion wird mit dem Livechatplugin Version 8.3.0 verfügbar sein."
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "Einführung"
@@ -2940,8 +3011,9 @@ msgstr "Wenn Sie den Wert auf eine positive ganze Zahl setzen, wird der Zeitraum
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr "Um den Wert für einen bereits existierenden Raum zu ändern, öffnen Sie einfach das Raum-Konfigurationsmenü (oben im Chatfenster) und ändern Sie den Wert für den langsamen Modus im Konfigurationsformular."
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr "Für Zuschauer"
@@ -2961,12 +3033,18 @@ msgstr "![Infobox Langsamer Modus](/peertube-plugin-livechat/images/slow_mode.pn
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr "Wenn sie eine Nachricht senden, wird das Eingabefeld für X Sekunden deaktiviert (wobei X die Dauer des langsamen Modus ist)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "You can handle tasks and task lists with your moderation team."
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+msgid "You can handle tasks and task lists with your moderation team."
 msgstr "Sie können Aufgaben und Aufgabenlisten mit Ihrem Moderationsteam bearbeiten."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
+msgstr "Aufgaben / To-do-Listen"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3192,10 +3270,11 @@ msgstr "![Aufgabe erstellt](/peertube-plugin-livechat/images/task_from_message_3
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr "Mit dieser Funktion können Sie z. B. Ihre Moderatoren bitten, alle Chat-Fragen zu markieren, damit Sie sie während Ihres Livestreams auf einen Blick sehen und als beantwortet markieren können."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "How to chat for stream viewers"
+msgstr "Wie man chattet für Live-Stream Zuschauer"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -3400,10 +3479,17 @@ msgstr "Sie können Ihren Spitznamen ändern, indem Sie `/nick ihr_neuer_spitzna
 msgid "You can also change your nickname using the chat menu."
 msgstr "Sie können Ihren Spitznamen auch über das Chatmenü ändern."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr "Verbindung zum Chat über einen XMPP-Client"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
+msgstr "XMPP Clients"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -3480,11 +3566,6 @@ msgstr "Um einen Einblick in die Fähigkeiten dieses Plugins zu bekommen, schaue
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
 msgstr "Sie können das Suchfeld im linken Menü verwenden, um bestimmte Teile der Dokumentation schnell zu finden."
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
-msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/intro/_index.md
@@ -3569,12 +3650,6 @@ msgstr "Damit der Zusammenschluss funktioniert, muss das Plugin natürlich auf b
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr "Manchmal muss man seine Community vor bösen Menschen schützen.  Als Instanzadministrator können Sie die Föderation für das Livechat-Plugin deaktivieren.  Wenn sich entfernte Akteure schlecht benehmen, können Streamer, Moderatoren und Administratoren Nutzer sperren oder stummschalten."
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr "Chatbot"
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3637,10 +3712,17 @@ msgstr "Auf der Instanzebene können Administratoren jedoch den Chat für alle V
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr "Sie können den Chat sogar für bestimmte VOD-Videos aktivieren.  So funktioniert die [Demonstrationsseite](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae): Es handelt sich nicht um einen Live-Stream, aber ich habe den Chat speziell für dieses Video aktiviert."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr "Fehler (Bugs) / Neue Funktionsanfragen"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
+msgstr "Fehlerverfolgung (Bug tracking) und neue Funktionen"
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3667,197 +3749,37 @@ msgstr "[Meilensteine auf Github](https://github.com/JohnXLivingston/peertube-pl
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Wenn Sie ein Webdesigner oder ein ConverseJS/Prosody/XMPP-Experte sind und helfen wollen, dieses Plugin zu verbessern, sind Sie gerne willkommen."
 
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "Den Autor kontaktieren"
+#, fuzzy, no-wrap
+#~| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
+#~ msgid ""
+#~ "<!--\n"
+#~ "SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+#~ msgstr "Das Plugin wird von [John Livingston](https://www.john-livingston.fr/) betrieben."
 
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "Kontaktieren Sie mich"
+#, fuzzy
+#~| msgid "Plugin Peertube Livechat settings - External Authentication"
+#~ msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#~ msgstr "Plugin Peertube Livechat Einstellungen - Externe Authentifizierung"
 
-#, no-wrap
-#~ msgid "Contributor Covenant Code of Conduct"
-#~ msgstr "Vereinbarung über Verhaltenskodex für Mitwirkende"
+#, fuzzy
+#~| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
+#~ msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#~ msgstr "Für die Benutzerdokumentation, siehe [Benutzerdokumentation](/peertube-plugin-livechat/de/documentation/user/viewers/)"
 
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "Verhaltenskodex"
+#, fuzzy
+#~| msgid "Some basics about how to setup and use the chat for your live stream"
+#~ msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#~ msgstr "Einige grundlegende Informationen zur Einrichtung und Nutzung des Chats für Ihren Livestream"
 
-#, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "Dokumentation"
+#, fuzzy
+#~| msgid "The bot can send periodically some messages."
+#~ msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#~ msgstr "Der Chatbot kann in regelmäßigen Abständen einige Nachrichten senden."
 
-#, no-wrap
-#~ msgid "Give your feedback"
-#~ msgstr "Geben Sie Ihr Feedback"
-
-#, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "Beitragen"
-
-#, no-wrap
-#~ msgid "Translate the plugin"
-#~ msgstr "Das Plugin übersetzen"
-
-#, no-wrap
-#~ msgid "Translate"
-#~ msgstr "Übersätzen"
-
-#, no-wrap
-#~ msgid "Plugin Credits"
-#~ msgstr "Impressum des Plugins"
-
-#, no-wrap
-#~ msgid "Credits"
-#~ msgstr "Impressum"
-
-#, no-wrap
-#~ msgid "Some advanced features"
-#~ msgstr "Einige erweiterte Funktionen"
-
-#, no-wrap
-#~ msgid "Advanced usage"
-#~ msgstr "Fortgeschrittene Nutzung"
-
-#, no-wrap
-#~ msgid "Using Matterbridge to bridge with other chats"
-#~ msgstr "Matterbridge als Brücke zu anderen Chats nutzen"
-
-#, no-wrap
-#~ msgid "Using Matterbridge"
-#~ msgstr "Matterbridge benutzen"
-
-#, no-wrap
-#~ msgid "Allow connections using XMPP clients"
-#~ msgstr "Verbindungen über XMPP-Clients zulassen"
-
-#, no-wrap
-#~ msgid "XMPP clients"
-#~ msgstr "XMPP-Clients"
-
-#, no-wrap
-#~ msgid "Plugin Peertube Livechat administration"
-#~ msgstr "Plugin Peertube Livechat Administation"
-
-#, no-wrap
-#~ msgid "Admin documentation"
-#~ msgstr "Admin Dokumentation"
-
-#, no-wrap
-#~ msgid "Plugin Peertube Livechat settings"
-#~ msgstr "Plugin Peertube Livechat Einstellungen"
-
-#, no-wrap
-#~ msgid "Settings"
-#~ msgstr "Einstellungen"
-
-#, no-wrap
-#~ msgid "Plugin documentation"
-#~ msgstr "Plugin Dokumentation"
-
-#, no-wrap
-#~ msgid "Known issues: CPU Compatibility"
-#~ msgstr "Bekannte Probleme: CPU Kompatibilität"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat installation guide"
-#~ msgstr "Plugin peertube-plugin-livechat Installationsanleitung"
-
-#, no-wrap
-#~ msgid "Installation guide"
-#~ msgstr "Installationsanleitung"
-
-#, no-wrap
-#~ msgid "Some classic mistakes and workarounds."
-#~ msgstr "Einige klassische Fehler und Umgehungsmöglichkeiten."
-
-#, no-wrap
-#~ msgid "Important notes when upgrading for an older version."
-#~ msgstr "Wichtige Hinweise zum aktualisieren von älteren Versionen."
-
-#, no-wrap
-#~ msgid "Upgrade from version older than 6.0.0"
-#~ msgstr "Aktualisieren von Versionen vor 6.0.0"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat user documentation"
-#~ msgstr "Plugin peertube-plugin-livechat Benutzer Dokumentation"
-
-#, no-wrap
-#~ msgid "User documentation"
-#~ msgstr "Benutzer Dokumentation"
-
-#, no-wrap
-#~ msgid "Some basics"
-#~ msgstr "Einige Grundlagen"
-
-#, no-wrap
-#~ msgid "The bot can respond to several commands."
-#~ msgstr "Der Chatbot kann auf verschiedene Befehle reagieren."
-
-#, no-wrap
-#~ msgid "Commands"
-#~ msgstr "Befehle"
-
-#, no-wrap
-#~ msgid "Forbidden words"
-#~ msgstr "Verbotene Wörter"
-
-#, no-wrap
-#~ msgid "Chat bot setup"
-#~ msgstr "Chatbot Einrichtung"
-
-#, no-wrap
-#~ msgid "Timers"
-#~ msgstr "Timer"
-
-#, no-wrap
-#~ msgid "Peertube channel chatrooms configuration"
-#~ msgstr "Peertube Kanal Chaträume Konfiguration"
-
-#, no-wrap
-#~ msgid "Channel configuration"
-#~ msgstr "Kanalkonfiguration"
-
-#, no-wrap
-#~ msgid "How to setup the chat for your live stream"
-#~ msgstr "So richten Sie den Chat für Ihren Live-Stream ein"
-
-#, no-wrap
-#~ msgid "For streamers"
-#~ msgstr "Für Streamer"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat slow mode"
-#~ msgstr "Plugin peertube-plugin-livechat Langsamer Modus"
-
-#, no-wrap
-#~ msgid "Slow mode"
-#~ msgstr "Langsamer Modus"
-
-#, no-wrap
-#~ msgid "Tasks / To-do lists"
-#~ msgstr "Aufgaben / To-do-Listen"
-
-#, no-wrap
-#~ msgid "How to chat for stream viewers"
-#~ msgstr "Wie man chattet für Live-Stream Zuschauer"
-
-#, no-wrap
-#~ msgid "Connect to chat using a XMPP client"
-#~ msgstr "Verbindung zum Chat über einen XMPP-Client"
-
-#, no-wrap
-#~ msgid "XMPP Clients"
-#~ msgstr "XMPP Clients"
-
-#, no-wrap
-#~ msgid "Bug tracking / New features requests"
-#~ msgstr "Fehler (Bugs) / Neue Funktionsanfragen"
-
-#, no-wrap
-#~ msgid "Bug tracking & new features"
-#~ msgstr "Fehlerverfolgung (Bug tracking) und neue Funktionen"
+#, fuzzy
+#~| msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#~ msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#~ msgstr "Plugin peertube-plugin-livechat Erweiterte Moderationsfunktionen"
 
 #~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
 #~ msgstr "Alle Instanzmoderatoren und Admins sind Eigentümer der erstellten Chaträume.  Der Eigentümer des Videos wird der Administrator des Chatraums sein."

--- a/support/documentation/po/livechat.el.po
+++ b/support/documentation/po/livechat.el.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/el/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.el.po
+++ b/support/documentation/po/livechat.el.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/el/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.en.pot
+++ b/support/documentation/po/livechat.en.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,16 +16,96 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
-#, no-wrap
-msgid "Contact the author"
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
+#, markdown-text, no-wrap
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
-#, no-wrap
-msgid "Contact me"
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
+#, markdown-text, no-wrap
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+#, markdown-text
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -40,16 +120,10 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+#, markdown-text
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -58,10 +132,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, markdown-text, no-wrap
-msgid "Develop"
+#, markdown-text
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -160,10 +234,22 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+#, markdown-text
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 #, markdown-text
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, markdown-text, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -225,6 +311,12 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+#, markdown-text
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -426,17 +518,10 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+#, markdown-text
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -667,10 +752,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+#, markdown-text
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -679,10 +764,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+#, markdown-text
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -691,16 +776,10 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+#, markdown-text
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -980,16 +1059,10 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+#, markdown-text
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1046,28 +1119,16 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+#, markdown-text
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+#, markdown-text
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1076,16 +1137,10 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+#, markdown-text
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1667,10 +1722,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, markdown-text, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1681,17 +1735,10 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, markdown-text, no-wrap
-msgid "External Authentication"
+#, markdown-text
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1884,28 +1931,16 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+#, markdown-text
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+#, markdown-text
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1931,6 +1966,12 @@ msgstr ""
 #: build/documentation/pot_in/documentation/admin/settings.md
 #, markdown-text
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, markdown-text, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -2182,22 +2223,16 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+#, markdown-text
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+#, markdown-text
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2319,16 +2354,10 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+#, markdown-text
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2350,10 +2379,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+#, markdown-text
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2458,16 +2487,10 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+#, markdown-text
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2494,28 +2517,16 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+#, markdown-text
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+#, markdown-text
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2614,16 +2625,10 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+#, markdown-text
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2730,7 +2735,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, markdown-text, no-wrap
 msgid "Moderation"
@@ -2829,16 +2833,10 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+#, markdown-text
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2853,16 +2851,10 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+#, markdown-text
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2931,17 +2923,10 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, markdown-text, no-wrap
-msgid "Chat bot"
+#, markdown-text
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2982,16 +2967,10 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+#, markdown-text
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3006,16 +2985,10 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+#, markdown-text
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3060,22 +3033,16 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+#, markdown-text
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#, markdown-text
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3188,16 +3155,10 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+#, markdown-text
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3206,10 +3167,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, markdown-text, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -3292,9 +3252,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, markdown-text, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -3317,16 +3276,10 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+#, markdown-text
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3587,10 +3540,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+#, markdown-text
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3824,16 +3777,10 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+#, markdown-text
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3924,6 +3871,12 @@ msgstr ""
 #: support/documentation/content/en/_index.md
 #, markdown-text
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+#, markdown-text
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -4022,6 +3975,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, markdown-text, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 #, markdown-text
@@ -4094,16 +4053,10 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+#, markdown-text
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.en.pot
+++ b/support/documentation/po/livechat.en.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,96 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
-#, markdown-text, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+#, no-wrap
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
-#, markdown-text, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-#, markdown-text
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+#, no-wrap
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -120,10 +40,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, markdown-text
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -132,10 +58,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-#, markdown-text
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, markdown-text, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -244,12 +170,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, markdown-text
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, markdown-text, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -518,10 +438,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-#, markdown-text
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -752,10 +679,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, markdown-text
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -764,10 +691,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-#, markdown-text
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -776,10 +703,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-#, markdown-text
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -1059,10 +992,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-#, markdown-text
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -1119,16 +1058,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, markdown-text
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, markdown-text
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1137,10 +1088,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, markdown-text
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1722,9 +1679,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, markdown-text, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1735,10 +1693,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, markdown-text
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, markdown-text, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1931,16 +1896,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-#, markdown-text
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, markdown-text
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1966,12 +1943,6 @@ msgstr ""
 #: build/documentation/pot_in/documentation/admin/settings.md
 #, markdown-text
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, markdown-text, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -2223,16 +2194,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-#, markdown-text
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, markdown-text
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2354,10 +2331,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-#, markdown-text
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2379,10 +2362,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, markdown-text
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2487,10 +2470,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, markdown-text
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2517,16 +2506,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-#, markdown-text
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-#, markdown-text
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2625,10 +2626,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, markdown-text
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2735,6 +2742,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, markdown-text, no-wrap
 msgid "Moderation"
@@ -2833,10 +2841,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, markdown-text
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2865,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, markdown-text
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2923,10 +2943,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, markdown-text
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, markdown-text, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2967,10 +2994,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, markdown-text
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2985,10 +3018,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, markdown-text
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -3033,16 +3072,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, markdown-text
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, markdown-text
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -3155,10 +3200,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, markdown-text
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -3167,9 +3218,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, markdown-text, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -3252,8 +3304,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, markdown-text, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -3276,10 +3329,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, markdown-text
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3540,10 +3599,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-#, markdown-text
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3777,10 +3836,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, markdown-text
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3871,12 +3936,6 @@ msgstr ""
 #: support/documentation/content/en/_index.md
 #, markdown-text
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-#, markdown-text
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3975,12 +4034,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, markdown-text, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 #, markdown-text
@@ -4053,10 +4106,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-#, markdown-text
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.eo.po
+++ b/support/documentation/po/livechat.eo.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eo/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.eo.po
+++ b/support/documentation/po/livechat.eo.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eo/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.es.po
+++ b/support/documentation/po/livechat.es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-04-16 21:38+0000\n"
 "Last-Translator: rnek0 <rnek0@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Spanish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/es/>\n"
@@ -17,17 +17,96 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.4.3\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
-msgstr "Contacta con el autor"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "Contáctame"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -39,28 +118,20 @@ msgstr "Si tiene alguna pregunta o si desea hablar sobre este plugin, puede unir
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Si quieres apoyar financieramente el proyecto, puedes contactarme por correo electrónico en git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr "Código de Conducta para contribuyentes"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "Código de Conducta"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, disponible en [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Las traducciones están a disposición en [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Los casos de comportamiento abusivo, acosador o inaceptable se pueden informar a los líderes de la comunidad responsables de la aplicación por correo en git.[at].john-livingston.fr."
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Desarrollar"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -143,10 +214,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Tenga en cuenta que este plugin necesita una AppImage para el servidor Prosody XMPP.  Esa AppImage la proporciona el proyecto paralelo [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage).  El script `build-prosody.sh` descarga los binarios adjuntos de ese repositorio remoto y verifica que sus checksum sha256 sean correctos."
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "Desarrollar"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -221,6 +303,11 @@ msgstr "Puede generar el plugin con características adicionales de depuración 
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -405,18 +492,12 @@ msgstr "Pruebas de rendimiento"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "El repositorio [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) contiene algunas herramientas para realizar pruebas de rendimiento.  Se puede utilizar para evaluar mejoras de código, o encontrar cuellos de botella."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+#, fuzzy
+#| msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr "Documente el plugin o traduzca la documentación."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
-msgstr "Documentación"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -619,39 +700,30 @@ msgstr "Publicación"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "La publicación de la documentación es automátizada cuando los cambios se fusionan en la rama `documentation`."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
-msgstr "Envianos tu feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "No necesitas saber programar para empezar a contribuir al desarrollo de este plugin. Otras contribuciones son igualmente muy valiosas, tales como: probar el software y reportar bugs, dar feedback, comentar sobre características que te interesen o sobre la interfaz de usuario, el diseño, ..."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
-msgstr "Contribuir"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "¿Interesado en contribuir? ¡Estupendo!"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr "Traducir el plugin"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
-msgstr "Traducir"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -897,16 +969,9 @@ msgstr "Información general"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -954,28 +1019,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -983,16 +1034,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1513,10 +1557,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1526,17 +1569,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1704,28 +1739,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1748,6 +1769,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1964,22 +1991,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2089,16 +2108,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2117,10 +2129,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2214,16 +2225,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2247,28 +2251,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2355,16 +2345,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2457,7 +2440,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2544,16 +2526,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2566,16 +2541,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2633,17 +2601,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2678,16 +2638,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2700,18 +2653,10 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, fuzzy, no-wrap
-#| msgid "General information"
-msgid "Channel configuration"
-msgstr "Información general"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2748,22 +2693,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2864,16 +2801,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2881,10 +2811,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2955,9 +2884,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2977,16 +2905,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3213,10 +3134,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3422,16 +3342,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3508,6 +3421,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3594,6 +3512,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3656,16 +3580,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3692,6 +3609,47 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "Contacta con el autor"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "Contáctame"
+
+#, no-wrap
+#~ msgid "Contributor Covenant Code of Conduct"
+#~ msgstr "Código de Conducta para contribuyentes"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "Código de Conducta"
+
+#, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "Documentación"
+
+#, no-wrap
+#~ msgid "Give your feedback"
+#~ msgstr "Envianos tu feedback"
+
+#, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "Contribuir"
+
+#, no-wrap
+#~ msgid "Translate the plugin"
+#~ msgstr "Traducir el plugin"
+
+#, no-wrap
+#~ msgid "Translate"
+#~ msgstr "Traducir"
+
+#, fuzzy, no-wrap
+#~| msgid "General information"
+#~ msgid "Channel configuration"
+#~ msgstr "Información general"
 
 #~ msgid "The plugin needs to build an AppImage for the Prosody XMPP server.  It appears that the way this AppImage is build requires `apt` and `dpkg` commands.  So it will only work \"out of the box\" on Debian-like systems.  If you are using another Linux distribution, you can try to install `apt` and `dpkg` manually.  See for example this [Github issue](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/200).  We will provide another solution as soon as possible."
 #~ msgstr "El plugin necesita construir una AppImage para el servidor XMPP Prosody .  Al parecer la forma en que se construye esta AppImage requiere los comandos `apt` y `dpkg`.  Así que sólo funcionará \"out of the box\" en sistemas tipo Debian.  Si utiliza otra distribución de Linux, puede intentar instalar `apt` y `dpkg` manualmente.  Vea por ejemplo este [Issue de Github](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/200).  Proporcionaremos otra solución lo antes posible."

--- a/support/documentation/po/livechat.es.po
+++ b/support/documentation/po/livechat.es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-04-16 21:38+0000\n"
 "Last-Translator: rnek0 <rnek0@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Spanish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/es/>\n"
@@ -17,96 +17,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.4.3\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "Contacta con el autor"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+msgid "Contact me"
+msgstr "Contáctame"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -118,20 +39,28 @@ msgstr "Si tiene alguna pregunta o si desea hablar sobre este plugin, puede unir
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Si quieres apoyar financieramente el proyecto, puedes contactarme por correo electrónico en git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr "Código de Conducta para contribuyentes"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "Código de Conducta"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, disponible en [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Las traducciones están a disposición en [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Los casos de comportamiento abusivo, acosador o inaceptable se pueden informar a los líderes de la comunidad responsables de la aplicación por correo en git.[at].john-livingston.fr."
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "Desarrollar"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -223,12 +152,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Tenga en cuenta que este plugin necesita una AppImage para el servidor Prosody XMPP.  Esa AppImage la proporciona el proyecto paralelo [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage).  El script `build-prosody.sh` descarga los binarios adjuntos de ese repositorio remoto y verifica que sus checksum sha256 sean correctos."
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Desarrollar"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -492,12 +415,19 @@ msgstr "Pruebas de rendimiento"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "El repositorio [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) contiene algunas herramientas para realizar pruebas de rendimiento.  Se puede utilizar para evaluar mejoras de código, o encontrar cuellos de botella."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "Document the plugin, or translate the documentation."
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+msgid "Document the plugin, or translate the documentation."
 msgstr "Documente el plugin o traduzca la documentación."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
+msgstr "Documentación"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -700,30 +630,39 @@ msgstr "Publicación"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "La publicación de la documentación es automátizada cuando los cambios se fusionan en la rama `documentation`."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Give your feedback"
+msgstr "Envianos tu feedback"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "No necesitas saber programar para empezar a contribuir al desarrollo de este plugin. Otras contribuciones son igualmente muy valiosas, tales como: probar el software y reportar bugs, dar feedback, comentar sobre características que te interesen o sobre la interfaz de usuario, el diseño, ..."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributing"
+msgstr "Contribuir"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "¿Interesado en contribuir? ¡Estupendo!"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Translate the plugin"
+msgstr "Traducir el plugin"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
+msgstr "Traducir"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -969,9 +908,16 @@ msgstr "Información general"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -1019,14 +965,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1034,9 +994,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1557,9 +1524,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1569,9 +1537,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1739,14 +1715,29 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "Admin documentation"
+msgstr "Redactar la documentación"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1769,12 +1760,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1991,14 +1976,23 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "Plugin documentation"
+msgstr "Redactar la documentación"
+
+#. type: Yaml Front Matter Hash Value: description
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2108,10 +2102,18 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, fuzzy, no-wrap
+#| msgid "Translations"
+msgid "Installation guide"
+msgstr "Traducciones"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
@@ -2129,9 +2131,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2225,9 +2228,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2251,14 +2261,29 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "User documentation"
+msgstr "Redactar la documentación"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2345,9 +2370,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2440,6 +2472,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2526,9 +2559,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2541,9 +2581,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2601,9 +2648,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2638,9 +2693,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2653,10 +2715,19 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "General information"
+msgid "Peertube channel chatrooms configuration"
+msgstr "Información general"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, fuzzy, no-wrap
+#| msgid "General information"
+msgid "Channel configuration"
+msgstr "Información general"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2693,14 +2764,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2801,9 +2880,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2811,9 +2897,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2884,8 +2971,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2905,9 +2993,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3134,9 +3229,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3342,9 +3438,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3421,11 +3524,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3512,12 +3610,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3580,9 +3672,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text
@@ -3609,47 +3708,6 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
-
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "Contacta con el autor"
-
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "Contáctame"
-
-#, no-wrap
-#~ msgid "Contributor Covenant Code of Conduct"
-#~ msgstr "Código de Conducta para contribuyentes"
-
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "Código de Conducta"
-
-#, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "Documentación"
-
-#, no-wrap
-#~ msgid "Give your feedback"
-#~ msgstr "Envianos tu feedback"
-
-#, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "Contribuir"
-
-#, no-wrap
-#~ msgid "Translate the plugin"
-#~ msgstr "Traducir el plugin"
-
-#, no-wrap
-#~ msgid "Translate"
-#~ msgstr "Traducir"
-
-#, fuzzy, no-wrap
-#~| msgid "General information"
-#~ msgid "Channel configuration"
-#~ msgstr "Información general"
 
 #~ msgid "The plugin needs to build an AppImage for the Prosody XMPP server.  It appears that the way this AppImage is build requires `apt` and `dpkg` commands.  So it will only work \"out of the box\" on Debian-like systems.  If you are using another Linux distribution, you can try to install `apt` and `dpkg` manually.  See for example this [Github issue](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/200).  We will provide another solution as soon as possible."
 #~ msgstr "El plugin necesita construir una AppImage para el servidor XMPP Prosody .  Al parecer la forma en que se construye esta AppImage requiere los comandos `apt` y `dpkg`.  Así que sólo funcionará \"out of the box\" en sistemas tipo Debian.  Si utiliza otra distribución de Linux, puede intentar instalar `apt` y `dpkg` manualmente.  Vea por ejemplo este [Issue de Github](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/200).  Proporcionaremos otra solución lo antes posible."

--- a/support/documentation/po/livechat.eu.po
+++ b/support/documentation/po/livechat.eu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eu/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.eu.po
+++ b/support/documentation/po/livechat.eu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eu/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.fa.po
+++ b/support/documentation/po/livechat.fa.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fa/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.fa.po
+++ b/support/documentation/po/livechat.fa.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fa/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.fi.po
+++ b/support/documentation/po/livechat.fi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fi/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.fi.po
+++ b/support/documentation/po/livechat.fi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fi/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.fr.po
+++ b/support/documentation/po/livechat.fr.po
@@ -7,11 +7,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-05-17 16:40+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
-"Language-Team: French <https://weblate.framasoft.org/projects/"
-"peertube-livechat/peertube-plugin-livechat-documentation/fr/>\n"
+"Language-Team: French <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,17 +18,97 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Weblate 5.5.5\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
-#, no-wrap
-msgid "Contact the author"
-msgstr "Contacter l'auteur"
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
+#, fuzzy, no-wrap
+#| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr "Le plugin est maintenu par [John Livingston](https://www.john-livingston.fr/)."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "Me contacter"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -41,28 +120,20 @@ msgstr "Si vous avez des questions ou souhaitez parler de ce plugin, vous pouvez
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Si vous souhaitez supporter le projet financièrement, vous pouvez me contacter par mail à l'adresse git.[arobase].john-livingston.fr, ou passer par mon [profil Liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr "Convention de Code de conduite Contributeur⋅rices"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "Code de conduite"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Ce code de conduite est adapté du [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, disponible à l'adresse [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Les traductions sont disponibles à l'adresse [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Les cas de comportements abusifs, harcelants ou tout autre comportement inacceptables peuvent être signalés aux dirigeant·e·s de la communauté responsables de l’application du code de conduite à git.[at].john-livingston.fr."
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Développer"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -145,10 +216,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Veuillez noter que ce plugin a besoin d'une AppImage du serveur XMPP Prosody. Cette AppImage est fournie par le project [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage). Le script `build-prosody.sh` télécharge les binaires attachés à ce dépôt distant, et vérifie que les sommes de contrôles sha256 sont correctes."
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "Développer"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -224,6 +306,11 @@ msgstr "Vous pouvez *builder* le plugin avec des infos de debug supplémentaires
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
 msgstr "NODE_ENV=dev npm run build\n"
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -407,18 +494,12 @@ msgstr "Tests de performance"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "Le dépôt [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) contient quelques outils pour effectuer des tests de performance. Ils peuvent être utilisés pour évaluer les améliorations du code source, ou trouver les goulots d'étranglement."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+#, fuzzy
+#| msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr "Documenter le plugin, ou traduire la documentation."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
-msgstr "Documentation"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -621,39 +702,30 @@ msgstr "Publication"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "La publication de la documentation est automatique, dès que les modifications sont fusionnées dans la branche `documentation`."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
-msgstr "Donnez vos retours"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "Vous n'avez pas besoin de coder pour commencer à contribuer à ce plugin ! Les autres formes de contributions sont également précieuses, parmis lesquelles : vous pouvez tester le plugin et remonter les bugs que vous rencontrez, partager vos retours d'expérience, proposer des fonctionnalités qui vous intéressent, remonter vos remarques sur l'interface, le design, etc."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
-msgstr "Contribuer"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Intéressé⋅e pour contribuer ? Super !"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr "Traduire le plugin"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
-msgstr "Traduction"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -905,17 +977,10 @@ msgstr "Recommandations génériques"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr "Merci d'être inclusif⋅ve dans vos phrasés, et merci de respecter le [code de conduite](/peertube-plugin-livechat/contributing/codeofconduct/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr "Crédits pour le plugin"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
-msgstr "Crédits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -962,46 +1027,25 @@ msgstr "Merci à [Octopuce](https://www.octopuce.fr/) pour le support financier.
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr "Et merci à toustes les contributeur⋅rices individuel⋅les qui ont fait un don via ma [page liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
-msgstr "Quelques fonctionnalités avancées"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr "Usage avancé"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr "Utiliser Matterbridge pour faire un pont vers d'autres tchats"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
-msgstr "Utiliser Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr "Voici un tutoriel sur comment utiliser Matterbridge avec ce plugin : <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr "Autoriser la connexion en utilisant des clients XMPP"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
-msgstr "Clients XMPP"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1094,18 +1138,12 @@ msgstr "DNS"
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 msgid "You need to add [DNS records](https://prosody.im/doc/dns) allowing remote servers to find \"room.your_instance.tld\" and \"external.your_instance.tld\" components."
-msgstr ""
-"Vous devez ajouter des [enregistrements DNS](https://prosody.im/doc/dns) "
-"permettant aux serveurs distant de trouver les composants «room."
-"votre_instance.tld» et «external.votre_instance.tld»."
+msgstr "Vous devez ajouter des [enregistrements DNS](https://prosody.im/doc/dns) permettant aux serveurs distant de trouver les composants «room.votre_instance.tld» et «external.votre_instance.tld»."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 msgid "The easiest way to do this is to add SRV records for the \"room\" and \"external\" [subdomain](https://prosody.im/doc/dns#subdomains):"
-msgstr ""
-"Le plus simple pour cela est d'ajouter des enregistrements SRV pour les "
-"[sous-domaines](https://prosody.im/doc/dns#subdomains) «room»  et «external» "
-":"
+msgstr "Le plus simple pour cela est d'ajouter des enregistrements SRV pour les [sous-domaines](https://prosody.im/doc/dns#subdomains) «room»  et «external» :"
 
 #. type: Bullet: '* '
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1150,9 +1188,7 @@ msgstr "target: votre_instance.tld. (remplacez par la valeur adéquate)"
 #. type: Bullet: '* '
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 msgid "record name: _xmpp-server._tcp.external.your_instance.tld. (replace «your_instance.tld» by your instance uri)"
-msgstr ""
-"nom de l'enregistrement : _xmpp-server._tcp.external.votre_instance.tld. ("
-"remplacez «votre_instance.tld» par la valeur adéquate)"
+msgstr "nom de l'enregistrement : _xmpp-server._tcp.external.votre_instance.tld. (remplacez «votre_instance.tld» par la valeur adéquate)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1162,9 +1198,7 @@ msgstr "Attention à bien conserver le point après «votre_instance.tld»."
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 msgid "Using the `dig` command to check your records, you should get a result similar to this:"
-msgstr ""
-"En utilisant la commande `dig` pour vérifier vos enregistrements, vous "
-"devriez obtenir un résultat similaire à celui-ci :"
+msgstr "En utilisant la commande `dig` pour vérifier vos enregistrements, vous devriez obtenir un résultat similaire à celui-ci :"
 
 #. type: Fenced code block (bash)
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1571,10 +1605,9 @@ msgstr ""
 "  --config /data/plugins/data/peertube-plugin-livechat/prosody/prosody.cfg.lua \\\n"
 "  check certs\n"
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "En cas de problème"
@@ -1584,18 +1617,12 @@ msgstr "En cas de problème"
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr "Si cela ne fonctionne pas, vous pouvez utiliser l'outils de diagnostic (un bouton se trouve en haut de la page des paramètres du plugin), et notamment regarder ce que dit la section «Prosody check»."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
+#, fuzzy
+#| msgid "Plugin Peertube Livechat settings - External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr "Paramètres du Plugin Peertube Livechat - Authentification Externe"
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
-msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1627,10 +1654,7 @@ msgstr "![Bouton connexion avec compte externe](/peertube-plugin-livechat/images
 #: build/documentation/pot_in/documentation/admin/external_auth.md
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![External login dialog - OpenID Connect](/peertube-plugin-livechat/images/external_login_dialog_oidc.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Fenêtre d'authentification Externe - OpenID Connect](/peertube-"
-"plugin-livechat/images/external_login_dialog_oidc."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Fenêtre d'authentification Externe - OpenID Connect](/peertube-plugin-livechat/images/external_login_dialog_oidc.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1640,10 +1664,7 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
 msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
-msgstr ""
-"Pour la documentation utilisateur⋅rice, veuillez vous référer à la page [de "
-"documentation utilisateur⋅rice](/peertube-plugin-livechat/fr/documentation/"
-"user/viewers/)"
+msgstr "Pour la documentation utilisateur⋅rice, veuillez vous référer à la page [de documentation utilisateur⋅rice](/peertube-plugin-livechat/fr/documentation/user/viewers/)"
 
 #. type: Title ##
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1768,29 +1789,15 @@ msgstr "Plus à venir..."
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
-msgstr "Administration du Plugin Peertube Livechat"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr "Documentation administrateur⋅rice"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr "Paramètres du Plugin Peertube Livechat"
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
-msgstr "Paramètres"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1814,6 +1821,12 @@ msgstr "Fédération"
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
 msgstr "Les paramètres suivants concernent la fédération avec d'autres instances Peertube et d'autres logiciels du fediverse."
 
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
+msgstr ""
+
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "See the detailed documentation page:"
@@ -1822,9 +1835,7 @@ msgstr "Voir la page de documentation détaillée :"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "[External Authentication](/peertube-plugin-livechat/documentation/admin/external_auth/)"
-msgstr ""
-"[Authentification Externe](/peertube-plugin-livechat/fr/documentation/admin/"
-"external_auth/)"
+msgstr "[Authentification Externe](/peertube-plugin-livechat/fr/documentation/admin/external_auth/)"
 
 #. type: Title ##
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2033,23 +2044,17 @@ msgstr "Cette fonction pourrait être utilisée pour connecter des ponts ou des 
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr "Plus d'informations sur les composants externes de Prosody [ici] (https://prosody.im/doc/components)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
-msgstr "Documentation du plugin"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+#, fuzzy
+#| msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr "Pour l'instant le plugin ne supporte de base que les architectures CPU x86_64 et arm64. Veuillez trouver ici des instructions pour le faire fonctionner sur d'autres architectures CPU."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
-msgstr "Problème connu : compatibilité CPU"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -2163,17 +2168,10 @@ msgstr "Ceci est déjà fait par l'application Yunohost Peertube, étant donné 
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr "Mais il se pourrait que ce soit retiré de l'application Yunohost Peertube dans un futur proche (pour éviter les inconvénients de cette méthode). Je dois discuter avec l'équipe Yunohost, pour décider de la bonne façon de faire pour minimiser les inconvénients et maximiser la compatibilité."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr "Installation du plugin peertube-plugin-livechat"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
-msgstr "Documentation d'installation"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
@@ -2191,11 +2189,10 @@ msgstr "Pour installer ou mettre à jour ce plugin, **utilisez simplement l'inte
 msgid "Here are some other more specific instructions:"
 msgstr "Vous trouverez ci-dessous d'autres instructions :"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
-msgstr "Quelques erreurs classiques, et solutions de contournement."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2288,17 +2285,10 @@ msgstr "Vous pouvez confirmer si c'est un problème de Websocket en ouvrant la c
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr "Si vous ne pouvez pas corriger cela tout de suite, vous pouvez déactiver Websocket en décochant \"{{% livechat_label disable_websocket_label %}}\"  dans la page des paramètres du plugin. En pareil cas, vous devriez aussi décocher \"{{% livechat_label federation_dont_publish_remotely_label %}}\", car la fédération du tchat ne fonctionnera pas sans Websocket."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr "Notes importantes pour la mise à jour depuis une ancienne version du plugin."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
-msgstr "Mise à jour depuis une version antérieure à 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -2321,29 +2311,19 @@ msgstr "Si vous utilisiez ce plugin avant, et que vous aviez installé Prosody m
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr "Si vous utilisiez l'image docker spéciale de Peertube (qui incluais Prosody), vous pouvez basculer sur l'image officielle de Peertube."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
-msgstr "Documentation utilisateur⋅rice du plugin peertube-plugin-livechat"
+#, fuzzy
+#| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+msgstr "Pour la documentation utilisateur⋅rice, veuillez vous référer à la page [de documentation utilisateur⋅rice](/peertube-plugin-livechat/fr/documentation/user/viewers/)"
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr "Documentation utilisateur⋅rice"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
+#, fuzzy
+#| msgid "Documentation to stream the chat content using OBS."
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr "Documentation pour diffuser le contenu du tchat à l'aide d'OBS."
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
-msgstr "OBS"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2429,17 +2409,12 @@ msgstr "Mélanger plusieurs tchats dans votre flux en direct"
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr "Vous pouvez utiliser l'extension [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) pour mélanger plusieurs sources de tchat (Peertube, Twitch, Youtube, Facebook, ...) et inclure leurs contenus dans votre flux en direct. La compatibilité avec ce plugin a été ajoutée dans les versions récentes."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
+#, fuzzy
+#| msgid "Some basics about how to setup and use the chat for your live stream"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr "Quelques basiques sur comment configurer et utiliser le tchat pour vos directs"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
-msgstr "Quelques basiques"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2531,7 +2506,6 @@ msgstr "La popup «{{% livechat_label share_chat_link %}}» peut également cont
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2618,17 +2592,10 @@ msgstr "Si vous voulez détruire le contenu du tchat, [ouvrez le menu déroulant
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr "Le tchat sera automatiquement recréé à chaque fois que quelqu'un essayera de le rejoindre, tant que la vidéo existe et qu'elle a le paramètre «{{% livechat_label use_chat %}}» activé."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr "Le bot peut répondre à différentes commandes."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
-msgstr "Commandes"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
@@ -2640,17 +2607,12 @@ msgstr "![Configuration des commandes](/peertube-plugin-livechat/images/bot_comm
 msgid "You can setup several commands."
 msgstr "Vous pouvez paramétrer différentes commandes."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
+#, fuzzy
+#| msgid "The bot can automatically moderate messages containing forbidden words."
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr "Le bot peut automatiquement modérer les messages contenant des mots interdits."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
-msgstr "Mots interdits"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
@@ -2707,18 +2669,10 @@ msgstr "Cette fonction est encore expérimentale. Il pourrait y avoir quelques p
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr "En cochant cette option, chaque ligne du champs «{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}» sera considéré comme une [expression régulière](https://fr.wikipedia.org/wiki/Expression_r%C3%A9guli%C3%A8re)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr "Configuration du bot de tchat"
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr "Bot de tchat"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2752,17 +2706,12 @@ msgstr "Une fois ici, vous pouvez activer le bot, et configurer quelques options
 msgid "The bot will reload instantly when you save the page."
 msgstr "Le bot recharge automatiquement ses options quand vous sauvegardez la page."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
+#, fuzzy
+#| msgid "The bot can send periodically some messages."
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr "Le bot peut envoyer des messages périodiquement."
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
-msgstr "Messages pré-enregistrés"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
@@ -2774,17 +2723,10 @@ msgstr "S'il n'y a pas d'utilisateur⋅rice dans le salon, le bot n'enverra pas 
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "![Configuration des messages pré-enregistrés](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr "Configuration des salons de discussion des chaînes Peertube"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
-msgstr "Configuration de la chaîne"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2821,22 +2763,16 @@ msgstr "[Le bot de tchat](/peertube-plugin-livechat/documentation/fr/user/stream
 msgid "More features to come..."
 msgstr "Nouvelles fonctionnalités à venir..."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
-msgstr "Comment mettre en place le tchat pour vos diffusions en direct"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr "Pour les streameur⋅euses"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#, fuzzy
+#| msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr "Fonctionnalités de modération avancées du plugin peertube-plugin-livechat"
 
 #. type: Plain text
@@ -2937,27 +2873,19 @@ msgstr "Vous pouvez lister toutes les salles de discussion existantes : dans l'�
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr "Mode lent du plugin peertube-plugin-livechat"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
-msgstr "Mode lent"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr "Cette fonctionnalité arrive avec le plugin livechat version 8.3.0."
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "Introduction"
@@ -3011,9 +2939,7 @@ msgstr "![Configuration de la chaîne / Mode lent](/peertube-plugin-livechat/ima
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "This value will apply as a default value for all your channel's chatrooms."
-msgstr ""
-"Cette valeur va s'appliquer comme valeur par défaut pour tous les salons de "
-"discussion de votre chaîne."
+msgstr "Cette valeur va s'appliquer comme valeur par défaut pour tous les salons de discussion de votre chaîne."
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -3030,9 +2956,8 @@ msgstr "Positionner la valeur à un nombre entier positif permet de fixer la pé
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr "Pour les spectateur⋅rices"
@@ -3052,16 +2977,9 @@ msgstr "![Information mode lent](/peertube-plugin-livechat/images/slow_mode.png?
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr "Lorsqu'iels envoient un message, le champ de saisie est désactivé pendant X secondes (X étant la durée du mode lent)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3109,23 +3027,17 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "To open the Task Application, there is a \"{{% livechat_label \"tasks\" %}}\" button in the top chat menu:"
-msgstr ""
-"Pour ouvrir l'Application Tâches, il y a un bouton «{{% livechat_label tasks "
-"%}}» dans le menu haut du tchat :"
+msgstr "Pour ouvrir l'Application Tâches, il y a un bouton «{{% livechat_label tasks %}}» dans le menu haut du tchat :"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Opening the Task Application](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Ouvrir l'Application Tâche](/peertube-plugin-livechat/images/"
-"task_open_app_video.png?classes=shadow,border&height=200px)"
+msgstr "![Ouvrir l'Application Tâche](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Opening the Task Application](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Ouvrir l'Application Tâche](/peertube-plugin-livechat/images/"
-"task_open_app_fullpage.png?classes=shadow,border&height=200px)"
+msgstr "![Ouvrir l'Application Tâche](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3135,16 +3047,12 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task Application](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Application Tâches](/peertube-plugin-livechat/images/task_app_video_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Application Tâches](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task Application](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Application Tâches](/peertube-plugin-livechat/images/task_app_fullpage_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Application Tâches](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3191,9 +3099,7 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task lists](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Listes de Tâches](/peertube-plugin-livechat/images/task_app_task_lists."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Listes de Tâches](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3220,16 +3126,12 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task form](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Formulaire de tâche](/peertube-plugin-livechat/images/task_app_task_form."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Formulaire de tâche](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task created](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Tâche créée](/peertube-plugin-livechat/images/task_app_task_1."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Tâche créée](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3250,9 +3152,7 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Tasks](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Tâches](/peertube-plugin-livechat/images/task_app_task_2."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Tâches](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3268,17 +3168,12 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Drag and drop to sort](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Glissé déposé pour trier](/peertube-plugin-livechat/images/task_drag_drop."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Glissé déposé pour trier](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Drag and drop to move to another list](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Glissé déposé pour déplacer vers une autre liste](/peertube-"
-"plugin-livechat/images/task_drag_drop_task_list."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Glissé déposé pour déplacer vers une autre liste](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px)"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -3294,34 +3189,27 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Create task from message](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Créer une tâche depuis un message](/peertube-plugin-livechat/images/"
-"task_from_message_1.png?classes=shadow,border&height=200px)"
+msgstr "![Créer une tâche depuis un message](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Choose the task list](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Sélectionnez la liste de tâches](/peertube-plugin-livechat/images/"
-"task_from_message_2.png?classes=shadow,border&height=200px)"
+msgstr "![Sélectionnez la liste de tâches](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Task created](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px)"
-msgstr ""
-"![Tâche créée](/peertube-plugin-livechat/images/task_from_message_3."
-"png?classes=shadow,border&height=200px)"
+msgstr "![Tâche créée](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px)"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
-msgstr "Comment tchater pour les spectateur⋅rices"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -3526,17 +3414,10 @@ msgstr "Vous pouvez changer de pseudonyme en tapant `/nick votre_nouveau_pseudo`
 msgid "You can also change your nickname using the chat menu."
 msgstr "Vous pouvez également changer votre pseudonyme en utilisant le menu déroulant du tchat."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr "Se connecter au tchat avec un client XMPP"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
-msgstr "Clients XMPP"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -3613,6 +3494,11 @@ msgstr "Pour avoir un aperçu des possibilités de ce plugin, aller jeter un œi
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
 msgstr "Vous pouvez utiliser la barre de recherche dans le menu gauche pour rapidement trouver des documentations spécifiques."
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
+msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/intro/_index.md
@@ -3697,6 +3583,12 @@ msgstr "Bien sûr, pour que la fédération fonctionne, le plugin doit être ins
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr "Parfois, vous devez protéger votre communauté contre les personnes mal intentionnées. En tant qu'administrateur⋅rice d'instance, vous pouvez choisir de désactiver la fédération pour le plugin livechat. Si des acteur⋅rices distant⋅es se comportent mal, les streameur⋅euses, les modérateur⋅rices et les administrateur⋅rices peuvent bannir ou mettre en sourdine des utilisateur⋅ices."
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr "Bot de tchat"
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3759,17 +3651,10 @@ msgstr "Mais au niveau de l'instance, les administrateur⋅rices peuvent choisir
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr "Vous pouvez également activer le tchat pour des vidéos à la demande spécifiques. C'est comme cela que fonctionne la page de [démo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) : ce n'est pas un direct, mais j'ai activé le tchat spécifiquement pour cette vidéo."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr "Évolutions / suivi des bugs"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
-msgstr "Évolutions / Bugs"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3795,6 +3680,198 @@ msgstr "les [jalons sur github](https://github.com/JohnXLivingston/peertube-plug
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Si vous êtes webdesigner ou avez une expertise en ConverseJS/Prosody/XMPP et souhaitez participer à l'évolution de ce plugin, n'hésitez pas à me contacter."
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "Contacter l'auteur"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "Me contacter"
+
+#, no-wrap
+#~ msgid "Contributor Covenant Code of Conduct"
+#~ msgstr "Convention de Code de conduite Contributeur⋅rices"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "Code de conduite"
+
+#, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "Documentation"
+
+#, no-wrap
+#~ msgid "Give your feedback"
+#~ msgstr "Donnez vos retours"
+
+#, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "Contribuer"
+
+#, no-wrap
+#~ msgid "Translate the plugin"
+#~ msgstr "Traduire le plugin"
+
+#, no-wrap
+#~ msgid "Translate"
+#~ msgstr "Traduction"
+
+#, no-wrap
+#~ msgid "Plugin Credits"
+#~ msgstr "Crédits pour le plugin"
+
+#, no-wrap
+#~ msgid "Credits"
+#~ msgstr "Crédits"
+
+#, no-wrap
+#~ msgid "Some advanced features"
+#~ msgstr "Quelques fonctionnalités avancées"
+
+#, no-wrap
+#~ msgid "Advanced usage"
+#~ msgstr "Usage avancé"
+
+#, no-wrap
+#~ msgid "Using Matterbridge to bridge with other chats"
+#~ msgstr "Utiliser Matterbridge pour faire un pont vers d'autres tchats"
+
+#, no-wrap
+#~ msgid "Using Matterbridge"
+#~ msgstr "Utiliser Matterbridge"
+
+#, no-wrap
+#~ msgid "Allow connections using XMPP clients"
+#~ msgstr "Autoriser la connexion en utilisant des clients XMPP"
+
+#, no-wrap
+#~ msgid "XMPP clients"
+#~ msgstr "Clients XMPP"
+
+#, no-wrap
+#~ msgid "Plugin Peertube Livechat administration"
+#~ msgstr "Administration du Plugin Peertube Livechat"
+
+#, no-wrap
+#~ msgid "Admin documentation"
+#~ msgstr "Documentation administrateur⋅rice"
+
+#, no-wrap
+#~ msgid "Plugin Peertube Livechat settings"
+#~ msgstr "Paramètres du Plugin Peertube Livechat"
+
+#, no-wrap
+#~ msgid "Settings"
+#~ msgstr "Paramètres"
+
+#, no-wrap
+#~ msgid "Plugin documentation"
+#~ msgstr "Documentation du plugin"
+
+#, no-wrap
+#~ msgid "Known issues: CPU Compatibility"
+#~ msgstr "Problème connu : compatibilité CPU"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat installation guide"
+#~ msgstr "Installation du plugin peertube-plugin-livechat"
+
+#, no-wrap
+#~ msgid "Installation guide"
+#~ msgstr "Documentation d'installation"
+
+#, no-wrap
+#~ msgid "Some classic mistakes and workarounds."
+#~ msgstr "Quelques erreurs classiques, et solutions de contournement."
+
+#, no-wrap
+#~ msgid "Important notes when upgrading for an older version."
+#~ msgstr "Notes importantes pour la mise à jour depuis une ancienne version du plugin."
+
+#, no-wrap
+#~ msgid "Upgrade from version older than 6.0.0"
+#~ msgstr "Mise à jour depuis une version antérieure à 6.0.0"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat user documentation"
+#~ msgstr "Documentation utilisateur⋅rice du plugin peertube-plugin-livechat"
+
+#, no-wrap
+#~ msgid "User documentation"
+#~ msgstr "Documentation utilisateur⋅rice"
+
+#, no-wrap
+#~ msgid "OBS"
+#~ msgstr "OBS"
+
+#, no-wrap
+#~ msgid "Some basics"
+#~ msgstr "Quelques basiques"
+
+#, no-wrap
+#~ msgid "The bot can respond to several commands."
+#~ msgstr "Le bot peut répondre à différentes commandes."
+
+#, no-wrap
+#~ msgid "Commands"
+#~ msgstr "Commandes"
+
+#, no-wrap
+#~ msgid "Forbidden words"
+#~ msgstr "Mots interdits"
+
+#, no-wrap
+#~ msgid "Chat bot setup"
+#~ msgstr "Configuration du bot de tchat"
+
+#, no-wrap
+#~ msgid "Timers"
+#~ msgstr "Messages pré-enregistrés"
+
+#, no-wrap
+#~ msgid "Peertube channel chatrooms configuration"
+#~ msgstr "Configuration des salons de discussion des chaînes Peertube"
+
+#, no-wrap
+#~ msgid "Channel configuration"
+#~ msgstr "Configuration de la chaîne"
+
+#, no-wrap
+#~ msgid "How to setup the chat for your live stream"
+#~ msgstr "Comment mettre en place le tchat pour vos diffusions en direct"
+
+#, no-wrap
+#~ msgid "For streamers"
+#~ msgstr "Pour les streameur⋅euses"
+
+#, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat slow mode"
+#~ msgstr "Mode lent du plugin peertube-plugin-livechat"
+
+#, no-wrap
+#~ msgid "Slow mode"
+#~ msgstr "Mode lent"
+
+#, no-wrap
+#~ msgid "How to chat for stream viewers"
+#~ msgstr "Comment tchater pour les spectateur⋅rices"
+
+#, no-wrap
+#~ msgid "Connect to chat using a XMPP client"
+#~ msgstr "Se connecter au tchat avec un client XMPP"
+
+#, no-wrap
+#~ msgid "XMPP Clients"
+#~ msgstr "Clients XMPP"
+
+#, no-wrap
+#~ msgid "Bug tracking / New features requests"
+#~ msgstr "Évolutions / suivi des bugs"
+
+#, no-wrap
+#~ msgid "Bug tracking & new features"
+#~ msgstr "Évolutions / Bugs"
 
 #~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
 #~ msgstr "Tous les modérateur⋅rices et administrateur⋅rices de l'instance seront propriétaires des salons de discussion créés. Le ou la propriétaire de la vidéo sera admin du salon."

--- a/support/documentation/po/livechat.fr.po
+++ b/support/documentation/po/livechat.fr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-05-17 16:40+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: French <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fr/>\n"
@@ -18,97 +18,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Weblate 5.5.5\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
-#, fuzzy, no-wrap
-#| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr "Le plugin est maintenu par [John Livingston](https://www.john-livingston.fr/)."
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "Contacter l'auteur"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contact me"
+msgstr "Me contacter"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -120,20 +40,28 @@ msgstr "Si vous avez des questions ou souhaitez parler de ce plugin, vous pouvez
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Si vous souhaitez supporter le projet financièrement, vous pouvez me contacter par mail à l'adresse git.[arobase].john-livingston.fr, ou passer par mon [profil Liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr "Convention de Code de conduite Contributeur⋅rices"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "Code de conduite"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "Ce code de conduite est adapté du [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, disponible à l'adresse [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html). Les traductions sont disponibles à l'adresse [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Les cas de comportements abusifs, harcelants ou tout autre comportement inacceptables peuvent être signalés aux dirigeant·e·s de la communauté responsables de l’application du code de conduite à git.[at].john-livingston.fr."
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "Développer"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -225,12 +153,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr "Veuillez noter que ce plugin a besoin d'une AppImage du serveur XMPP Prosody. Cette AppImage est fournie par le project [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage). Le script `build-prosody.sh` télécharge les binaires attachés à ce dépôt distant, et vérifie que les sommes de contrôles sha256 sont correctes."
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Développer"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -494,12 +416,19 @@ msgstr "Tests de performance"
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr "Le dépôt [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) contient quelques outils pour effectuer des tests de performance. Ils peuvent être utilisés pour évaluer les améliorations du code source, ou trouver les goulots d'étranglement."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "Document the plugin, or translate the documentation."
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+msgid "Document the plugin, or translate the documentation."
 msgstr "Documenter le plugin, ou traduire la documentation."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
+msgstr "Documentation"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -702,30 +631,39 @@ msgstr "Publication"
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr "La publication de la documentation est automatique, dès que les modifications sont fusionnées dans la branche `documentation`."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Give your feedback"
+msgstr "Donnez vos retours"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr "Vous n'avez pas besoin de coder pour commencer à contribuer à ce plugin ! Les autres formes de contributions sont également précieuses, parmis lesquelles : vous pouvez tester le plugin et remonter les bugs que vous rencontrez, partager vos retours d'expérience, proposer des fonctionnalités qui vous intéressent, remonter vos remarques sur l'interface, le design, etc."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributing"
+msgstr "Contribuer"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Intéressé⋅e pour contribuer ? Super !"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Translate the plugin"
+msgstr "Traduire le plugin"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
+msgstr "Traduction"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -977,10 +915,17 @@ msgstr "Recommandations génériques"
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr "Merci d'être inclusif⋅ve dans vos phrasés, et merci de respecter le [code de conduite](/peertube-plugin-livechat/contributing/codeofconduct/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Credits"
+msgstr "Crédits pour le plugin"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
+msgstr "Crédits"
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -1027,25 +972,46 @@ msgstr "Merci à [Octopuce](https://www.octopuce.fr/) pour le support financier.
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr "Et merci à toustes les contributeur⋅rices individuel⋅les qui ont fait un don via ma [page liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Some advanced features"
+msgstr "Quelques fonctionnalités avancées"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr "Usage avancé"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr "Utiliser Matterbridge pour faire un pont vers d'autres tchats"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
+msgstr "Utiliser Matterbridge"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr "Voici un tutoriel sur comment utiliser Matterbridge avec ce plugin : <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr "Autoriser la connexion en utilisant des clients XMPP"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
+msgstr "Clients XMPP"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
@@ -1605,9 +1571,10 @@ msgstr ""
 "  --config /data/plugins/data/peertube-plugin-livechat/prosody/prosody.cfg.lua \\\n"
 "  check certs\n"
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "En cas de problème"
@@ -1617,12 +1584,19 @@ msgstr "En cas de problème"
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr "Si cela ne fonctionne pas, vous pouvez utiliser l'outils de diagnostic (un bouton se trouve en haut de la page des paramètres du plugin), et notamment regarder ce que dit la section «Prosody check»."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, fuzzy
-#| msgid "Plugin Peertube Livechat settings - External Authentication"
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
-msgstr "Paramètres du Plugin Peertube Livechat - Authentification Externe"
+#, fuzzy, no-wrap
+#| msgid "Plugin Peertube Livechat settings"
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr "Paramètres du Plugin Peertube Livechat"
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1789,15 +1763,29 @@ msgstr "Plus à venir..."
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
+msgstr "Administration du Plugin Peertube Livechat"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr "Documentation administrateur⋅rice"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr "Paramètres du Plugin Peertube Livechat"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
+msgstr "Paramètres"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1820,12 +1808,6 @@ msgstr "Fédération"
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
 msgstr "Les paramètres suivants concernent la fédération avec d'autres instances Peertube et d'autres logiciels du fediverse."
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
-msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2044,17 +2026,24 @@ msgstr "Cette fonction pourrait être utilisée pour connecter des ponts ou des 
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr "Plus d'informations sur les composants externes de Prosody [ici] (https://prosody.im/doc/components)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin documentation"
+msgstr "Documentation du plugin"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr "Pour l'instant le plugin ne supporte de base que les architectures CPU x86_64 et arm64. Veuillez trouver ici des instructions pour le faire fonctionner sur d'autres architectures CPU."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
+msgstr "Problème connu : compatibilité CPU"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
@@ -2168,10 +2157,17 @@ msgstr "Ceci est déjà fait par l'application Yunohost Peertube, étant donné 
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr "Mais il se pourrait que ce soit retiré de l'application Yunohost Peertube dans un futur proche (pour éviter les inconvénients de cette méthode). Je dois discuter avec l'équipe Yunohost, pour décider de la bonne façon de faire pour minimiser les inconvénients et maximiser la compatibilité."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr "Installation du plugin peertube-plugin-livechat"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
+msgstr "Documentation d'installation"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
@@ -2189,10 +2185,11 @@ msgstr "Pour installer ou mettre à jour ce plugin, **utilisez simplement l'inte
 msgid "Here are some other more specific instructions:"
 msgstr "Vous trouverez ci-dessous d'autres instructions :"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
+msgstr "Quelques erreurs classiques, et solutions de contournement."
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2285,10 +2282,17 @@ msgstr "Vous pouvez confirmer si c'est un problème de Websocket en ouvrant la c
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr "Si vous ne pouvez pas corriger cela tout de suite, vous pouvez déactiver Websocket en décochant \"{{% livechat_label disable_websocket_label %}}\"  dans la page des paramètres du plugin. En pareil cas, vous devriez aussi décocher \"{{% livechat_label federation_dont_publish_remotely_label %}}\", car la fédération du tchat ne fonctionnera pas sans Websocket."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr "Notes importantes pour la mise à jour depuis une ancienne version du plugin."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
+msgstr "Mise à jour depuis une version antérieure à 6.0.0"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
@@ -2311,19 +2315,30 @@ msgstr "Si vous utilisiez ce plugin avant, et que vous aviez installé Prosody m
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr "Si vous utilisiez l'image docker spéciale de Peertube (qui incluais Prosody), vous pouvez basculer sur l'image officielle de Peertube."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-#, fuzzy
-#| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
-msgstr "Pour la documentation utilisateur⋅rice, veuillez vous référer à la page [de documentation utilisateur⋅rice](/peertube-plugin-livechat/fr/documentation/user/viewers/)"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
+msgstr "Documentation utilisateur⋅rice du plugin peertube-plugin-livechat"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr "Documentation utilisateur⋅rice"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "Documentation to stream the chat content using OBS."
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+msgid "Documentation to stream the chat content using OBS."
 msgstr "Documentation pour diffuser le contenu du tchat à l'aide d'OBS."
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
+msgstr "OBS"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2409,12 +2424,18 @@ msgstr "Mélanger plusieurs tchats dans votre flux en direct"
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr "Vous pouvez utiliser l'extension [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) pour mélanger plusieurs sources de tchat (Peertube, Twitch, Youtube, Facebook, ...) et inclure leurs contenus dans votre flux en direct. La compatibilité avec ce plugin a été ajoutée dans les versions récentes."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, fuzzy
-#| msgid "Some basics about how to setup and use the chat for your live stream"
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
-msgstr "Quelques basiques sur comment configurer et utiliser le tchat pour vos directs"
+#, fuzzy, no-wrap
+#| msgid "How to setup the chat for your live stream"
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr "Comment mettre en place le tchat pour vos diffusions en direct"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
+msgstr "Quelques basiques"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2506,6 +2527,7 @@ msgstr "La popup «{{% livechat_label share_chat_link %}}» peut également cont
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2592,10 +2614,17 @@ msgstr "Si vous voulez détruire le contenu du tchat, [ouvrez le menu déroulant
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr "Le tchat sera automatiquement recréé à chaque fois que quelqu'un essayera de le rejoindre, tant que la vidéo existe et qu'elle a le paramètre «{{% livechat_label use_chat %}}» activé."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr "Le bot peut répondre à différentes commandes."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
+msgstr "Commandes"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
@@ -2607,12 +2636,18 @@ msgstr "![Configuration des commandes](/peertube-plugin-livechat/images/bot_comm
 msgid "You can setup several commands."
 msgstr "Vous pouvez paramétrer différentes commandes."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, fuzzy
+#, fuzzy, no-wrap
 #| msgid "The bot can automatically moderate messages containing forbidden words."
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+msgid "The bot can automatically moderate messages containing forbidden words."
 msgstr "Le bot peut automatiquement modérer les messages contenant des mots interdits."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
+msgstr "Mots interdits"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
@@ -2669,10 +2704,18 @@ msgstr "Cette fonction est encore expérimentale. Il pourrait y avoir quelques p
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr "En cochant cette option, chaque ligne du champs «{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}» sera considéré comme une [expression régulière](https://fr.wikipedia.org/wiki/Expression_r%C3%A9guli%C3%A8re)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Chat bot setup"
+msgstr "Configuration du bot de tchat"
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr "Bot de tchat"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2706,12 +2749,18 @@ msgstr "Une fois ici, vous pouvez activer le bot, et configurer quelques options
 msgid "The bot will reload instantly when you save the page."
 msgstr "Le bot recharge automatiquement ses options quand vous sauvegardez la page."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, fuzzy
-#| msgid "The bot can send periodically some messages."
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
-msgstr "Le bot peut envoyer des messages périodiquement."
+#, fuzzy, no-wrap
+#| msgid "The bot can respond to several commands."
+msgid "The bot can send periodically some messages."
+msgstr "Le bot peut répondre à différentes commandes."
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
+msgstr "Messages pré-enregistrés"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
@@ -2723,10 +2772,17 @@ msgstr "S'il n'y a pas d'utilisateur⋅rice dans le salon, le bot n'enverra pas 
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "![Configuration des messages pré-enregistrés](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr "Configuration des salons de discussion des chaînes Peertube"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
+msgstr "Configuration de la chaîne"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2763,17 +2819,24 @@ msgstr "[Le bot de tchat](/peertube-plugin-livechat/documentation/fr/user/stream
 msgid "More features to come..."
 msgstr "Nouvelles fonctionnalités à venir..."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "How to setup the chat for your live stream"
+msgstr "Comment mettre en place le tchat pour vos diffusions en direct"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr "Pour les streameur⋅euses"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, fuzzy
-#| msgid "Plugin peertube-plugin-livechat advanced moderation features"
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
-msgstr "Fonctionnalités de modération avancées du plugin peertube-plugin-livechat"
+#, fuzzy, no-wrap
+#| msgid "Plugin peertube-plugin-livechat installation guide"
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgstr "Installation du plugin peertube-plugin-livechat"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
@@ -2873,19 +2936,27 @@ msgstr "Vous pouvez lister toutes les salles de discussion existantes : dans l'�
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr "Mode lent du plugin peertube-plugin-livechat"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
+msgstr "Mode lent"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr "Cette fonctionnalité arrive avec le plugin livechat version 8.3.0."
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr "Introduction"
@@ -2956,8 +3027,9 @@ msgstr "Positionner la valeur à un nombre entier positif permet de fixer la pé
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr "Pour les spectateur⋅rices"
@@ -2977,9 +3049,16 @@ msgstr "![Information mode lent](/peertube-plugin-livechat/images/slow_mode.png?
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr "Lorsqu'iels envoient un message, le champ de saisie est désactivé pendant X secondes (X étant la durée du mode lent)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3206,10 +3285,11 @@ msgstr "![Tâche créée](/peertube-plugin-livechat/images/task_from_message_3.p
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "How to chat for stream viewers"
+msgstr "Comment tchater pour les spectateur⋅rices"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -3414,10 +3494,17 @@ msgstr "Vous pouvez changer de pseudonyme en tapant `/nick votre_nouveau_pseudo`
 msgid "You can also change your nickname using the chat menu."
 msgstr "Vous pouvez également changer votre pseudonyme en utilisant le menu déroulant du tchat."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr "Se connecter au tchat avec un client XMPP"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
+msgstr "Clients XMPP"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -3494,11 +3581,6 @@ msgstr "Pour avoir un aperçu des possibilités de ce plugin, aller jeter un œi
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
 msgstr "Vous pouvez utiliser la barre de recherche dans le menu gauche pour rapidement trouver des documentations spécifiques."
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
-msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/intro/_index.md
@@ -3583,12 +3665,6 @@ msgstr "Bien sûr, pour que la fédération fonctionne, le plugin doit être ins
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr "Parfois, vous devez protéger votre communauté contre les personnes mal intentionnées. En tant qu'administrateur⋅rice d'instance, vous pouvez choisir de désactiver la fédération pour le plugin livechat. Si des acteur⋅rices distant⋅es se comportent mal, les streameur⋅euses, les modérateur⋅rices et les administrateur⋅rices peuvent bannir ou mettre en sourdine des utilisateur⋅ices."
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr "Bot de tchat"
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3651,10 +3727,17 @@ msgstr "Mais au niveau de l'instance, les administrateur⋅rices peuvent choisir
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr "Vous pouvez également activer le tchat pour des vidéos à la demande spécifiques. C'est comme cela que fonctionne la page de [démo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) : ce n'est pas un direct, mais j'ai activé le tchat spécifiquement pour cette vidéo."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr "Évolutions / suivi des bugs"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
+msgstr "Évolutions / Bugs"
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3681,197 +3764,37 @@ msgstr "les [jalons sur github](https://github.com/JohnXLivingston/peertube-plug
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "Si vous êtes webdesigner ou avez une expertise en ConverseJS/Prosody/XMPP et souhaitez participer à l'évolution de ce plugin, n'hésitez pas à me contacter."
 
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "Contacter l'auteur"
+#, fuzzy, no-wrap
+#~| msgid "The plugin is maintained by [John Livingston](https://www.john-livingston.fr/)."
+#~ msgid ""
+#~ "<!--\n"
+#~ "SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+#~ msgstr "Le plugin est maintenu par [John Livingston](https://www.john-livingston.fr/)."
 
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "Me contacter"
+#, fuzzy
+#~| msgid "Plugin Peertube Livechat settings - External Authentication"
+#~ msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#~ msgstr "Paramètres du Plugin Peertube Livechat - Authentification Externe"
 
-#, no-wrap
-#~ msgid "Contributor Covenant Code of Conduct"
-#~ msgstr "Convention de Code de conduite Contributeur⋅rices"
+#, fuzzy
+#~| msgid "For the user documentation, see [user documentation](/peertube-plugin-livechat/documentation/user/viewers/)"
+#~ msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#~ msgstr "Pour la documentation utilisateur⋅rice, veuillez vous référer à la page [de documentation utilisateur⋅rice](/peertube-plugin-livechat/fr/documentation/user/viewers/)"
 
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "Code de conduite"
+#, fuzzy
+#~| msgid "Some basics about how to setup and use the chat for your live stream"
+#~ msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#~ msgstr "Quelques basiques sur comment configurer et utiliser le tchat pour vos directs"
 
-#, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "Documentation"
+#, fuzzy
+#~| msgid "The bot can send periodically some messages."
+#~ msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#~ msgstr "Le bot peut envoyer des messages périodiquement."
 
-#, no-wrap
-#~ msgid "Give your feedback"
-#~ msgstr "Donnez vos retours"
-
-#, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "Contribuer"
-
-#, no-wrap
-#~ msgid "Translate the plugin"
-#~ msgstr "Traduire le plugin"
-
-#, no-wrap
-#~ msgid "Translate"
-#~ msgstr "Traduction"
-
-#, no-wrap
-#~ msgid "Plugin Credits"
-#~ msgstr "Crédits pour le plugin"
-
-#, no-wrap
-#~ msgid "Credits"
-#~ msgstr "Crédits"
-
-#, no-wrap
-#~ msgid "Some advanced features"
-#~ msgstr "Quelques fonctionnalités avancées"
-
-#, no-wrap
-#~ msgid "Advanced usage"
-#~ msgstr "Usage avancé"
-
-#, no-wrap
-#~ msgid "Using Matterbridge to bridge with other chats"
-#~ msgstr "Utiliser Matterbridge pour faire un pont vers d'autres tchats"
-
-#, no-wrap
-#~ msgid "Using Matterbridge"
-#~ msgstr "Utiliser Matterbridge"
-
-#, no-wrap
-#~ msgid "Allow connections using XMPP clients"
-#~ msgstr "Autoriser la connexion en utilisant des clients XMPP"
-
-#, no-wrap
-#~ msgid "XMPP clients"
-#~ msgstr "Clients XMPP"
-
-#, no-wrap
-#~ msgid "Plugin Peertube Livechat administration"
-#~ msgstr "Administration du Plugin Peertube Livechat"
-
-#, no-wrap
-#~ msgid "Admin documentation"
-#~ msgstr "Documentation administrateur⋅rice"
-
-#, no-wrap
-#~ msgid "Plugin Peertube Livechat settings"
-#~ msgstr "Paramètres du Plugin Peertube Livechat"
-
-#, no-wrap
-#~ msgid "Settings"
-#~ msgstr "Paramètres"
-
-#, no-wrap
-#~ msgid "Plugin documentation"
-#~ msgstr "Documentation du plugin"
-
-#, no-wrap
-#~ msgid "Known issues: CPU Compatibility"
-#~ msgstr "Problème connu : compatibilité CPU"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat installation guide"
-#~ msgstr "Installation du plugin peertube-plugin-livechat"
-
-#, no-wrap
-#~ msgid "Installation guide"
-#~ msgstr "Documentation d'installation"
-
-#, no-wrap
-#~ msgid "Some classic mistakes and workarounds."
-#~ msgstr "Quelques erreurs classiques, et solutions de contournement."
-
-#, no-wrap
-#~ msgid "Important notes when upgrading for an older version."
-#~ msgstr "Notes importantes pour la mise à jour depuis une ancienne version du plugin."
-
-#, no-wrap
-#~ msgid "Upgrade from version older than 6.0.0"
-#~ msgstr "Mise à jour depuis une version antérieure à 6.0.0"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat user documentation"
-#~ msgstr "Documentation utilisateur⋅rice du plugin peertube-plugin-livechat"
-
-#, no-wrap
-#~ msgid "User documentation"
-#~ msgstr "Documentation utilisateur⋅rice"
-
-#, no-wrap
-#~ msgid "OBS"
-#~ msgstr "OBS"
-
-#, no-wrap
-#~ msgid "Some basics"
-#~ msgstr "Quelques basiques"
-
-#, no-wrap
-#~ msgid "The bot can respond to several commands."
-#~ msgstr "Le bot peut répondre à différentes commandes."
-
-#, no-wrap
-#~ msgid "Commands"
-#~ msgstr "Commandes"
-
-#, no-wrap
-#~ msgid "Forbidden words"
-#~ msgstr "Mots interdits"
-
-#, no-wrap
-#~ msgid "Chat bot setup"
-#~ msgstr "Configuration du bot de tchat"
-
-#, no-wrap
-#~ msgid "Timers"
-#~ msgstr "Messages pré-enregistrés"
-
-#, no-wrap
-#~ msgid "Peertube channel chatrooms configuration"
-#~ msgstr "Configuration des salons de discussion des chaînes Peertube"
-
-#, no-wrap
-#~ msgid "Channel configuration"
-#~ msgstr "Configuration de la chaîne"
-
-#, no-wrap
-#~ msgid "How to setup the chat for your live stream"
-#~ msgstr "Comment mettre en place le tchat pour vos diffusions en direct"
-
-#, no-wrap
-#~ msgid "For streamers"
-#~ msgstr "Pour les streameur⋅euses"
-
-#, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat slow mode"
-#~ msgstr "Mode lent du plugin peertube-plugin-livechat"
-
-#, no-wrap
-#~ msgid "Slow mode"
-#~ msgstr "Mode lent"
-
-#, no-wrap
-#~ msgid "How to chat for stream viewers"
-#~ msgstr "Comment tchater pour les spectateur⋅rices"
-
-#, no-wrap
-#~ msgid "Connect to chat using a XMPP client"
-#~ msgstr "Se connecter au tchat avec un client XMPP"
-
-#, no-wrap
-#~ msgid "XMPP Clients"
-#~ msgstr "Clients XMPP"
-
-#, no-wrap
-#~ msgid "Bug tracking / New features requests"
-#~ msgstr "Évolutions / suivi des bugs"
-
-#, no-wrap
-#~ msgid "Bug tracking & new features"
-#~ msgstr "Évolutions / Bugs"
+#, fuzzy
+#~| msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#~ msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#~ msgstr "Fonctionnalités de modération avancées du plugin peertube-plugin-livechat"
 
 #~ msgid "All instance moderators and admins will be owner of created chat rooms.  The video owner will be admin in the chat room."
 #~ msgstr "Tous les modérateur⋅rices et administrateur⋅rices de l'instance seront propriétaires des salons de discussion créés. Le ou la propriétaire de la vidéo sera admin du salon."

--- a/support/documentation/po/livechat.gd.po
+++ b/support/documentation/po/livechat.gd.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Gaelic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gd/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.gd.po
+++ b/support/documentation/po/livechat.gd.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Gaelic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gd/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.gl.po
+++ b/support/documentation/po/livechat.gl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Galician <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gl/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.gl.po
+++ b/support/documentation/po/livechat.gl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Galician <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gl/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.hr.po
+++ b/support/documentation/po/livechat.hr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-05-01 01:17+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hr/>\n"
@@ -17,17 +17,96 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.5.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
-msgstr "Kontaktiraj autora"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "Kontaktiraj me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -39,28 +118,20 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "Kodeks ponašanja"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Razvijaj"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -143,10 +214,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "Razvijaj"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,18 +466,10 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
-msgstr "Dokumentacija"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -593,39 +672,30 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
-msgstr "Šalji povratne informacije"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
-msgstr "Doprinošenje"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Želiš doprinijeti? Super!"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr "Prevedi dodatak"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
-msgstr "Prevodi"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1677,29 +1710,15 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
-msgstr "Postavke"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1721,6 +1740,12 @@ msgstr "Federacija"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1937,22 +1962,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2064,16 +2081,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2092,10 +2102,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2189,16 +2198,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2222,28 +2224,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2330,16 +2318,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2432,7 +2413,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2519,16 +2499,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2541,16 +2514,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2608,17 +2574,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2653,16 +2611,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2675,16 +2626,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2722,22 +2666,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2838,16 +2774,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2855,10 +2784,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2929,9 +2857,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2951,16 +2878,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3193,10 +3113,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3402,16 +3321,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3488,6 +3400,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3573,6 +3490,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3635,16 +3558,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3671,3 +3587,39 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "Kontaktiraj autora"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "Kontaktiraj me"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "Kodeks ponašanja"
+
+#, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "Dokumentacija"
+
+#, no-wrap
+#~ msgid "Give your feedback"
+#~ msgstr "Šalji povratne informacije"
+
+#, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "Doprinošenje"
+
+#, no-wrap
+#~ msgid "Translate the plugin"
+#~ msgstr "Prevedi dodatak"
+
+#, no-wrap
+#~ msgid "Translate"
+#~ msgstr "Prevodi"
+
+#, no-wrap
+#~ msgid "Settings"
+#~ msgstr "Postavke"

--- a/support/documentation/po/livechat.hr.po
+++ b/support/documentation/po/livechat.hr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-05-01 01:17+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hr/>\n"
@@ -17,96 +17,17 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.5.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "Kontaktiraj autora"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+msgid "Contact me"
+msgstr "Kontaktiraj me"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -118,20 +39,28 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "Kodeks ponašanja"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "Razvijaj"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -223,12 +152,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "Razvijaj"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -466,10 +389,18 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
+msgstr "Dokumentacija"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -672,30 +603,39 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Give your feedback"
+msgstr "Šalji povratne informacije"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributing"
+msgstr "Doprinošenje"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr "Želiš doprinijeti? Super!"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Translate the plugin"
+msgstr "Prevedi dodatak"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
+msgstr "Prevodi"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1710,15 +1687,30 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "Admin documentation"
+msgstr "Piši dokumentaciju"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
+msgstr "Postavke"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1740,12 +1732,6 @@ msgstr "Federacija"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1962,14 +1948,23 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "Plugin documentation"
+msgstr "Piši dokumentaciju"
+
+#. type: Yaml Front Matter Hash Value: description
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2081,9 +2076,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2102,9 +2104,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2198,9 +2201,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2224,14 +2234,29 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "User documentation"
+msgstr "Piši dokumentaciju"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2318,9 +2343,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2413,6 +2445,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2499,9 +2532,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2514,9 +2554,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2574,9 +2621,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2611,9 +2666,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2626,10 +2688,18 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, fuzzy, no-wrap
+#| msgid "General information"
+msgid "Channel configuration"
+msgstr "Opće informacije"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -2666,14 +2736,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2774,9 +2852,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2784,9 +2869,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2857,8 +2943,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2878,9 +2965,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3113,9 +3207,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3321,9 +3416,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3400,11 +3502,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3490,12 +3587,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3558,9 +3649,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text
@@ -3587,39 +3685,3 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
-
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "Kontaktiraj autora"
-
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "Kontaktiraj me"
-
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "Kodeks ponašanja"
-
-#, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "Dokumentacija"
-
-#, no-wrap
-#~ msgid "Give your feedback"
-#~ msgstr "Šalji povratne informacije"
-
-#, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "Doprinošenje"
-
-#, no-wrap
-#~ msgid "Translate the plugin"
-#~ msgstr "Prevedi dodatak"
-
-#, no-wrap
-#~ msgid "Translate"
-#~ msgstr "Prevodi"
-
-#, no-wrap
-#~ msgid "Settings"
-#~ msgstr "Postavke"

--- a/support/documentation/po/livechat.hu.po
+++ b/support/documentation/po/livechat.hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hu/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.hu.po
+++ b/support/documentation/po/livechat.hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hu/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.is.po
+++ b/support/documentation/po/livechat.is.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Icelandic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/is/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.is.po
+++ b/support/documentation/po/livechat.is.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Icelandic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/is/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.it.po
+++ b/support/documentation/po/livechat.it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 14:21+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: Italian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/it/>\n"
@@ -17,96 +17,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "Contattare l'autore"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+msgid "Contact me"
+msgstr "Contattarmi"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -118,9 +39,16 @@ msgstr "Se avete domande, o volete parlare di questo plugin, potete unirvi a que
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Se volete sostenere il progetto finanziariamente, potete contattarmi via email all'indirizzo git.[at].john-livingston.fr. o utilizzare il mio [profilo Liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr "Codice di comportamento dei Contributori⋅trici"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text
@@ -3577,15 +3671,3 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
-
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "Contattare l'autore"
-
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "Contattarmi"
-
-#, no-wrap
-#~ msgid "Contributor Covenant Code of Conduct"
-#~ msgstr "Codice di comportamento dei Contributori⋅trici"

--- a/support/documentation/po/livechat.it.po
+++ b/support/documentation/po/livechat.it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 14:21+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: Italian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/it/>\n"
@@ -17,17 +17,96 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
-msgstr "Contattare l'autore"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "Contattarmi"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -39,16 +118,9 @@ msgstr "Se avete domande, o volete parlare di questo plugin, potete unirvi a que
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "Se volete sostenere il progetto finanziariamente, potete contattarmi via email all'indirizzo git.[at].john-livingston.fr. o utilizzare il mio [profilo Liberapay](https://liberapay.com/JohnLivingston/)."
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr "Codice di comportamento dei Contributori⋅trici"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3661,3 +3577,15 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr ""
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "Contattare l'autore"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "Contattarmi"
+
+#, no-wrap
+#~ msgid "Contributor Covenant Code of Conduct"
+#~ msgstr "Codice di comportamento dei Contributori⋅trici"

--- a/support/documentation/po/livechat.ja.po
+++ b/support/documentation/po/livechat.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2024-03-10 20:38+0000\n"
 "Last-Translator: \"T.S\" <fusen@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Japanese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ja/>\n"
@@ -18,17 +18,96 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
-msgstr "作者に問い合わせる"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
-msgstr "お問い合わせ"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -40,28 +119,20 @@ msgstr "もし、ご質問、このプラグインに関して話したいこと
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "もし、プロジェクトを金銭面でご支援頂ける場合は、メールにて git.[at].john-livingston.fr, までご連絡頂くか、私の[Liberapay profile](https://liberapay.com/JohnLivingston/)をご確認頂けますと幸いです。"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr "コントリビューター規約の行動規範"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
-msgstr "コード規約"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "この行動規範は、[Contributor Covenant](https://www.contributor-covenant.org)のバージョン 2.1を基に作成されており、[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)から入手できます。  翻訳は[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)にあります。  虐待的、嫌がらせ、またはその他の受け入れられない行為の事例は、執行を担当するコミュニティリーダーに、git.[at].john-livingston.fr宛のメールで報告することができます。"
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "開発"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -144,10 +215,21 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
+msgstr "開発"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -203,6 +285,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -380,18 +467,10 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, fuzzy, no-wrap
-msgid "Documentation"
-msgstr "ドキュメンテーション"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -594,10 +673,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -605,27 +683,19 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, fuzzy, no-wrap
-msgid "Contributing"
-msgstr "はじめに"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -872,17 +942,10 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, fuzzy, no-wrap
-msgid "Plugin Credits"
-msgstr "クレジット"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, fuzzy, no-wrap
-msgid "Credits"
-msgstr "クレジット"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -940,28 +1003,14 @@ msgstr "経済的な支援を行って頂いている[ritimo](https://www.ritimo
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -969,16 +1018,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1499,10 +1541,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1512,18 +1553,11 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, fuzzy, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
+#, fuzzy
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr "クレジット"
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
-msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1693,29 +1727,15 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, fuzzy, no-wrap
-msgid "Plugin Peertube Livechat administration"
-msgstr "クレジット"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, fuzzy, no-wrap
-msgid "Admin documentation"
-msgstr "ドキュメンテーション"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, fuzzy, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr "クレジット"
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, fuzzy, no-wrap
-msgid "Settings"
-msgstr "クレジット"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1737,6 +1757,12 @@ msgstr "ドキュメンテーション"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1966,22 +1992,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, fuzzy, no-wrap
-msgid "Plugin documentation"
-msgstr "ドキュメンテーション"
-
-#. type: Yaml Front Matter Hash Value: description
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2091,16 +2109,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, fuzzy, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr "PeerTube ライブチャットプラグイン"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2119,10 +2130,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2221,16 +2231,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2254,28 +2257,15 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, fuzzy, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+#, fuzzy
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr "PeerTube ライブチャットプラグイン"
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, fuzzy, no-wrap
-msgid "User documentation"
-msgstr "ドキュメンテーション"
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2368,16 +2358,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2474,7 +2457,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, fuzzy, no-wrap
 msgid "Moderation"
@@ -2567,16 +2549,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2591,16 +2566,9 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2663,18 +2631,10 @@ msgstr "新しい機能のリクエスト、バグ、プラグインのセット
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, fuzzy, no-wrap
-msgid "Chat bot"
-msgstr "クレジット"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2711,16 +2671,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2735,16 +2688,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "![チャット画面のスクリーンショット](/peertube-plugin-livechat/images/chat.png?classes=shadow,border&height=200px)"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2786,22 +2732,15 @@ msgstr "PeerTube ライブチャットプラグイン"
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, fuzzy, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+#, fuzzy
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr "PeerTube ライブチャットプラグイン"
 
 #. type: Plain text
@@ -2904,16 +2843,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, fuzzy, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr "PeerTube ライブチャットプラグイン"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2921,10 +2853,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, fuzzy, no-wrap
 msgid "Introduction"
 msgstr "はじめに"
@@ -2998,9 +2929,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -3022,16 +2952,9 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3284,10 +3207,9 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3501,16 +3423,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3589,6 +3504,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3680,6 +3600,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, fuzzy, no-wrap
+msgid "Chat bot"
+msgstr "クレジット"
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 #, fuzzy
@@ -3743,17 +3669,10 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, fuzzy, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr "新規機能のリクエスト / バグトラッキング"
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, fuzzy, no-wrap
-msgid "Bug tracking & new features"
-msgstr "新規機能のリクエスト / バグトラッキング"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+msgstr ""
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3779,6 +3698,82 @@ msgstr ""
 #: support/documentation/content/en/issues/_index.md
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "あなたがWebデザイナーの方または、ConverseJS/Prosody/XMPP上級者の方の場合は、このプラグインをより良くする為に力を貸してください、歓迎致します。"
+
+#, no-wrap
+#~ msgid "Contact the author"
+#~ msgstr "作者に問い合わせる"
+
+#, no-wrap
+#~ msgid "Contact me"
+#~ msgstr "お問い合わせ"
+
+#, no-wrap
+#~ msgid "Contributor Covenant Code of Conduct"
+#~ msgstr "コントリビューター規約の行動規範"
+
+#, no-wrap
+#~ msgid "Code of Conduct"
+#~ msgstr "コード規約"
+
+#, fuzzy, no-wrap
+#~ msgid "Documentation"
+#~ msgstr "ドキュメンテーション"
+
+#, fuzzy, no-wrap
+#~ msgid "Contributing"
+#~ msgstr "はじめに"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin Credits"
+#~ msgstr "クレジット"
+
+#, fuzzy, no-wrap
+#~ msgid "Credits"
+#~ msgstr "クレジット"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin Peertube Livechat administration"
+#~ msgstr "クレジット"
+
+#, fuzzy, no-wrap
+#~ msgid "Admin documentation"
+#~ msgstr "ドキュメンテーション"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin Peertube Livechat settings"
+#~ msgstr "クレジット"
+
+#, fuzzy, no-wrap
+#~ msgid "Settings"
+#~ msgstr "クレジット"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin documentation"
+#~ msgstr "ドキュメンテーション"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat installation guide"
+#~ msgstr "PeerTube ライブチャットプラグイン"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat user documentation"
+#~ msgstr "PeerTube ライブチャットプラグイン"
+
+#, fuzzy, no-wrap
+#~ msgid "User documentation"
+#~ msgstr "ドキュメンテーション"
+
+#, fuzzy, no-wrap
+#~ msgid "Plugin peertube-plugin-livechat slow mode"
+#~ msgstr "PeerTube ライブチャットプラグイン"
+
+#, fuzzy, no-wrap
+#~ msgid "Bug tracking / New features requests"
+#~ msgstr "新規機能のリクエスト / バグトラッキング"
+
+#, fuzzy, no-wrap
+#~ msgid "Bug tracking & new features"
+#~ msgstr "新規機能のリクエスト / バグトラッキング"
 
 #, fuzzy
 #~| msgid "![Fullscreen chat screenshot](/peertube-plugin-livechat/images/fullscreen.png?classes=shadow,border&height=200px)"

--- a/support/documentation/po/livechat.ja.po
+++ b/support/documentation/po/livechat.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2024-03-10 20:38+0000\n"
 "Last-Translator: \"T.S\" <fusen@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Japanese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ja/>\n"
@@ -18,96 +18,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
-msgstr ""
+msgid "Contact the author"
+msgstr "作者に問い合わせる"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
-msgstr ""
+msgid "Contact me"
+msgstr "お問い合わせ"
 
 #. type: Plain text
 #: support/documentation/content/en/contact/_index.md
@@ -119,20 +40,28 @@ msgstr "もし、ご質問、このプラグインに関して話したいこと
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr "もし、プロジェクトを金銭面でご支援頂ける場合は、メールにて git.[at].john-livingston.fr, までご連絡頂くか、私の[Liberapay profile](https://liberapay.com/JohnLivingston/)をご確認頂けますと幸いです。"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr "コントリビューター規約の行動規範"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
+msgstr "コード規約"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr "この行動規範は、[Contributor Covenant](https://www.contributor-covenant.org)のバージョン 2.1を基に作成されており、[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)から入手できます。  翻訳は[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)にあります。  虐待的、嫌がらせ、またはその他の受け入れられない行為の事例は、執行を担当するコミュニティリーダーに、git.[at].john-livingston.fr宛のメールで報告することができます。"
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
-msgstr ""
+#, no-wrap
+msgid "Develop"
+msgstr "開発"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -224,12 +153,6 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
 msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
-msgstr "開発"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
@@ -467,10 +390,18 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
 msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, fuzzy, no-wrap
+msgid "Documentation"
+msgstr "ドキュメンテーション"
 
 #. type: Title ##
 #: support/documentation/content/en/contributing/document/_index.md
@@ -673,9 +604,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -683,19 +615,27 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Contributing"
+msgstr "はじめに"
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -942,10 +882,17 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Plugin Credits"
+msgstr "クレジット"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, fuzzy, no-wrap
+msgid "Credits"
+msgstr "クレジット"
 
 #. type: Plain text
 #: support/documentation/content/en/credits/_index.md
@@ -1003,14 +950,28 @@ msgstr "経済的な支援を行って頂いている[ritimo](https://www.ritimo
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1018,9 +979,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1541,9 +1509,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1553,11 +1522,18 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, fuzzy
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
 msgstr "クレジット"
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
+msgstr ""
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1727,15 +1703,29 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Plugin Peertube Livechat administration"
+msgstr "クレジット"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, fuzzy, no-wrap
+msgid "Admin documentation"
+msgstr "ドキュメンテーション"
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr "クレジット"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, fuzzy, no-wrap
+msgid "Settings"
+msgstr "クレジット"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -1757,12 +1747,6 @@ msgstr "ドキュメンテーション"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1992,14 +1976,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin documentation"
+msgstr "ドキュメンテーション"
+
+#. type: Yaml Front Matter Hash Value: description
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2109,9 +2101,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr "PeerTube ライブチャットプラグイン"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2130,9 +2129,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2231,9 +2231,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2257,15 +2264,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-#, fuzzy
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr "PeerTube ライブチャットプラグイン"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, fuzzy, no-wrap
+msgid "User documentation"
+msgstr "ドキュメンテーション"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2358,9 +2378,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2457,6 +2484,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, fuzzy, no-wrap
 msgid "Moderation"
@@ -2549,9 +2577,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2566,9 +2601,16 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2631,10 +2673,18 @@ msgstr "新しい機能のリクエスト、バグ、プラグインのセット
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Chat bot setup"
+msgstr "クレジット"
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, fuzzy, no-wrap
+msgid "Chat bot"
+msgstr "クレジット"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -2671,9 +2721,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2688,9 +2745,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr "![チャット画面のスクリーンショット](/peertube-plugin-livechat/images/chat.png?classes=shadow,border&height=200px)"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2732,15 +2796,22 @@ msgstr "PeerTube ライブチャットプラグイン"
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, fuzzy
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr "PeerTube ライブチャットプラグイン"
 
 #. type: Plain text
@@ -2843,9 +2914,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, fuzzy, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr "PeerTube ライブチャットプラグイン"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2853,9 +2931,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, fuzzy, no-wrap
 msgid "Introduction"
 msgstr "はじめに"
@@ -2929,8 +3008,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2952,9 +3032,16 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3207,9 +3294,10 @@ msgstr "![チャット画面のスクリーンショット](/peertube-plugin-liv
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3423,9 +3511,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3504,11 +3599,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3600,12 +3690,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, fuzzy, no-wrap
-msgid "Chat bot"
-msgstr "クレジット"
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 #, fuzzy
@@ -3669,10 +3753,17 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
-msgstr ""
+#, fuzzy, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr "新規機能のリクエスト / バグトラッキング"
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, fuzzy, no-wrap
+msgid "Bug tracking & new features"
+msgstr "新規機能のリクエスト / バグトラッキング"
 
 #. type: Plain text
 #: support/documentation/content/en/issues/_index.md
@@ -3699,81 +3790,17 @@ msgstr ""
 msgid "If you are a webdesigner or a ConverseJS/Prosody/XMPP expert, and want to help improve this plugin, you are welcome."
 msgstr "あなたがWebデザイナーの方または、ConverseJS/Prosody/XMPP上級者の方の場合は、このプラグインをより良くする為に力を貸してください、歓迎致します。"
 
-#, no-wrap
-#~ msgid "Contact the author"
-#~ msgstr "作者に問い合わせる"
-
-#, no-wrap
-#~ msgid "Contact me"
-#~ msgstr "お問い合わせ"
-
-#, no-wrap
-#~ msgid "Contributor Covenant Code of Conduct"
-#~ msgstr "コントリビューター規約の行動規範"
-
-#, no-wrap
-#~ msgid "Code of Conduct"
-#~ msgstr "コード規約"
-
-#, fuzzy, no-wrap
-#~ msgid "Documentation"
-#~ msgstr "ドキュメンテーション"
-
-#, fuzzy, no-wrap
-#~ msgid "Contributing"
-#~ msgstr "はじめに"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin Credits"
+#, fuzzy
+#~ msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 #~ msgstr "クレジット"
 
-#, fuzzy, no-wrap
-#~ msgid "Credits"
-#~ msgstr "クレジット"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin Peertube Livechat administration"
-#~ msgstr "クレジット"
-
-#, fuzzy, no-wrap
-#~ msgid "Admin documentation"
-#~ msgstr "ドキュメンテーション"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin Peertube Livechat settings"
-#~ msgstr "クレジット"
-
-#, fuzzy, no-wrap
-#~ msgid "Settings"
-#~ msgstr "クレジット"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin documentation"
-#~ msgstr "ドキュメンテーション"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat installation guide"
+#, fuzzy
+#~ msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 #~ msgstr "PeerTube ライブチャットプラグイン"
 
-#, fuzzy, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat user documentation"
+#, fuzzy
+#~ msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 #~ msgstr "PeerTube ライブチャットプラグイン"
-
-#, fuzzy, no-wrap
-#~ msgid "User documentation"
-#~ msgstr "ドキュメンテーション"
-
-#, fuzzy, no-wrap
-#~ msgid "Plugin peertube-plugin-livechat slow mode"
-#~ msgstr "PeerTube ライブチャットプラグイン"
-
-#, fuzzy, no-wrap
-#~ msgid "Bug tracking / New features requests"
-#~ msgstr "新規機能のリクエスト / バグトラッキング"
-
-#, fuzzy, no-wrap
-#~ msgid "Bug tracking & new features"
-#~ msgstr "新規機能のリクエスト / バグトラッキング"
 
 #, fuzzy
 #~| msgid "![Fullscreen chat screenshot](/peertube-plugin-livechat/images/fullscreen.png?classes=shadow,border&height=200px)"

--- a/support/documentation/po/livechat.kab.po
+++ b/support/documentation/po/livechat.kab.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Kabyle <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/kab/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.kab.po
+++ b/support/documentation/po/livechat.kab.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Kabyle <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/kab/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nb.po
+++ b/support/documentation/po/livechat.nb.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nb_NO/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nb.po
+++ b/support/documentation/po/livechat.nb.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nb_NO/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nl.po
+++ b/support/documentation/po/livechat.nl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nl/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nl.po
+++ b/support/documentation/po/livechat.nl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nl/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nn.po
+++ b/support/documentation/po/livechat.nn.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Nynorsk <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nn/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.nn.po
+++ b/support/documentation/po/livechat.nn.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Nynorsk <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nn/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.oc.po
+++ b/support/documentation/po/livechat.oc.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Occitan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/oc/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.oc.po
+++ b/support/documentation/po/livechat.oc.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Occitan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/oc/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.pl.po
+++ b/support/documentation/po/livechat.pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pl/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.pl.po
+++ b/support/documentation/po/livechat.pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pl/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.pt.po
+++ b/support/documentation/po/livechat.pt.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pt/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.pt.po
+++ b/support/documentation/po/livechat.pt.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pt/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.ru.po
+++ b/support/documentation/po/livechat.ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ru/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.ru.po
+++ b/support/documentation/po/livechat.ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ru/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.sq.po
+++ b/support/documentation/po/livechat.sq.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Albanian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sq/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.sq.po
+++ b/support/documentation/po/livechat.sq.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Albanian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sq/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.sv.po
+++ b/support/documentation/po/livechat.sv.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sv/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.sv.po
+++ b/support/documentation/po/livechat.sv.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sv/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.th.po
+++ b/support/documentation/po/livechat.th.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/th/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.th.po
+++ b/support/documentation/po/livechat.th.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/th/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.tok.po
+++ b/support/documentation/po/livechat.tok.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Toki Pona <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/tok/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.tok.po
+++ b/support/documentation/po/livechat.tok.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Toki Pona <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/tok/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.tr.po
+++ b/support/documentation/po/livechat.tr.po
@@ -1,92 +1,13 @@
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -99,9 +20,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -109,9 +37,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -203,12 +132,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -447,9 +370,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -653,9 +584,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -663,9 +595,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -673,9 +606,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -921,9 +861,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -971,14 +918,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -986,9 +947,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1509,9 +1477,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1521,9 +1490,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the Prosody check section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1689,14 +1666,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1719,12 +1710,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1941,14 +1926,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2058,9 +2051,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2079,9 +2079,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2175,9 +2176,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2201,14 +2209,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2295,9 +2317,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2390,6 +2419,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2476,9 +2506,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2491,9 +2528,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2551,9 +2595,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2588,9 +2640,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2603,9 +2662,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2643,14 +2709,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2751,9 +2825,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2761,9 +2842,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2834,8 +2916,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2855,9 +2938,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3084,9 +3174,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3292,9 +3383,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3371,11 +3469,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3461,12 +3554,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3529,9 +3616,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.tr.po
+++ b/support/documentation/po/livechat.tr.po
@@ -1,13 +1,92 @@
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -20,16 +99,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -37,10 +109,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -124,9 +195,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -183,6 +265,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -360,17 +447,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -574,10 +653,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -585,10 +663,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -596,16 +673,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -851,16 +921,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -908,28 +971,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -937,16 +986,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1467,10 +1509,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1480,17 +1521,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the Prosody check section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1656,28 +1689,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1700,6 +1719,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1916,22 +1941,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2041,16 +2058,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2069,10 +2079,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2166,16 +2175,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2199,28 +2201,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2307,16 +2295,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2409,7 +2390,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2496,16 +2476,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2518,16 +2491,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2585,17 +2551,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2630,16 +2588,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2652,16 +2603,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2699,22 +2643,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2815,16 +2751,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2832,10 +2761,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2906,9 +2834,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2928,16 +2855,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3164,10 +3084,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3373,16 +3292,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3459,6 +3371,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3544,6 +3461,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3606,16 +3529,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.uk.po
+++ b/support/documentation/po/livechat.uk.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/uk/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.uk.po
+++ b/support/documentation/po/livechat.uk.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/uk/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.vi.po
+++ b/support/documentation/po/livechat.vi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Vietnamese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/vi/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.vi.po
+++ b/support/documentation/po/livechat.vi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Vietnamese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/vi/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.zh-Hans.po
+++ b/support/documentation/po/livechat.zh-Hans.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hans/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.zh-Hans.po
+++ b/support/documentation/po/livechat.zh-Hans.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hans/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.zh-Hant.po
+++ b/support/documentation/po/livechat.zh-Hant.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-23 12:27+0200\n"
+"POT-Creation-Date: 2024-05-23 12:32+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hant/>\n"
@@ -17,95 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"<!--\n"
-"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
+msgid "Contact the author"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contact/_index.md
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#: support/documentation/content/en/contributing/develop/_index.md
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/contributing/feedback/_index.md
-#: support/documentation/content/en/contributing/_index.md
-#: support/documentation/content/en/contributing/translate/_index.md
-#: support/documentation/content/en/credits/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/admin/_index.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#: support/documentation/content/en/documentation/_index.md
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#: support/documentation/content/en/documentation/installation/_index.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#: support/documentation/content/en/documentation/user/_index.md
-#: support/documentation/content/en/documentation/user/obs.md
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/documentation/user/viewers.md
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#: support/documentation/content/en/_index.md
-#: support/documentation/content/en/intro/_index.md
-#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid ""
-"SPDX-License-Identifier: AGPL-3.0-only\n"
-"-->\n"
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/contact/_index.md
-msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
+msgid "Contact me"
 msgstr ""
 
 #. type: Plain text
@@ -118,9 +39,16 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Contributor Covenant Code of Conduct"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#, no-wrap
+msgid "Code of Conduct"
 msgstr ""
 
 #. type: Plain text
@@ -128,9 +56,10 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Plain text
+#. type: Title ##
 #: support/documentation/content/en/contributing/develop/_index.md
-msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -222,12 +151,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -466,9 +389,17 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/document/_index.md
-msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Document the plugin, or translate the documentation."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/documentation/_index.md
+#, no-wrap
+msgid "Documentation"
 msgstr ""
 
 #. type: Title ##
@@ -672,9 +603,10 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/feedback/_index.md
-msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Give your feedback"
 msgstr ""
 
 #. type: Plain text
@@ -682,9 +614,10 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/contributing/_index.md
-msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Contributing"
 msgstr ""
 
 #. type: Plain text
@@ -692,9 +625,16 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/contributing/translate/_index.md
-msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Translate the plugin"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/contributing/translate/_index.md
+#, no-wrap
+msgid "Translate"
 msgstr ""
 
 #. type: Plain text
@@ -940,9 +880,16 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/credits/_index.md
-msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
+#, no-wrap
+msgid "Plugin Credits"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/credits/_index.md
+#, no-wrap
+msgid "Credits"
 msgstr ""
 
 #. type: Plain text
@@ -990,14 +937,28 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Some advanced features"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#, no-wrap
+msgid "Advanced usage"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Using Matterbridge to bridge with other chats"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#, no-wrap
+msgid "Using Matterbridge"
 msgstr ""
 
 #. type: Plain text
@@ -1005,9 +966,16 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Allow connections using XMPP clients"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#, no-wrap
+msgid "XMPP clients"
 msgstr ""
 
 #. type: Plain text
@@ -1528,9 +1496,10 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Title ###
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1540,9 +1509,17 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings - External Authentication"
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1708,14 +1685,28 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/admin/_index.md
-msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat administration"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/admin/_index.md
+#, no-wrap
+msgid "Admin documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/admin/settings.md
-msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin Peertube Livechat settings"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "Settings"
 msgstr ""
 
 #. type: Plain text
@@ -1738,12 +1729,6 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1960,14 +1945,22 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/_index.md
-msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#, no-wrap
+msgid "Known issues: CPU Compatibility"
 msgstr ""
 
 #. type: Plain text
@@ -2077,9 +2070,16 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/_index.md
-msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat installation guide"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/_index.md
+#, no-wrap
+msgid "Installation guide"
 msgstr ""
 
 #. type: Plain text
@@ -2098,9 +2098,10 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some classic mistakes and workarounds."
 msgstr ""
 
 #. type: Title ##
@@ -2194,9 +2195,16 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
+#, no-wrap
+msgid "Important notes when upgrading for an older version."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#, no-wrap
+msgid "Upgrade from version older than 6.0.0"
 msgstr ""
 
 #. type: Title ##
@@ -2220,14 +2228,28 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/_index.md
-msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat user documentation"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/_index.md
+#, no-wrap
+msgid "User documentation"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/obs.md
-msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Documentation to stream the chat content using OBS."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/obs.md
+#, no-wrap
+msgid "OBS"
 msgstr ""
 
 #. type: Plain text
@@ -2314,9 +2336,16 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
+#, no-wrap
+msgid "Some basics about how to setup and use the chat for your live stream"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#, no-wrap
+msgid "Some basics"
 msgstr ""
 
 #. type: Title ##
@@ -2409,6 +2438,7 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2495,9 +2525,16 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
+#, no-wrap
+msgid "The bot can respond to several commands."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#, no-wrap
+msgid "Commands"
 msgstr ""
 
 #. type: Plain text
@@ -2510,9 +2547,16 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
+#, no-wrap
+msgid "The bot can automatically moderate messages containing forbidden words."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#, no-wrap
+msgid "Forbidden words"
 msgstr ""
 
 #. type: Plain text
@@ -2570,9 +2614,17 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
+#, no-wrap
+msgid "Chat bot setup"
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
 msgstr ""
 
 #. type: Plain text
@@ -2607,9 +2659,16 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
+#, no-wrap
+msgid "The bot can send periodically some messages."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#, no-wrap
+msgid "Timers"
 msgstr ""
 
 #. type: Plain text
@@ -2622,9 +2681,16 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Peertube channel chatrooms configuration"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#, no-wrap
+msgid "Channel configuration"
 msgstr ""
 
 #. type: Plain text
@@ -2662,14 +2728,22 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
+#, no-wrap
+msgid "How to setup the chat for your live stream"
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#, no-wrap
+msgid "For streamers"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat advanced moderation features"
 msgstr ""
 
 #. type: Plain text
@@ -2770,9 +2844,16 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat slow mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#, no-wrap
+msgid "Slow mode"
 msgstr ""
 
 #. type: Plain text
@@ -2780,9 +2861,10 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2853,8 +2935,9 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Title ##
+#. type: Yaml Front Matter Hash Value: title
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2874,9 +2957,16 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
+#, no-wrap
+msgid "You can handle tasks and task lists with your moderation team."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#, no-wrap
+msgid "Tasks / To-do lists"
 msgstr ""
 
 #. type: Plain text
@@ -3103,9 +3193,10 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/viewers.md
-msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
+#, no-wrap
+msgid "How to chat for stream viewers"
 msgstr ""
 
 #. type: Title ##
@@ -3311,9 +3402,16 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
+#, no-wrap
+msgid "Connect to chat using a XMPP client"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#, no-wrap
+msgid "XMPP Clients"
 msgstr ""
 
 #. type: Plain text
@@ -3390,11 +3488,6 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
-msgstr ""
-
-#. type: Plain text
-#: support/documentation/content/en/intro/_index.md
-msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3480,12 +3573,6 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
-#. type: Title ##
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
-msgstr ""
-
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3548,9 +3635,16 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Plain text
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/issues/_index.md
-msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
+#, no-wrap
+msgid "Bug tracking / New features requests"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: support/documentation/content/en/issues/_index.md
+#, no-wrap
+msgid "Bug tracking & new features"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/po/livechat.zh-Hant.po
+++ b/support/documentation/po/livechat.zh-Hant.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-05-17 15:56+0200\n"
+"POT-Creation-Date: 2024-05-23 12:27+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hant/>\n"
@@ -17,16 +17,95 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.2\n"
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact the author"
+msgid ""
+"<!--\n"
+"SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contact/_index.md
+#: support/documentation/content/en/contributing/codeofconduct/_index.md
+#: support/documentation/content/en/contributing/develop/_index.md
+#: support/documentation/content/en/contributing/document/_index.md
+#: support/documentation/content/en/contributing/feedback/_index.md
+#: support/documentation/content/en/contributing/_index.md
+#: support/documentation/content/en/contributing/translate/_index.md
+#: support/documentation/content/en/credits/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/_index.md
+#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
+#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
+#: build/documentation/pot_in/documentation/admin/external_auth.md
+#: support/documentation/content/en/documentation/admin/_index.md
+#: build/documentation/pot_in/documentation/admin/settings.md
+#: support/documentation/content/en/documentation/_index.md
+#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
+#: support/documentation/content/en/documentation/installation/_index.md
+#: support/documentation/content/en/documentation/installation/troubleshooting.md
+#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
+#: support/documentation/content/en/documentation/user/_index.md
+#: support/documentation/content/en/documentation/user/obs.md
+#: support/documentation/content/en/documentation/user/streamers/basics.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
+#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
+#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
+#: support/documentation/content/en/documentation/user/streamers/channel.md
+#: support/documentation/content/en/documentation/user/streamers/_index.md
+#: support/documentation/content/en/documentation/user/streamers/moderation.md
+#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
+#: support/documentation/content/en/documentation/user/streamers/tasks.md
+#: support/documentation/content/en/documentation/user/viewers.md
+#: support/documentation/content/en/documentation/user/xmpp_clients.md
+#: support/documentation/content/en/_index.md
+#: support/documentation/content/en/intro/_index.md
+#: support/documentation/content/en/issues/_index.md
 #, no-wrap
-msgid "Contact me"
+msgid ""
+"SPDX-License-Identifier: AGPL-3.0-only\n"
+"-->\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contact/_index.md
+msgid "title: \"Contact me\" description: \"Contact the author\" weight: 80 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -39,16 +118,9 @@ msgstr ""
 msgid "If you want to support the project financially, you can contact me by mail at git.[at].john-livingston.fr, or check my [Liberapay profile](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Contributor Covenant Code of Conduct"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/codeofconduct/_index.md
-#, no-wrap
-msgid "Code of Conduct"
+msgid "title: \"Code of Conduct\" description: \"Contributor Covenant Code of Conduct\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -56,10 +128,9 @@ msgstr ""
 msgid "This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).  Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).  Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by mail at git.[at].john-livingston.fr."
 msgstr ""
 
-#. type: Title ##
+#. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
-#, no-wrap
-msgid "Develop"
+msgid "title: \"Develop\" description: \"Develop\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -143,9 +214,20 @@ msgstr ""
 msgid "`wget`"
 msgstr ""
 
+#. type: Bullet: '* '
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "`reuse`"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/contributing/develop/_index.md
 msgid "Please note that this plugin needs an AppImage for the Prosody XMPP server.  This AppImage is provided by the [Prosody AppImage](https://github.com/JohnXLivingston/prosody-appimage) sideproject.  The `build-prosody.sh` script download binaries attached to this remote repository, and checks that their sha256 hashsum are correct."
+msgstr ""
+
+#. type: Title ##
+#: support/documentation/content/en/contributing/develop/_index.md
+#, no-wrap
+msgid "Develop"
 msgstr ""
 
 #. type: Plain text
@@ -202,6 +284,11 @@ msgstr ""
 #: support/documentation/content/en/contributing/develop/_index.md
 #, no-wrap
 msgid "NODE_ENV=dev npm run build\n"
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/contributing/develop/_index.md
+msgid "This plugin is [REUSE](https://reuse.software/) compliant: it uses SPDX headers to identify licensing information of its source code.  More information on the [REUSE](https://reuse.software/) website.  You can use the [reuse](https://reuse.readthedocs.io/en/stable/readme.html#) command line tool to help you update headers.  The `npm run lint` command will use the `reuse` command to check compliance.  Don't forget to add your copyright information in SPDX headers when you modify some code."
 msgstr ""
 
 #. type: Title ##
@@ -379,17 +466,9 @@ msgstr ""
 msgid "The [livechat-perf-test](https://github.com/JohnXLivingston/livechat-perf-test) repository contains some tools to make performance tests.  It can be used to evaluate code improvements, or find bottlenecks."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
-#, no-wrap
-msgid "Document the plugin, or translate the documentation."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/document/_index.md
-#: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Documentation"
+msgid "title: \"Documentation\" description: \"Document the plugin, or translate the documentation.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -593,10 +672,9 @@ msgstr ""
 msgid "Publishing the documentation is automatic, as soon as the changes are merged into the `documentation` branch."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/feedback/_index.md
-#, no-wrap
-msgid "Give your feedback"
+msgid "title: \"Give your feedback\" description: \"Give your feedback\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -604,10 +682,9 @@ msgstr ""
 msgid "You don't need to know how to code to start contributing to this plugin! Other contributions are very valuable too, among which: you can test the software and report bugs, you can give feedback, features that you are interested in, user interface, design, ..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Plain text
 #: support/documentation/content/en/contributing/_index.md
-#, no-wrap
-msgid "Contributing"
+msgid "title: \"Contributing\" description: \"Contributing\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -615,16 +692,9 @@ msgstr ""
 msgid "Interested in contributing? Awesome!"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate the plugin"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/contributing/translate/_index.md
-#, no-wrap
-msgid "Translate"
+msgid "title: \"Translate\" description: \"Translate the plugin\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -870,16 +940,9 @@ msgstr ""
 msgid "Please be inclusive in your wordings, and please respect the [code of coduct](/peertube-plugin-livechat/contributing/codeofconduct/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Plugin Credits"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/credits/_index.md
-#, no-wrap
-msgid "Credits"
+msgid "title: \"Credits\" description: \"Plugin Credits\" weight: 90 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -927,28 +990,14 @@ msgstr ""
 msgid "And thanks to all individual contributors who have made a donation via my [liberapay page](https://liberapay.com/JohnLivingston/)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Some advanced features"
+msgid "title: \"Advanced usage\" description: \"Some advanced features\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/_index.md
-#, no-wrap
-msgid "Advanced usage"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge to bridge with other chats"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/matterbridge.md
-#, no-wrap
-msgid "Using Matterbridge"
+msgid "title: \"Using Matterbridge\" description: \"Using Matterbridge to bridge with other chats\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -956,16 +1005,9 @@ msgstr ""
 msgid "Here is a tutorial to use Matterbridge with the plugin: <https://gitlab.com/refrac/obs-matterbridge-overlay/-/blob/master/documentation/peertube.md>"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "Allow connections using XMPP clients"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
-#, no-wrap
-msgid "XMPP clients"
+msgid "title: \"XMPP clients\" description: \"Allow connections using XMPP clients\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1486,10 +1528,9 @@ msgid ""
 "  check certs\n"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ###
 #: support/documentation/content/en/documentation/admin/advanced/xmpp_clients.md
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#: support/documentation/content/en/documentation/installation/troubleshooting.md
 #, no-wrap
 msgid "Troubleshooting"
 msgstr ""
@@ -1499,17 +1540,9 @@ msgstr ""
 msgid "If you can't make it work, you can use the diagnostic tool (there is a button on top of the plugin settings page), and take a close look on the «Prosody check» section."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings - External Authentication"
-msgstr ""
-
-#. type: Title ##
-#: build/documentation/pot_in/documentation/admin/external_auth.md
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "External Authentication"
+msgid "title: \"External Authentication\" description: \"Plugin Peertube Livechat settings - External Authentication\" weight: 15 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1675,28 +1708,14 @@ msgstr ""
 msgid "Other authentication methods will be implemented in the future."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Plugin Peertube Livechat administration"
+msgid "title: \"Admin documentation\" description: \"Plugin Peertube Livechat administration\" weight: 30 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/admin/_index.md
-#, no-wrap
-msgid "Admin documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Plugin Peertube Livechat settings"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/admin/settings.md
-#, no-wrap
-msgid "Settings"
+msgid "title: \"Settings\" description: \"Plugin Peertube Livechat settings\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -1719,6 +1738,12 @@ msgstr ""
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "Following settings concern the federation with other Peertube instances, and other fediverse softwares."
+msgstr ""
+
+#. type: Title ##
+#: build/documentation/pot_in/documentation/admin/settings.md
+#, no-wrap
+msgid "External Authentication"
 msgstr ""
 
 #. type: Plain text
@@ -1935,22 +1960,14 @@ msgstr ""
 msgid "More informations on Prosody external components [here](https://prosody.im/doc/components)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/_index.md
-#, no-wrap
-msgid "Plugin documentation"
+msgid "title: \"Documentation\" description: \"Plugin documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/cpu_compatibility.md
-#, no-wrap
-msgid "Known issues: CPU Compatibility"
+msgid "title: \"Known issues: CPU Compatibility\" description: \"For now, the plugin only works out of the box for x86_64 and arm64 CPU architecture. Here are some instructions for other CPU architectures.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2060,16 +2077,9 @@ msgstr ""
 msgid "But it may be removed in a near feature (to avoid drawbacks of this method).  I have to discuss with Yunohost team, to decide how we can do to minimize drawbacks, and maximize compatibility."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat installation guide"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/_index.md
-#, no-wrap
-msgid "Installation guide"
+msgid "title: \"Installation guide\" description: \"Plugin peertube-plugin-livechat installation guide\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2088,10 +2098,9 @@ msgstr ""
 msgid "Here are some other more specific instructions:"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
-#, no-wrap
-msgid "Some classic mistakes and workarounds."
+msgid "title: \"Troubleshooting\" description: \"Some classic mistakes and workarounds.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2185,16 +2194,9 @@ msgstr ""
 msgid "If you can't fix this immediatly, you can disable Websocket by unchecking \"{{% livechat_label disable_websocket_label %}}\" in the plugin setting page.  In such case, you should also check \"{{% livechat_label federation_dont_publish_remotely_label %}}\", as chat federation won't work without Websocket."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Important notes when upgrading for an older version."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/installation/upgrade_before_6.0.0.md
-#, no-wrap
-msgid "Upgrade from version older than 6.0.0"
+msgid "title: \"Upgrade from version older than 6.0.0\" description: \"Important notes when upgrading for an older version.\" weight: 50 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2218,28 +2220,14 @@ msgstr ""
 msgid "If you were using the custom Peertube docker image that is embedding Prosody, you can switch back to the official Peertube image."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat user documentation"
+msgid "title: \"User documentation\" description: \"Plugin peertube-plugin-livechat user documentation\" weight: 10 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/_index.md
-#, no-wrap
-msgid "User documentation"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "Documentation to stream the chat content using OBS."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/obs.md
-#, no-wrap
-msgid "OBS"
+msgid "title: \"OBS\" description: \"Documentation to stream the chat content using OBS.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2326,16 +2314,9 @@ msgstr ""
 msgid "You can use the [social_stream browser extension](https://github.com/steveseguin/social_stream#readme) to mix multiple chat source (from Peertube, Twitch, Youtube, Facebook, ...) and include their contents in your live stream.  The compatibility with this plugin was added in recent versions."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics about how to setup and use the chat for your live stream"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/basics.md
-#, no-wrap
-msgid "Some basics"
+msgid "title: \"Some basics\" description: \"Some basics about how to setup and use the chat for your live stream\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -2428,7 +2409,6 @@ msgstr ""
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
-#: support/documentation/content/en/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Moderation"
@@ -2515,16 +2495,9 @@ msgstr ""
 msgid "The chat will be automatically recreated each time someone tries to join it as long as the video exists, and has the \"{{% livechat_label use_chat %}}\" feature activated."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "The bot can respond to several commands."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
-#, no-wrap
-msgid "Commands"
+msgid "title: \"Commands\" description: \"The bot can respond to several commands.\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2537,16 +2510,9 @@ msgstr ""
 msgid "You can setup several commands."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "The bot can automatically moderate messages containing forbidden words."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
-#, no-wrap
-msgid "Forbidden words"
+msgid "title: \"Forbidden words\" description: \"The bot can automatically moderate messages containing forbidden words.\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2604,17 +2570,9 @@ msgstr ""
 msgid "By checking this option, each line of the \"{{% livechat_label livechat_configuration_channel_forbidden_words_label %}}\" field will be considered as a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#, no-wrap
-msgid "Chat bot setup"
-msgstr ""
-
-#. type: Title ##
-#: support/documentation/content/en/documentation/user/streamers/bot/_index.md
-#: support/documentation/content/en/intro/_index.md
-#, no-wrap
-msgid "Chat bot"
+msgid "title: \"Chat bot\" description: \"Chat bot setup\" weight: 40 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2649,16 +2607,9 @@ msgstr ""
 msgid "The bot will reload instantly when you save the page."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "The bot can send periodically some messages."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
-#, no-wrap
-msgid "Timers"
+msgid "title: \"Timers\" description: \"The bot can send periodically some messages.\" weight: 20 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2671,16 +2622,9 @@ msgstr ""
 msgid "![Timers configuration](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px)"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Peertube channel chatrooms configuration"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/channel.md
-#, no-wrap
-msgid "Channel configuration"
+msgid "title: \"Channel configuration\" description: \"Peertube channel chatrooms configuration\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2718,22 +2662,14 @@ msgstr ""
 msgid "More features to come..."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "How to setup the chat for your live stream"
+msgid "title: \"For streamers\" description: \"How to setup the chat for your live stream\" weight: 20 chapter: false"
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/_index.md
-#, no-wrap
-msgid "For streamers"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat advanced moderation features"
+msgid "title: \"Moderation\" description: \"Plugin peertube-plugin-livechat advanced moderation features\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2834,16 +2770,9 @@ msgstr ""
 msgid "From there, you can also promote yourself as room moderator by using the \"{{% livechat_label promote %}}\" button on the right."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Plugin peertube-plugin-livechat slow mode"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#, no-wrap
-msgid "Slow mode"
+msgid "title: \"Slow mode\" description: \"Plugin peertube-plugin-livechat slow mode\" weight: 30 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -2851,10 +2780,9 @@ msgstr ""
 msgid "This feature comes with the livechat plugin version 8.3.0."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#: support/documentation/content/en/intro/_index.md
 #, no-wrap
 msgid "Introduction"
 msgstr ""
@@ -2925,9 +2853,8 @@ msgstr ""
 msgid "To modify the value for an already existing room, just open the room \"configuration\" menu (on top of the chat window), and change the slow mode value in the configuration form."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: title
+#. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
-#: support/documentation/content/en/documentation/user/viewers.md
 #, no-wrap
 msgid "For viewers"
 msgstr ""
@@ -2947,16 +2874,9 @@ msgstr ""
 msgid "When they send a message, the input field will be disabled for X seconds (where X is the slow mode duration)."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "You can handle tasks and task lists with your moderation team."
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/streamers/tasks.md
-#, no-wrap
-msgid "Tasks / To-do lists"
+msgid "title: \"Tasks / To-do lists\" description: \"You can handle tasks and task lists with your moderation team.\" weight: 35 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3183,10 +3103,9 @@ msgstr ""
 msgid "Using this feature, for example, you can ask your moderators to highlight all chat questions, so you can see them at a glance during your livestream, and check them as answered."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
-#, no-wrap
-msgid "How to chat for stream viewers"
+msgid "title: \"For viewers\" description: \"How to chat for stream viewers\" weight: 10 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3392,16 +3311,9 @@ msgstr ""
 msgid "You can also change your nickname using the chat menu."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "Connect to chat using a XMPP client"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/documentation/user/xmpp_clients.md
-#, no-wrap
-msgid "XMPP Clients"
+msgid "title: \"XMPP Clients\" description: \"Connect to chat using a XMPP client\" weight: 60 chapter: false"
 msgstr ""
 
 #. type: Plain text
@@ -3478,6 +3390,11 @@ msgstr ""
 #. type: Plain text
 #: support/documentation/content/en/_index.md
 msgid "You can use the searchbox in the left menu to quickly find specific documentation parts."
+msgstr ""
+
+#. type: Plain text
+#: support/documentation/content/en/intro/_index.md
+msgid "title: \"Introduction\" description: \"Introduction\" weight: 5 chapter: false"
 msgstr ""
 
 #. type: Title ##
@@ -3563,6 +3480,12 @@ msgstr ""
 msgid "Some times, you have to protect your community from bad people.  As an instance administrator, you can choose to disallow federation for the livechat plugin.  If remote actors behave badly, streamers, moderators and administrators can ban or mute users."
 msgstr ""
 
+#. type: Title ##
+#: support/documentation/content/en/intro/_index.md
+#, no-wrap
+msgid "Chat bot"
+msgstr ""
+
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "This plugin comes with a built-in [chat bot](/peertube-plugin-livechat/documentation/user/streamers/bot/).  Check its documentation for more information."
@@ -3625,16 +3548,9 @@ msgstr ""
 msgid "You can even activate the chat for specific VOD videos.  This is how the [demo](https://www.yiny.org/w/399a8d13-d4cf-4ef2-b843-98530a8ccbae) page works: it is not a live stream, but I have activated the chat specifically for this video."
 msgstr ""
 
-#. type: Yaml Front Matter Hash Value: description
+#. type: Plain text
 #: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking / New features requests"
-msgstr ""
-
-#. type: Yaml Front Matter Hash Value: title
-#: support/documentation/content/en/issues/_index.md
-#, no-wrap
-msgid "Bug tracking & new features"
+msgid "title: \"Bug tracking & new features\" description: \"Bug tracking / New features requests\" weight: 70 chapter: false"
 msgstr ""
 
 #. type: Plain text

--- a/support/documentation/static/css/livechatdoc.css
+++ b/support/documentation/static/css/livechatdoc.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 :root {
   /* more contrast than the default theme. */
   --MAIN-TEXT-color:#000; /* Color of text by default */

--- a/support/documentation/static/images/favicon.png.license
+++ b/support/documentation/static/images/favicon.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/support/forbidden_words/README.md
+++ b/support/forbidden_words/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Chat bot: forbidden words or expressions
 
 This page lists some common options you can use to configure the bot forbidden words feature.

--- a/support/forbidden_words/import-wikimedia.md
+++ b/support/forbidden_words/import-wikimedia.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # import-wikimedia.mjs
 
 The [import-wikimedia.mjs](./import-wikimedia.mjs) script can be used to generate some word lists.

--- a/support/forbidden_words/import-wikimedia.mjs
+++ b/support/forbidden_words/import-wikimedia.mjs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 John Livingston <https://www.john-livingston.fr/>
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/support/forbidden_words/lists/en.english_swear_words.md
+++ b/support/forbidden_words/lists/en.english_swear_words.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Insultes en français
 
 ## Source

--- a/support/forbidden_words/lists/fr.insultes_en_francais.md
+++ b/support/forbidden_words/lists/fr.insultes_en_francais.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Insultes en français
 
 ## Source

--- a/support/forbidden_words/lists/fr.termes_vulgaires_en_francais.md
+++ b/support/forbidden_words/lists/fr.termes_vulgaires_en_francais.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 # Termes vulgaires en français
 
 ## Source


### PR DESCRIPTION
## Description

Reuse (https://reuse.software/) compliance.

Replaces https://github.com/JohnXLivingston/peertube-plugin-livechat/pull/195
