### PR TITLE
Fix #436: Saving emojis per batch, to avoid hitting max payload limit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.1.1 (Not released yet)
+
+* #436: Saving emojis per batch, to avoid hitting max payload limit.
+
 ## 10.1.0
 
 ### New features

--- a/client/common/configuration/elements/channel-emojis.ts
+++ b/client/common/configuration/elements/channel-emojis.ts
@@ -102,9 +102,13 @@ export class ChannelEmojisElement extends LivechatElement {
 
     try {
       this.actionDisabled = true
-      await this._channelDetailsService.saveEmojisConfiguration(this.channelId, this.channelEmojisConfiguration.emojis)
+      this.channelEmojisConfiguration = await this._channelDetailsService.saveEmojisConfiguration(
+        this.channelId,
+        this.channelEmojisConfiguration.emojis
+      )
       this.validationError = undefined
       this.ptNotifier.info(await this.ptTranslate(LOC_SUCCESSFULLY_SAVED))
+      this.requestUpdate('channelEmojisConfiguration')
       this.requestUpdate('_validationError')
     } catch (error) {
       this.validationError = undefined

--- a/server/lib/routers/api/configuration.ts
+++ b/server/lib/routers/api/configuration.ts
@@ -168,7 +168,16 @@ async function initConfigurationApiRouter (options: RegisterServerOptions, route
 
         await emojis.saveChannelDefinition(channelInfos.id, emojisDefinitionSanitized, bufferInfos)
 
-        res.sendStatus(200)
+        // Reloading data, to send them back to front:
+        const channelEmojis =
+          (await emojis.channelCustomEmojisDefinition(channelInfos.id)) ??
+          emojis.emptyChannelDefinition()
+        const result: ChannelEmojisConfiguration = {
+          channel: channelInfos,
+          emojis: channelEmojis
+        }
+        res.status(200)
+        res.json(result)
       } catch (err) {
         logger.error(err)
         res.sendStatus(500)

--- a/shared/lib/emojis.ts
+++ b/shared/lib/emojis.ts
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// Note: API request body size is limited to 100Kb (expressjs body-parser defaut limit, and Peertube nginx config).
+// So we must be sure to never send more than 100Kb. The front end sends new emojis by batch, but maxSize must remain
+// as little as possible, so that we never reach 100Kb in JSON/base64 format.
 export const maxSize: number = 30 * 1024
 export const allowedExtensions = ['png', 'jpg', 'jpeg', 'gif']
 export const inputFileAccept = ['image/jpg', 'image/png', 'image/gif']


### PR DESCRIPTION
## Related issues

#436 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
