### PR TITLE
New setting to listen C2S connection on non-localhost interfaces (#377).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## ??? (Not Released Yet)
+
+### New features
+
+* #377: new setting to listen C2S connection on non-localhost interfaces.
+
 ## 10.0.2
 
 ### Minor changes and fixes

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -254,6 +254,7 @@ function register (clientOptions: RegisterClientOptions): void {
       const name = options.setting.name
       switch (name) {
         case 'prosody-c2s-port':
+        case 'prosody-c2s-interfaces':
           return options.formValues['prosody-c2s'] !== true
         case 'prosody-s2s-port':
         case 'prosody-s2s-interfaces':

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -301,6 +301,21 @@ prosody_c2s_port_description: |
   You can keep this port closed on your firewall for now, it will not be accessed from the outer world.<br>
   Note: this might change in a near future, as it is planned to add a feature to activate external connections.
 
+
+prosody_c2s_interfaces_label: "Client to server network interfaces"
+prosody_c2s_interfaces_description: |
+  The network interfaces to listen on for client to server connections.<br>
+  This settings is provided for advanced users. Don't change this settings if you don't fully understand what it means.<br>
+  List of IP to listen on, coma separated (spaces will be stripped).<br>
+  You can use «*» to listen on all IPv4 interfaces, and «::» for all IPv6.<br>
+  Examples:
+  <ul>
+    <li>*, ::</li>
+    <li>*</li>
+    <li>127.0.0.1, ::1</li>
+    <li>127.0.0.1, ::1, 172.18.0.42</li>
+  </ul>
+
 prosody_components_label: "Enable custom Prosody external components"
 prosody_components_description: |
   Enable the use of external XMPP components.<br>

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -337,8 +337,9 @@ class ProsodyConfigContent {
     }
   }
 
-  useC2S (c2sPort: string): void {
+  useC2S (c2sPort: string, c2sInterfaces: string[]): void {
     this.global.set('c2s_ports', [c2sPort])
+    this.global.set('c2s_interfaces', c2sInterfaces)
   }
 
   useS2S (

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -633,6 +633,15 @@ function initChatServerAdvancedSettings ({ registerSetting }: RegisterServerOpti
   })
 
   registerSetting({
+    name: 'prosody-c2s-interfaces',
+    label: loc('prosody_c2s_interfaces_label'),
+    type: 'input',
+    default: '127.0.0.1, ::1',
+    private: true,
+    descriptionHTML: loc('prosody_c2s_interfaces_description')
+  })
+
+  registerSetting({
     name: 'prosody-components',
     label: loc('prosody_components_label'),
     type: 'input-checkbox',

--- a/support/documentation/content/en/documentation/admin/settings.md
+++ b/support/documentation/content/en/documentation/admin/settings.md
@@ -209,6 +209,10 @@ As example, this option can allow an instance of Matterbridge (once it could use
 
 {{% livechat_label prosody_c2s_port_description %}}
 
+### {{% livechat_label prosody_c2s_interfaces_label %}}
+
+{{% livechat_label prosody_c2s_interfaces_description %}}
+
 ### {{% livechat_label prosody_components_label %}}
 
 This settings enable XMPP external components to connect to the server.


### PR DESCRIPTION
## Description

New setting to listen C2S connection on non-localhost interfaces (#377).

## Related issues

#377

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [ ] I have run `npm run lint` to check that my changes respects the coding conventions
- [x] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files
