### PR TITLE
Deregister prosodyctl interval callback when spawn.stdin disappears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ TODO: tag conversejs livechat branch, and replace commit ID in build-converse.js
 ### Minor changes and fixes
 
 * Fix cleanup on channel deletion.
+* #416: Deregister prosodyctl interval callback when spawn.stdin disappears.
 
 ## 10.0.2
 

--- a/server/lib/prosody/ctl.ts
+++ b/server/lib/prosody/ctl.ts
@@ -165,6 +165,14 @@ async function prosodyCtl (
         options.peertubeHelpers.logger.debug('ProsodyCtl was called in yesMode, writing to standard input.')
         spawned.stdin.write('\n')
       }, 10)
+      spawned.stdin.on('close', () => {
+        options.peertubeHelpers.logger.debug('ProsodyCtl standard input closed, clearing interval.')
+        clearInterval(yesModeInterval)
+      })
+      spawned.stdin.on('error', () => {
+        options.peertubeHelpers.logger.debug('ProsodyCtl standard input errored, clearing interval.')
+        clearInterval(yesModeInterval)
+      })
     }
 
     spawned.stdout.on('data', (data) => {
@@ -186,7 +194,6 @@ async function prosodyCtl (
     // on 'close' and not 'exit', to be sure everything is done
     // (else it can cause trouble by cleaning AppImage extract too soon)
     spawned.on('close', (code) => {
-      if (yesModeInterval) { clearInterval(yesModeInterval) }
       resolve({
         code: code,
         stdout: d,


### PR DESCRIPTION
## Description

Feel free to close & address in a different manner if you have a preferred solution. I'm not super deep into JS/TS stuff, just upstreaming our downstream workaround.

---

Add callbacks to deregister the interval callback when stdin closes or errors out.

De-escalates the issue to the following messages:

- Usually:
```
[...]
server # [   69.269893] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.893 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.281086] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.902 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.291426] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.914 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.297076] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.919 info: Going to launch prosody (/nix/store/9dksh571y1wy0lns6af2qiyy4s9cfx0c-prosody-0.12.4/bin/prosody)
server # [   69.304664] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.927 info: Creating a new http bind proxy
server # [   69.308845] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.931 info: Creating a new websocket proxy
server # [   69.310803] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.934 info: Creating a new s2s websocket proxy
server # [   69.313199] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.935 info: Waiting for the prosody process to launch
server # [   69.314654] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:10.936 debug: ProsodyCtl standard input closed, clearing interval.
server # [   69.813078] peertube[1411]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:48:11.435 info: Verifying prosody is launched
[...]
```

- Sometimes:
```
[...]
server # [   69.574057] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.158 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.583343] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.168 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.593365] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.178 debug: ProsodyCtl was called in yesMode, writing to standard input.
server # [   69.600077] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.184 debug: ProsodyCtl standard input errored, clearing interval.
server # [   69.601829] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.184 info: Going to launch prosody (/nix/store/9dksh571y1wy0lns6af2qiyy4s9cfx0c-prosody-0.12.4/bin/prosody)
server # [   69.612112] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.196 info: Creating a new http bind proxy
server # [   69.615585] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.200 info: Creating a new websocket proxy
server # [   69.617591] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.202 info: Creating a new s2s websocket proxy
server # [   69.620089] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.204 info: Waiting for the prosody process to launch
server # [   69.621706] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.204 debug: ProsodyCtl standard input closed, clearing interval.
server # [   70.122132] peertube[1413]: [localhost:9000 peertube-plugin-livechat] 2024-06-11 20:50:52.705 info: Verifying prosody is launched
[...]
```

## Related issues

Closes #416

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files