### PR TITLE
Handle livechat-active parameter on live creation endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ TODO: tag conversejs livechat branch, and replace commit ID in build-converse.js
 * #416: Deregister prosodyctl interval callback when spawn.stdin disappears.
 * #423: Merging video-watch scope into common scope.
 * Rewriting the share chat dialog with more modern code.
-* #400: Enable the chat by default when a live is created. So that lives created by the Android Peertube Live app will have chat by default.
+* #400: Reading livechat-active parameter on live creation API endpoint. So that the Android Peertube Live app can pass the parameter withing the first (and only) API call.
 
 ## 10.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ TODO: tag conversejs livechat branch, and replace commit ID in build-converse.js
 * #416: Deregister prosodyctl interval callback when spawn.stdin disappears.
 * #423: Merging video-watch scope into common scope.
 * Rewriting the share chat dialog with more modern code.
+* #400: Enable the chat by default when a live is created. So that lives created by the Android Peertube Live app will have chat by default.
 
 ## 10.0.2
 


### PR DESCRIPTION
So that the Android Peertube Live app can enable the chat in one request.
See #400 for more information.

## Description

This concern the plugin when the settings "chat-per-live-video" is true (which is default). In other words, when streamers can enable/disable chat for each lives by themselves.

Before this, when a live was created, the chat was not enabled before the users edits chat meta data, and submit the form.

This PR allow to pass the `livechat-active` parameter.

## Related issues

#400 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files
