### PR TITLE
Emoji only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 11.1.0 (Not Released Yet)
+
+### New features
+
+* #131: Emoji only mode.
+
 ## 11.0.1
 
 ### Minor changes and fixes

--- a/build-prosody.sh
+++ b/build-prosody.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 # This script download the Prosody AppImage from the https://github.com/JohnXLivingston/prosody-appimage project.
 
 repo_base_url='https://github.com/JohnXLivingston/prosody-appimage/releases/download'
-wanted_release='v0.12.3-1'
+wanted_release='v0.12.4-2'
 
 x86_64_filename='prosody-x86_64.AppImage'
-x86_64_sha256sum='f4af9bfefa2f804ad7e8b03a68f04194abb801f070ae620b3d4bcedb144e8523'
+x86_64_sha256sum='664d9f3b1ea6dc5fdbe29ef8e8b4c0655abdff697e8c94bfecc894ef2c2fea08'
 aarch64_filename='prosody-aarch64.AppImage'
-aarch64_sha256sum='878c5be719e1e36a84d637fd2bd44e3059aa91ddb6906ad05f1dd0334078df09'
+aarch64_sha256sum='9911c0d581a92a817e9795a7944773a07e85151127233a2e551eb07dc4c44fb5'
 
 download_dir="$(pwd)/vendor/prosody-appimage"
 dist_dir="$(pwd)/dist/server/prosody"

--- a/build-prosody.sh
+++ b/build-prosody.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 # This script download the Prosody AppImage from the https://github.com/JohnXLivingston/prosody-appimage project.
 
 repo_base_url='https://github.com/JohnXLivingston/prosody-appimage/releases/download'
-wanted_release='v0.12.4-2'
+wanted_release='v0.12.4-3'
 
 x86_64_filename='prosody-x86_64.AppImage'
-x86_64_sha256sum='664d9f3b1ea6dc5fdbe29ef8e8b4c0655abdff697e8c94bfecc894ef2c2fea08'
+x86_64_sha256sum='83a583ac7036387514bed17afab257dab4161ccdd0ab7453818c78b51f830357'
 aarch64_filename='prosody-aarch64.AppImage'
-aarch64_sha256sum='9911c0d581a92a817e9795a7944773a07e85151127233a2e551eb07dc4c44fb5'
+aarch64_sha256sum='7b7e6bf30d4498fc99a40022232c3065707ee4f4df24dc17947b007621634304'
 
 download_dir="$(pwd)/vendor/prosody-appimage"
 dist_dir="$(pwd)/dist/server/prosody"

--- a/client/@types/global.d.ts
+++ b/client/@types/global.d.ts
@@ -144,3 +144,9 @@ declare const LOC_PROSODY_FIREWALL_FILE_ENABLED: string
 declare const LOC_PROSODY_FIREWALL_NAME: string
 declare const LOC_PROSODY_FIREWALL_NAME_DESC: string
 declare const LOC_PROSODY_FIREWALL_CONTENT: string
+
+declare const LOC_EMOJI_ONLY_MODE_TITLE: string
+declare const LOC_EMOJI_ONLY_MODE_DESC_1: string
+declare const LOC_EMOJI_ONLY_MODE_DESC_2: string
+declare const LOC_EMOJI_ONLY_MODE_DESC_3: string
+declare const LOC_EMOJI_ONLY_ENABLE_ALL_ROOMS: string

--- a/client/common/configuration/elements/channel-emojis.ts
+++ b/client/common/configuration/elements/channel-emojis.ts
@@ -256,6 +256,21 @@ export class ChannelEmojisElement extends LivechatElement {
     }
   }
 
+  public async enableEmojisOnlyModeOnAllRooms (ev: Event): Promise<void> {
+    ev.preventDefault()
+    if (!this._channelDetailsService || !this.channelId) {
+      this.ptNotifier.error(await this.ptTranslate(LOC_ERROR))
+      return
+    }
+    try {
+      await this._channelDetailsService.enableEmojisOnlyModeOnAllRooms(this.channelId)
+      this.ptNotifier.info(await this.ptTranslate(LOC_SUCCESSFULLY_SAVED))
+    } catch (err) {
+      console.error(err)
+      this.ptNotifier.error(await this.ptTranslate(LOC_ERROR))
+    }
+  }
+
   /**
    * Takes an url (or dataUrl), download the image, and converts to dataUrl.
    * @param url the url

--- a/client/common/configuration/elements/templates/channel-emojis.ts
+++ b/client/common/configuration/elements/templates/channel-emojis.ts
@@ -45,13 +45,14 @@ export function tplChannelEmojis (el: ChannelEmojisElement): TemplateResult {
 
       <livechat-channel-tabs .active=${'emojis'} .channelId=${el.channelId}></livechat-channel-tabs>
 
+      <h2>${ptTr(LOC_LIVECHAT_CONFIGURATION_CHANNEL_EMOJIS_TITLE)}</h2>
+
       <p>
         ${ptTr(LOC_LIVECHAT_CONFIGURATION_CHANNEL_EMOJIS_DESC)}
         <livechat-help-button .page=${'documentation/user/streamers/emojis'}>
         </livechat-help-button>
       </p>
 
-      
       <form role="form" @submit=${el.saveEmojis} @change=${el.resetValidation}>
         <div class="peertube-plugin-livechat-configuration-actions">
           ${
@@ -106,5 +107,23 @@ export function tplChannelEmojis (el: ChannelEmojisElement): TemplateResult {
           </button>
         </div>
       </form>
+
+      <h2>${ptTr(LOC_EMOJI_ONLY_MODE_TITLE)}</h2>
+
+      <p>
+        ${ptTr(LOC_EMOJI_ONLY_MODE_DESC_1, true)}
+      </p>
+      <p>
+        ${ptTr(LOC_EMOJI_ONLY_MODE_DESC_2, true)}
+      </p>
+      <p>
+        ${ptTr(LOC_EMOJI_ONLY_MODE_DESC_3, true)}
+      </p>
+
+      <div class="peertube-plugin-livechat-configuration-actions">
+        <button type="button" @click=${el.enableEmojisOnlyModeOnAllRooms}>
+          ${ptTr(LOC_EMOJI_ONLY_ENABLE_ALL_ROOMS)}
+        </button>
+      </div>
     </div>`
 }

--- a/client/common/configuration/services/channel-details.ts
+++ b/client/common/configuration/services/channel-details.ts
@@ -312,4 +312,23 @@ export class ChannelDetailsService {
 
     return response.json()
   }
+
+  public async enableEmojisOnlyModeOnAllRooms (channelId: number): Promise<void> {
+    const response = await fetch(
+      getBaseRoute(this._registerClientOptions) +
+        '/api/configuration/channel/emojis/' +
+        encodeURIComponent(channelId) +
+        '/enable_emoji_only',
+      {
+        method: 'POST',
+        headers: this._headers
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error('Can\'t enable Emojis Only Mode on all rooms.')
+    }
+
+    return response.json()
+  }
 }

--- a/conversejs/build-conversejs.sh
+++ b/conversejs/build-conversejs.sh
@@ -40,6 +40,7 @@ if [ -n "$CONVERSE_COMMIT" ]; then
 fi
 converse_build_dir="$rootdir/build/conversejs"
 converse_destination_dir="$rootdir/dist/client/conversejs"
+converse_emoji_destination="$rootdir/dist/converse-emoji.json"
 
 if [[ ! -d $src_dir ]]; then
   echo "$0 must be called from the plugin livechat root dir."
@@ -118,6 +119,9 @@ cd $rootdir
 
 echo "Copying ConverseJS dist files..."
 mkdir -p "$converse_destination_dir" && cp -r $converse_build_dir/dist/* "$converse_destination_dir/"
+
+echo "Copying ConverseJS original emoji.json file..." # this is needed for some backend code.
+cp "$converse_build_dir/src/headless/plugins/emoji/emoji.json" "$converse_emoji_destination"
 
 echo "ConverseJS OK."
 

--- a/conversejs/custom/index.js
+++ b/conversejs/custom/index.js
@@ -66,6 +66,7 @@ CORE_PLUGINS.push('livechat-converse-mam-search')
 // We must also add our custom ROOM_FEATURES, so that they correctly resets
 // (see headless/plugins/muc, getDiscoInfoFeatures, which loops on this const)
 ROOM_FEATURES.push('x_peertubelivechat_mute_anonymous')
+ROOM_FEATURES.push('x_peertubelivechat_emoji_only_mode')
 
 _converse.exports.CustomElement = CustomElement
 

--- a/conversejs/custom/shared/styles/_peertubetheme.scss
+++ b/conversejs/custom/shared/styles/_peertubetheme.scss
@@ -35,6 +35,14 @@
       }
     }
 
+    // Emoji only info box
+    .livechat-emoji-only-info-box {
+      border: 1px dashed var(--peertube-menu-background);
+      color: var(--peertube-main-foreground);
+      background-color: var(--peertube-main-background);
+      margin: 0 5px;
+    }
+
     converse-chat-toolbar {
       border-top: none !important; // removing border, to avoid confusing the toolbar with an input field.
       color: var(--peertube-main-foreground);

--- a/conversejs/custom/templates/muc-bottom-panel.js
+++ b/conversejs/custom/templates/muc-bottom-panel.js
@@ -83,6 +83,20 @@ const tplSlowMode = (o) => {
   return html`<livechat-slow-mode jid=${o.model.get('jid')}>`
 }
 
+const tplEmojiOnly = (o) => {
+  if (!o.can_post) { return html`` }
+  if (!o.model.features?.get?.('x_peertubelivechat_emoji_only_mode')) {
+    return ''
+  }
+  return html`<div class="livechat-emoji-only-info-box">
+      <converse-icon class="fa fa-info-circle" size="1.2em"></converse-icon>
+      ${
+        // eslint-disable-next-line no-undef
+        __(LOC_emoji_only_info)
+      }
+    </div>`
+}
+
 const tplViewerMode = (o) => {
   if (!api.settings.get('livechat_enable_viewer_mode')) {
     return html``
@@ -145,6 +159,7 @@ export default (o) => {
   return html`
     ${tplViewerMode(o)}
     ${tplSlowMode(o)}
+    ${tplEmojiOnly(o)}
     ${
       mutedAnonymousMessage
         ? html`<span class="muc-bottom-panel muc-bottom-panel--muted">${mutedAnonymousMessage}</span>`

--- a/conversejs/lib/plugins/livechat-specific.ts
+++ b/conversejs/lib/plugins/livechat-specific.ts
@@ -9,6 +9,7 @@ import { chatRoomOverrides } from './livechat-specific/chatroom'
 import { chatRoomMessageOverrides } from './livechat-specific/chatroom-message'
 import { customizeMessageAction } from './livechat-specific/message-action'
 import { customizeProfileModal } from './livechat-specific/profile'
+import { customizeMUCBottomPanel } from './livechat-specific/muc-bottom-panel'
 
 export const livechatSpecificsPlugin = {
   dependencies: ['converse-muc', 'converse-muc-views'],
@@ -26,6 +27,7 @@ export const livechatSpecificsPlugin = {
     customizeToolbar(this)
     customizeMessageAction(this)
     customizeProfileModal(this)
+    customizeMUCBottomPanel(this)
 
     _converse.api.listen.on('chatRoomViewInitialized', function (this: any, _model: any): void {
       // Remove the spinner if present...

--- a/conversejs/lib/plugins/livechat-specific/muc-bottom-panel.ts
+++ b/conversejs/lib/plugins/livechat-specific/muc-bottom-panel.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Override the MUCBottomPanel custom element
+ */
+export function customizeMUCBottomPanel (plugin: any): void {
+  const _converse = plugin._converse
+  const MUCBottomPanel = _converse.api.elements.registry['converse-muc-bottom-panel']
+  if (MUCBottomPanel) {
+    class MUCBottomPanelOverloaded extends MUCBottomPanel {
+      async initialize (): Promise<any> {
+        await super.initialize()
+        // We must refresh the bottom panel when these features changes (to display the infobox)
+        // FIXME: the custom muc-bottom-panel template should be used here, in an overloaded render method, instead
+        //    of using webpack to overload the original file.
+        this.listenTo(this.model.features, 'change:x_peertubelivechat_emoji_only_mode', () => this.requestUpdate())
+      }
+    }
+    _converse.api.elements.define('converse-muc-bottom-panel', MUCBottomPanelOverloaded)
+  }
+}

--- a/conversejs/loc.keys.js
+++ b/conversejs/loc.keys.js
@@ -62,7 +62,8 @@ const locKeys = [
   'moderator_note_original_nick',
   'search_occupant_message',
   'message_search',
-  'message_search_original_nick'
+  'message_search_original_nick',
+  'emoji_only_info'
 ]
 
 module.exports = locKeys

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -636,3 +636,5 @@ prosody_firewall_name_desc: |
   Can only contain: alphanumerical characters, underscores and hyphens.
   Scripts will be loaded in alphabetical order.
 prosody_firewall_content: File content
+
+emoji_only_info: Emoji only mode is enabled, you can only use emoji in your messages.

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -638,3 +638,18 @@ prosody_firewall_name_desc: |
 prosody_firewall_content: File content
 
 emoji_only_info: Emoji only mode is enabled, you can only use emoji in your messages.
+emoji_only_mode_title: Emojis only mode
+emoji_only_mode_desc_1: |
+  You can enable an "Emojy only mode" in your chatrooms.
+  When this mode is enabled, participants can only send emojis (standard, or channel custom emojis).
+  Moderators are not affected by this limitation.
+emoji_only_mode_desc_2: |
+  This mode can be usefull for Example:
+  <ul>
+    <li>To avoid spam or offensive message when you are not here to moderate.</li>
+    <li>When there are too many speaking participants, and you can't no more moderate correctly.</li>
+  </ul>
+emoji_only_mode_desc_3: |
+  To enable or disable this mode, you can use the room configuration form.
+  If you want to enable it for all your rooms at once, you can use the button bellow.
+emoji_only_enable_all_rooms: Enable the emoji only mode on all channel's chatrooms

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -644,12 +644,12 @@ emoji_only_mode_desc_1: |
   When this mode is enabled, participants can only send emojis (standard, or channel custom emojis).
   Moderators are not affected by this limitation.
 emoji_only_mode_desc_2: |
-  This mode can be usefull for Example:
+  This mode can be usefull for example:
   <ul>
     <li>To avoid spam or offensive message when you are not here to moderate.</li>
     <li>When there are too many speaking participants, and you can't no more moderate correctly.</li>
   </ul>
 emoji_only_mode_desc_3: |
   To enable or disable this mode, you can use the room configuration form.
-  If you want to enable it for all your rooms at once, you can use the button bellow.
+  If you want to enable it for all your chatrooms at once, you can use the button bellow.
 emoji_only_enable_all_rooms: Enable the emoji only mode on all channel's chatrooms

--- a/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
+++ b/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
@@ -18,7 +18,7 @@ local mod_muc_peertubelivechat_terms = module:depends"muc_peertubelivechat_terms
 local set_muc_terms = rawget(mod_muc_peertubelivechat_terms, "set_muc_terms");
 local mod_muc_peertubelivechat_restrict_message = module:depends"muc_peertubelivechat_restrict_message";
 local set_peertubelivechat_emoji_only_mode = rawget(mod_muc_peertubelivechat_restrict_message, "set_peertubelivechat_emoji_only_mode");
-local set_peertubelivechat_emoji_only_regexp = rawget(mod_muc_peertubelivechat_restrict_message, "set_peertubelivechat_emoji_only_regexp");
+local set_peertubelivechat_custom_emoji_regexp = rawget(mod_muc_peertubelivechat_restrict_message, "set_peertubelivechat_custom_emoji_regexp");
 
 function check_auth(routes)
   local function check_request_auth(event)
@@ -110,9 +110,9 @@ local function update_room(event)
       set_peertubelivechat_emoji_only_mode(room, config.livechat_emoji_only)
     end
   end
-  if type(config.livechat_emoji_only_regexp) == "string" then
-    if set_peertubelivechat_emoji_only_mode then
-      set_peertubelivechat_emoji_only_regexp(room, config.livechat_emoji_only_regexp)
+  if type(config.livechat_custom_emoji_regexp) == "string" then
+    if set_peertubelivechat_custom_emoji_regexp then
+      set_peertubelivechat_custom_emoji_regexp(room, config.livechat_custom_emoji_regexp)
     end
   end
   if (type(config.livechat_muc_terms) == "string") then

--- a/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
+++ b/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
@@ -16,6 +16,9 @@ module:depends"http";
 
 local mod_muc_peertubelivechat_terms = module:depends"muc_peertubelivechat_terms";
 local set_muc_terms = rawget(mod_muc_peertubelivechat_terms, "set_muc_terms");
+local mod_muc_peertubelivechat_restrict_message = module:depends"muc_peertubelivechat_restrict_message";
+local set_peertubelivechat_emoji_only_mode = rawget(mod_muc_peertubelivechat_restrict_message, "set_peertubelivechat_emoji_only_mode");
+local set_peertubelivechat_emoji_only_regexp = rawget(mod_muc_peertubelivechat_restrict_message, "set_peertubelivechat_emoji_only_regexp");
 
 function check_auth(routes)
   local function check_request_auth(event)
@@ -100,6 +103,16 @@ local function update_room(event)
   if type(config.moderation_delay) == "number" then
     if room._data.moderation_delay ~= config.moderation_delay then
       room._data.moderation_delay = config.moderation_delay;
+    end
+  end
+  if type(config.livechat_emoji_only) == "boolean" then
+    if set_peertubelivechat_emoji_only_mode then
+      set_peertubelivechat_emoji_only_mode(room, config.livechat_emoji_only)
+    end
+  end
+  if type(config.livechat_emoji_only_regexp) == "string" then
+    if set_peertubelivechat_emoji_only_mode then
+      set_peertubelivechat_emoji_only_regexp(room, config.livechat_emoji_only_regexp)
     end
   end
   if (type(config.livechat_muc_terms) == "string") then

--- a/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
+++ b/prosody-modules/mod_http_peertubelivechat_manage_rooms/mod_http_peertubelivechat_manage_rooms.lua
@@ -107,7 +107,9 @@ local function update_room(event)
   end
   if type(config.livechat_emoji_only) == "boolean" then
     if set_peertubelivechat_emoji_only_mode then
-      set_peertubelivechat_emoji_only_mode(room, config.livechat_emoji_only)
+      if set_peertubelivechat_emoji_only_mode(room, config.livechat_emoji_only) then
+        must104 = true;
+      end
     end
   end
   if type(config.livechat_custom_emoji_regexp) == "string" then

--- a/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
+++ b/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
@@ -9,6 +9,9 @@
 -- * "mute_anonymous"
 -- * "moderation_delay"
 -- * "anonymize_moderation_actions"
+-- * "livechat_emoji_only"
+-- * "livechat_emoji_only_regexp"
+-- * "livechat_muc_terms"
 -- These options are introduced in the Peertube livechat plugin.
 --
 -- The "slow_mode_duration" comes with mod_muc_slow_mode.
@@ -127,6 +130,12 @@ local function apply_config(room, settings)
 		end
 		if (type(config.mute_anonymous) == "boolean") then
 			room._data.x_peertubelivechat_mute_anonymous = config.mute_anonymous;
+		end
+		if (type(config.livechat_emoji_only) == "boolean") then
+			room._data.x_peertubelivechat_emoji_only_mode = config.livechat_emoji_only;
+		end
+		if (type(config.livechat_emoji_only_regexp) == "string" and config.livechat_emoji_only_regexp ~= "") then
+			room._data.x_peertubelivechat_emoji_only_regexp = config.emoji_only_regexp;
 		end
 		if (type(config.livechat_muc_terms) == "string") then
 			-- we don't need to use set_muc_terms here, as this is called for a newly created room

--- a/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
+++ b/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
@@ -135,7 +135,7 @@ local function apply_config(room, settings)
 			room._data.x_peertubelivechat_emoji_only_mode = config.livechat_emoji_only;
 		end
 		if (type(config.livechat_emoji_only_regexp) == "string" and config.livechat_emoji_only_regexp ~= "") then
-			room._data.x_peertubelivechat_emoji_only_regexp = config.emoji_only_regexp;
+			room._data.x_peertubelivechat_emoji_only_regexp = config.livechat_emoji_only_regexp;
 		end
 		if (type(config.livechat_muc_terms) == "string") then
 			-- we don't need to use set_muc_terms here, as this is called for a newly created room

--- a/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
+++ b/prosody-modules/mod_muc_http_defaults/mod_muc_http_defaults.lua
@@ -10,7 +10,7 @@
 -- * "moderation_delay"
 -- * "anonymize_moderation_actions"
 -- * "livechat_emoji_only"
--- * "livechat_emoji_only_regexp"
+-- * "livechat_custom_emoji_regexp"
 -- * "livechat_muc_terms"
 -- These options are introduced in the Peertube livechat plugin.
 --
@@ -134,8 +134,8 @@ local function apply_config(room, settings)
 		if (type(config.livechat_emoji_only) == "boolean") then
 			room._data.x_peertubelivechat_emoji_only_mode = config.livechat_emoji_only;
 		end
-		if (type(config.livechat_emoji_only_regexp) == "string" and config.livechat_emoji_only_regexp ~= "") then
-			room._data.x_peertubelivechat_emoji_only_regexp = config.livechat_emoji_only_regexp;
+		if (type(config.livechat_custom_emoji_regexp) == "string" and config.livechat_custom_emoji_regexp ~= "") then
+			room._data.x_peertubelivechat_custom_emoji_regexp = config.livechat_custom_emoji_regexp;
 		end
 		if (type(config.livechat_muc_terms) == "string") then
 			-- we don't need to use set_muc_terms here, as this is called for a newly created room

--- a/prosody-modules/mod_muc_peertubelivechat_restrict_message/README.markdown
+++ b/prosody-modules/mod_muc_peertubelivechat_restrict_message/README.markdown
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+# mod_muc_peertubelivechat_restrict_message
+
+This module is a custom module designed for the peertube-plugin-livechat project, that can restrict message content to 
+given regular expression.
+
+This module is part of peertube-plugin-livechat, and is under the same LICENSE (AGPL-v3).
+
+## Prerequisites
+
+This modules needs lrexlib instlaled (available as lua-rex-pcre2 package on Debian).

--- a/prosody-modules/mod_muc_peertubelivechat_restrict_message/mod_muc_peertubelivechat_restrict_message.lua
+++ b/prosody-modules/mod_muc_peertubelivechat_restrict_message/mod_muc_peertubelivechat_restrict_message.lua
@@ -11,7 +11,8 @@
 local st = require "util.stanza";
 local jid_bare = require "util.jid".bare;
 
-local rex = require "rex_pcre2"; -- We are using PCRE2 (Perl Compatible Regular Expression)
+local rex = require "rex_onig"; -- We are using Oniguruma because PCRE2 does not handle long regexp.
+rex.setdefaultsyntax ("PERL");
 
 -- Plugin dependencies
 local mod_muc = module:depends "muc";
@@ -87,7 +88,7 @@ function handle_groupchat(event)
     if (r == nil) then
       return;
     end
-    room.x_peertubelivechat_emoji_only_compiled_regexp = rex.new(r, "i");
+    room.x_peertubelivechat_emoji_only_compiled_regexp = rex.new(r, "i", "UTF8");
   end
 
   -- only consider messages with body (ie: ignore chatstate and other non-text xmpp messages)

--- a/prosody-modules/mod_muc_peertubelivechat_restrict_message/mod_muc_peertubelivechat_restrict_message.lua
+++ b/prosody-modules/mod_muc_peertubelivechat_restrict_message/mod_muc_peertubelivechat_restrict_message.lua
@@ -1,0 +1,131 @@
+-- mod_muc_peertubelivechat_roles
+--
+-- SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- This file is AGPL-v3 licensed.
+-- Please see the Peertube livechat plugin copyright information.
+-- https://livingston.frama.io/peertube-plugin-livechat/credits/
+--
+
+local st = require "util.stanza";
+local jid_bare = require "util.jid".bare;
+
+local rex = require "rex_pcre2"; -- We are using PCRE2 (Perl Compatible Regular Expression)
+
+-- Plugin dependencies
+local mod_muc = module:depends "muc";
+local muc_util = module:require "muc/util";
+local valid_roles = muc_util.valid_roles;
+
+
+function get_peertubelivechat_emoji_only_mode(room)
+  return room._data.x_peertubelivechat_emoji_only_mode;
+end
+
+function set_peertubelivechat_emoji_only_mode(room, emoji_only)
+  emoji_only = emoji_only and true or nil;
+  if get_peertubelivechat_emoji_only_mode(room) == emoji_only then return false; end
+  room._data.x_peertubelivechat_emoji_only_mode = emoji_only;
+  return true;
+end
+
+function get_peertubelivechat_emoji_only_regexp(room)
+  return room._data.x_peertubelivechat_emoji_only_regexp;
+end
+
+function set_peertubelivechat_emoji_only_regexp(room, emoji_only_regexp)
+  if (emoji_only_regexp ~= nil and type(emoji_only_regexp) ~= "string") then
+    return false;
+  end
+  if emoji_only_regexp == "" then emoji_only_regexp = nil; end
+  if get_peertubelivechat_emoji_only_regexp(room) == emoji_only_regexp then return false; end
+  room._data.x_peertubelivechat_emoji_only_regexp = emoji_only_regexp;
+
+  -- and we must decache the compile regexp
+  room.x_peertubelivechat_emoji_only_compiled_regexp = nil;
+  return true;
+end
+
+module:hook("muc-disco#info", function(event)
+  if get_peertubelivechat_emoji_only_mode(event.room) and get_peertubelivechat_emoji_only_regexp(event.room) ~= nil then
+    event.reply:tag("feature", {var = "x_peertubelivechat_emoji_only_mode"}):up();
+  end
+end);
+
+module:hook("muc-config-form", function(event)
+  if (get_peertubelivechat_emoji_only_regexp(event.room) ~= nil) then
+    table.insert(event.form, {
+      name = "muc#roomconfig_x_peertubelivechat_emoji_only_mode";
+      type = "boolean";
+      label = "Emoji only mode";
+      desc = "Occupants will only be able to send emoji. This does not affect moderators.";
+      value = get_peertubelivechat_emoji_only_mode(event.room);
+    });
+  end
+end, 121);
+
+module:hook("muc-config-submitted/muc#roomconfig_x_peertubelivechat_emoji_only_mode", function(event)
+  if get_peertubelivechat_emoji_only_regexp(event.room) ~= nil and set_peertubelivechat_emoji_only_mode(event.room, event.value) then
+    event.status_codes["104"] = true;
+  end
+end);
+
+
+-- handling groupchat messages
+function handle_groupchat(event)
+  local origin, stanza = event.origin, event.stanza;
+  local room = event.room;
+
+  if (not get_peertubelivechat_emoji_only_mode(room)) then
+    return;
+  end
+
+  if not room.x_peertubelivechat_emoji_only_compiled_regexp then
+    -- compute the regexp on first access
+    local r = get_peertubelivechat_emoji_only_regexp(room);
+    if (r == nil) then
+      return;
+    end
+    room.x_peertubelivechat_emoji_only_compiled_regexp = rex.new(r, "i");
+  end
+
+  -- only consider messages with body (ie: ignore chatstate and other non-text xmpp messages)
+  local body = stanza:get_child_text("body")
+  if not body or #body < 1 then
+    -- module:log("debug", "No body, message accepted");
+    return;
+  end
+
+  -- Checking user's permissions (moderators are not subject to restrictions)
+  local actor = stanza.attr.from;
+  local actor_nick = room:get_occupant_jid(actor);
+  local actor_jid = jid_bare(actor);
+  -- Only checking role, not affiliation (restrictions only applies on users currently connected to the room)
+  local role = room:get_role(actor_nick);
+  if valid_roles[role or "none"] >= valid_roles.moderator then
+    -- user bypasses
+    -- module:log("debug", "User is moderator, bypassing restrictions");
+    return;
+  end
+
+  -- testing the content
+  if (room.x_peertubelivechat_emoji_only_compiled_regexp:match(body) ~= nil) then
+    -- module:log("debug", "Message accepted");
+    return;
+  end
+
+  module:log("debug", "Bouncing message for user %s", actor_nick);
+  local reply = st.error_reply(
+    stanza,
+    -- error_type = 'modify' (see descriptions in RFC 6120 https://xmpp.org/rfcs/rfc6120.html#stanzas-error-syntax)
+    "modify",
+    -- error_condition = 'policy-violation' (see RFC 6120 Defined Error Conditions https://xmpp.org/rfcs/rfc6120.html#stanzas-error-conditions)
+    "policy-violation",
+    "Emoji only mode enabled"
+  );
+
+  origin.send(reply);
+  return true; -- stoping propagation
+end
+module:hook("muc-occupant-groupchat", handle_groupchat);

--- a/server/lib/configuration/channel/init.ts
+++ b/server/lib/configuration/channel/init.ts
@@ -120,9 +120,10 @@ async function initChannelConfiguration (options: RegisterServerOptions): Promis
           //   but will be more efficient to add here, as we already tested hasChat).
           // Note: no need to await here, would only degrade performances.
           // FIXME: should also update livechat_muc_terms if channel has changed.
-          // FIXME: should also update livechat_emoji_only_regexp if channel has changed.
           updateProsodyRoom(options, video.uuid, {
-            name: video.name
+            name: video.name,
+            // In case the channel changed:
+            livechat_custom_emoji_regexp: await Emojis.singletonSafe()?.getChannelCustomEmojisRegexp(video.channelId)
           }).then(
             () => {},
             (err) => logger.error(err)

--- a/server/lib/configuration/channel/init.ts
+++ b/server/lib/configuration/channel/init.ts
@@ -120,6 +120,7 @@ async function initChannelConfiguration (options: RegisterServerOptions): Promis
           //   but will be more efficient to add here, as we already tested hasChat).
           // Note: no need to await here, would only degrade performances.
           // FIXME: should also update livechat_muc_terms if channel has changed.
+          // FIXME: should also update livechat_emoji_only_regexp if channel has changed.
           updateProsodyRoom(options, video.uuid, {
             name: video.name
           }).then(

--- a/server/lib/emojis/emojis.ts
+++ b/server/lib/emojis/emojis.ts
@@ -144,7 +144,7 @@ export class Emojis {
    * @param sn short name
    */
   public validShortName (sn: any): boolean {
-    // Important note: do not change this without checking if it can breaks getChannelEmojisOnlyRegexp.
+    // Important note: do not change this without checking if it can breaks getChannelCustomEmojisRegexp.
     if ((typeof sn !== 'string') || !/^:?[\w-]+:?$/.test(sn)) {
       this.logger.debug('Short name invalid: ' + (typeof sn === 'string' ? sn : '???'))
       return false
@@ -395,14 +395,13 @@ export class Emojis {
   }
 
   /**
-   * Returns a string representing a regular expression (Perl Compatible RE) that can validate that a message
-   * contains only emojis (for this channel).
+   * Returns a string representing a regular expression validating channel custom emojis.
    * This is used for the emoji only mode (test are made on the Prosody server).
    *
    * @param channelId channel id
    */
-  public async getChannelEmojisOnlyRegexp (channelId: number): Promise<string | undefined> {
-    const parts = [...this.commonEmojisCodes]
+  public async getChannelCustomEmojisRegexp (channelId: number): Promise<string | undefined> {
+    const parts = []
 
     if (await this.channelHasCustomEmojis(channelId)) {
       const def = await this.channelCustomEmojisDefinition(channelId)
@@ -411,11 +410,17 @@ export class Emojis {
       }
     }
 
-    // Note: validShortName should ensure we won't put special chars.
-    // And for the common emojis, we assume that there is no special regexp chars
-    const regexp = '^\\s*(?:(?:' + parts.join('|') + ')\\s*)+\\s*$'
+    if (parts.length === 0) {
+      return undefined
+    }
 
-    return regexp
+    // Note: validShortName should ensure we won't put special chars.
+    return parts.join('|')
+  }
+
+  public getCommonEmojisRegexp (): string {
+    // We assume that there is no special regexp chars (should only contains unicode emojis)
+    return this.commonEmojisCodes.join('|')
   }
 
   /**

--- a/server/lib/prosody/api/manage-rooms.ts
+++ b/server/lib/prosody/api/manage-rooms.ts
@@ -65,6 +65,8 @@ async function updateProsodyRoom (
     name?: string
     slow_mode_duration?: number
     moderation_delay?: number
+    livechat_emoji_only?: boolean
+    livechat_emoji_only_regexp?: string
     livechat_muc_terms?: string
     addAffiliations?: Affiliations
     removeAffiliationsFor?: string[]
@@ -99,6 +101,12 @@ async function updateProsodyRoom (
   }
   if ('livechat_muc_terms' in data) {
     apiData.livechat_muc_terms = data.livechat_muc_terms ?? ''
+  }
+  if ('livechat_emoji_only' in data) {
+    apiData.livechat_emoji_only = data.livechat_emoji_only ?? false
+  }
+  if ('livechat_emoji_only_regexp' in data) {
+    apiData.livechat_emoji_only_regexp = data.livechat_emoji_only_regexp ?? ''
   }
   if (('addAffiliations' in data) && data.addAffiliations !== undefined) {
     apiData.addAffiliations = data.addAffiliations

--- a/server/lib/prosody/api/manage-rooms.ts
+++ b/server/lib/prosody/api/manage-rooms.ts
@@ -115,7 +115,7 @@ async function updateProsodyRoom (
     apiData.removeAffiliationsFor = data.removeAffiliationsFor
   }
   try {
-    logger.debug('Calling update room API on url: ' + apiUrl + ', with data: ' + JSON.stringify(apiData))
+    logger.debug('Calling update room API on url: ' + apiUrl)
     const result = await got(apiUrl, {
       method: 'POST',
       headers: {

--- a/server/lib/prosody/api/manage-rooms.ts
+++ b/server/lib/prosody/api/manage-rooms.ts
@@ -66,7 +66,7 @@ async function updateProsodyRoom (
     slow_mode_duration?: number
     moderation_delay?: number
     livechat_emoji_only?: boolean
-    livechat_emoji_only_regexp?: string
+    livechat_custom_emoji_regexp?: string
     livechat_muc_terms?: string
     addAffiliations?: Affiliations
     removeAffiliationsFor?: string[]
@@ -105,8 +105,8 @@ async function updateProsodyRoom (
   if ('livechat_emoji_only' in data) {
     apiData.livechat_emoji_only = data.livechat_emoji_only ?? false
   }
-  if ('livechat_emoji_only_regexp' in data) {
-    apiData.livechat_emoji_only_regexp = data.livechat_emoji_only_regexp ?? ''
+  if ('livechat_custom_emoji_regexp' in data) {
+    apiData.livechat_custom_emoji_regexp = data.livechat_custom_emoji_regexp ?? ''
   }
   if (('addAffiliations' in data) && data.addAffiliations !== undefined) {
     apiData.addAffiliations = data.addAffiliations

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -260,6 +260,8 @@ class ProsodyConfigContent {
     this.muc.set('anonymize_moderation_actions_form_position', 117)
 
     this.muc.add('modules_enabled', 'muc_mam_search')
+
+    this.muc.add('modules_enabled', 'muc_peertubelivechat_restrict_message')
   }
 
   useAnonymous (autoBanIP: boolean): void {

--- a/server/lib/prosody/config/content.ts
+++ b/server/lib/prosody/config/content.ts
@@ -260,8 +260,6 @@ class ProsodyConfigContent {
     this.muc.set('anonymize_moderation_actions_form_position', 117)
 
     this.muc.add('modules_enabled', 'muc_mam_search')
-
-    this.muc.add('modules_enabled', 'muc_peertubelivechat_restrict_message')
   }
 
   useAnonymous (autoBanIP: boolean): void {
@@ -562,6 +560,18 @@ class ProsodyConfigContent {
   useModFirewall (files: string[]): void {
     this.global.add('modules_enabled', 'firewall')
     this.global.set('firewall_scripts', files)
+  }
+
+  /**
+   * Enable and configure the restrict message module.
+   * @param commonEmojiRegexp A regexp to match common emojis.
+   */
+  useRestrictMessage (commonEmojiRegexp: string): void {
+    this.muc.add('modules_enabled', 'muc_peertubelivechat_restrict_message')
+    this.muc.set(
+      'peertubelivechat_restrict_message_common_emoji_regexp',
+      new ConfigEntryValueMultiLineString(commonEmojiRegexp)
+    )
   }
 
   addMucAdmins (jids: string[]): void {

--- a/server/lib/prosody/migration/migrageV11-1.ts
+++ b/server/lib/prosody/migration/migrageV11-1.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { RegisterServerOptions } from '@peertube/peertube-types'
+import { listProsodyRooms, updateProsodyRoom } from '../api/manage-rooms'
+import * as path from 'path'
+import * as fs from 'fs'
+import { Emojis } from '../../emojis'
+
+/**
+ * Livechat v11.1.0: we must send channel custom emojis regexp to Prosody.
+ *
+ * This script will only be launched one time.
+ */
+async function updateProsodyChannelEmojisRegex (options: RegisterServerOptions): Promise<void> {
+  const logger = options.peertubeHelpers.logger
+
+  // First, detect if we already run this script.
+  const doneFilePath = path.resolve(options.peertubeHelpers.plugin.getDataDirectoryPath(), 'fix-v11.1-emojis')
+  if (fs.existsSync(doneFilePath)) {
+    logger.debug('[migratev11_1_ChannelEmojis] Channel Emojis Regex already updated on Prosody.')
+    return
+  }
+
+  logger.info('[migratev11_1_ChannelEmojis] Updating Channel custom emojis regexp on Prosody')
+
+  const emojis = Emojis.singleton()
+  const rooms = await listProsodyRooms(options)
+  logger.debug('[migratev11_1_ChannelEmojis] Found ' + rooms.length.toString() + ' rooms.')
+
+  for (const room of rooms) {
+    try {
+      let channelId: number
+      logger.info('[migratev11_1_ChannelEmojis] Must update custom emojis regexp for room ' + room.localpart)
+      const matches = room.localpart.match(/^channel\.(\d+)$/)
+      if (matches?.[1]) {
+        // room associated to a channel
+        channelId = parseInt(matches[1])
+      } else {
+        // room associated to a video
+        const video = await options.peertubeHelpers.videos.loadByIdOrUUID(room.localpart)
+        if (!video || video.remote) {
+          logger.info('[migratev11_1_ChannelEmojis] Video ' + room.localpart + ' not found or remote, skipping')
+          continue
+        }
+        channelId = video.channelId
+      }
+
+      if (!channelId) {
+        throw new Error('Cant find channelId')
+      }
+
+      const regexp = await emojis.getChannelCustomEmojisRegexp(channelId)
+      if (regexp === undefined) {
+        logger.info('[migratev11_1_ChannelEmojis] Room ' + room.localpart + ' channel has no custom emojis, skipping.')
+        continue
+      }
+
+      await updateProsodyRoom(options, room.jid, {
+        livechat_custom_emoji_regexp: regexp
+      })
+    } catch (err) {
+      logger.error(
+        '[migratev11_1_ChannelEmojis] Failed to handle room ' + room.localpart + ', skipping. Error: ' + (err as string)
+      )
+      continue
+    }
+  }
+
+  await fs.promises.writeFile(doneFilePath, '')
+}
+
+export {
+  updateProsodyChannelEmojisRegex
+}

--- a/server/lib/routers/api/configuration.ts
+++ b/server/lib/routers/api/configuration.ts
@@ -171,13 +171,13 @@ async function initConfigurationApiRouter (options: RegisterServerOptions, route
         await emojis.saveChannelDefinition(channelInfos.id, emojisDefinitionSanitized, bufferInfos)
 
         // We must update the emoji only regexp on the Prosody server.
-        const emojisOnlyRegexp = await emojis.getChannelEmojisOnlyRegexp(channelInfos.id)
+        const customEmojisRegexp = await emojis.getChannelCustomEmojisRegexp(channelInfos.id)
         const roomJIDs = RoomChannel.singleton().getChannelRoomJIDs(channelInfos.id)
         for (const roomJID of roomJIDs) {
           // No need to await here
           logger.info(`Updating room ${roomJID} emoji only regexp...`)
           updateProsodyRoom(options, roomJID, {
-            livechat_emoji_only_regexp: emojisOnlyRegexp
+            livechat_custom_emoji_regexp: customEmojisRegexp
           }).then(
             () => {},
             (err) => logger.error(err)

--- a/server/lib/routers/api/room.ts
+++ b/server/lib/routers/api/room.ts
@@ -39,7 +39,7 @@ interface RoomDefaults {
     slow_mode_duration?: number
     mute_anonymous?: boolean
     livechat_emoji_only?: boolean
-    livechat_emoji_only_regexp?: string
+    livechat_custom_emoji_regexp?: string
     livechat_muc_terms?: string
     moderation_delay?: number
     anonymize_moderation_actions?: boolean
@@ -54,12 +54,12 @@ async function _getChannelSpecificOptions (
   const channelOptions = await getChannelConfigurationOptions(options, channelId) ??
     getDefaultChannelConfigurationOptions(options)
 
-  const emojiOnlyRegexp = await Emojis.singletonSafe()?.getChannelEmojisOnlyRegexp(channelId)
+  const customEmojisRegexp = await Emojis.singletonSafe()?.getChannelCustomEmojisRegexp(channelId)
 
   return {
     slow_mode_duration: channelOptions.slowMode.duration,
     mute_anonymous: channelOptions.mute.anonymous,
-    livechat_emoji_only_regexp: emojiOnlyRegexp,
+    livechat_custom_emoji_regexp: customEmojisRegexp,
     livechat_muc_terms: channelOptions.terms,
     moderation_delay: channelOptions.moderation.delay,
     anonymize_moderation_actions: channelOptions.moderation.anonymize

--- a/server/lib/routers/api/room.ts
+++ b/server/lib/routers/api/room.ts
@@ -15,6 +15,7 @@ import {
   getChannelConfigurationOptions,
   getDefaultChannelConfigurationOptions
 } from '../../configuration/channel/storage'
+import { Emojis } from '../../emojis'
 
 // See here for description: https://modules.prosody.im/mod_muc_http_defaults.html
 interface RoomDefaults {
@@ -37,6 +38,8 @@ interface RoomDefaults {
     // Following fields are specific to livechat (for now), and requires a customized version for mod_muc_http_defaults.
     slow_mode_duration?: number
     mute_anonymous?: boolean
+    livechat_emoji_only?: boolean
+    livechat_emoji_only_regexp?: string
     livechat_muc_terms?: string
     moderation_delay?: number
     anonymize_moderation_actions?: boolean
@@ -51,9 +54,12 @@ async function _getChannelSpecificOptions (
   const channelOptions = await getChannelConfigurationOptions(options, channelId) ??
     getDefaultChannelConfigurationOptions(options)
 
+  const emojiOnlyRegexp = await Emojis.singletonSafe()?.getChannelEmojisOnlyRegexp(channelId)
+
   return {
     slow_mode_duration: channelOptions.slowMode.duration,
     mute_anonymous: channelOptions.mute.anonymous,
+    livechat_emoji_only_regexp: emojiOnlyRegexp,
     livechat_muc_terms: channelOptions.terms,
     moderation_delay: channelOptions.moderation.delay,
     anonymize_moderation_actions: channelOptions.moderation.anonymize

--- a/support/documentation/content/en/documentation/user/streamers/emojis_only.md
+++ b/support/documentation/content/en/documentation/user/streamers/emojis_only.md
@@ -1,0 +1,24 @@
+---
+title: "Emojis only mode"
+description: "Plugin peertube-plugin-livechat emojis only mode"
+weight: 335
+chapter: false
+---
+
+{{% notice info %}}
+This feature comes with the livechat plugin version 11.1.0.
+{{% /notice %}}
+
+## {{% livechat_label emoji_only_mode_title %}}
+
+{{% livechat_label emoji_only_mode_desc_1 %}}
+
+This mode can be usefull for example:
+
+* To avoid spam or offensive message when you are not here to moderate.
+* When there are too many speaking participants, and you can't no more moderate correctly.
+
+To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the "configure" menu.
+In the form, you will find a "{{% livechat_label emoji_only_mode_title %}}" checkbox.
+
+If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the "{{% livechat_label emoji_only_enable_all_rooms %}}" button.

--- a/support/documentation/content/en/documentation/user/streamers/polls.md
+++ b/support/documentation/content/en/documentation/user/streamers/polls.md
@@ -1,7 +1,7 @@
 ---
 title: "Polls"
-description: "You can create polls to ask viewers their opinion."
-weight: 330
+description: "You can create polls to ask viewers their opinion"
+weight: 340
 chapter: false
 ---
 

--- a/support/documentation/po/livechat.ar.po
+++ b/support/documentation/po/livechat.ar.po
@@ -6,17 +6,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-08-30 20:08+0000\n"
 "Last-Translator: ButterflyOfFire <butterflyoffire@protonmail.com>\n"
-"Language-Team: Arabic <https://weblate.framasoft.org/projects/"
-"peertube-livechat/peertube-plugin-livechat-documentation/ar/>\n"
+"Language-Team: Arabic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ar/>\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : (n%100>=3 "
-"&& n%100<=10) ? 3 : n%100>=11 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : (n%100>=3 && n%100<=10) ? 3 : n%100>=11 ? 4 : 5);\n"
 "X-Generator: Weblate 5.7\n"
 
 #. type: Yaml Front Matter Hash Value: description
@@ -3212,6 +3210,49 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+#| msgid "Documentation"
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "المستندات"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3777,7 +3818,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ca.po
+++ b/support/documentation/po/livechat.ca.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ca/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.cs.po
+++ b/support/documentation/po/livechat.cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/cs/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.de.po
+++ b/support/documentation/po/livechat.de.po
@@ -7,12 +7,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-08-31 17:22+0000\n"
-"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>"
-"\n"
-"Language-Team: German <https://weblate.framasoft.org/projects/"
-"peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
+"Last-Translator: Victor Hampel <v.hampel@users.noreply.weblate.framasoft.org>\n"
+"Language-Team: German <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -460,17 +458,12 @@ msgstr "Die Dokumentation wird mit [Hugo](https://gohugo.io/) erstellt.  Sie mü
 #. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
 msgid "The minimum required version for Hugo is 0.121.0.  It was tested using version 0.132.2."
-msgstr ""
-"Die erforderliche Mindestversion für Hugo ist 0.121.0.  Es wurde mit Version "
-"0.132.2 getestet."
+msgstr "Die erforderliche Mindestversion für Hugo ist 0.121.0.  Es wurde mit Version 0.132.2 getestet."
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
 msgid "The used theme is [hugo-theme-relearn](https://mcshelby.github.io/hugo-theme-relearn).  You should read its documentation before starting editing the documentation."
-msgstr ""
-"Das verwendete Thema ist [hugo-theme-learn](https://mcshelby.github.io/hugo-"
-"theme-relearn). Sie sollten dessen Dokumentation lesen, bevor Sie mit der "
-"Bearbeitung der Dokumentation beginnen."
+msgstr "Das verwendete Thema ist [hugo-theme-learn](https://mcshelby.github.io/hugo-theme-relearn). Sie sollten dessen Dokumentation lesen, bevor Sie mit der Bearbeitung der Dokumentation beginnen."
 
 #. type: Plain text
 #: support/documentation/content/en/contributing/document/_index.md
@@ -1780,23 +1773,13 @@ msgstr "Dies ermöglicht es den Nutzern auch, dem Chat beizutreten, ohne ein Pee
 #: build/documentation/pot_in/documentation/admin/external_auth.md
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of a Peertube video page, with a chat on the right. At the bottom of the chat, there is a \"{{% livechat_label login_using_external_account %}}\" button.](/peertube-plugin-livechat/images/external_login_button.png?classes=shadow,border&height=200px \"{{% livechat_label login_using_external_account %}} button\")"
-msgstr ""
-"![Screenshot einer Peertube-Videoseite, mit einem Chat auf der rechten "
-"Seite. Am unteren Ende des Chats befindet sich die Schaltfläche \"{{% "
-"livechat_label login_using_external_account %}}\".](/peertube-"
-"plugin-livechat/images/"
-"external_login_button.png?classes=shadow,border&height=200px \"{{% "
-"livechat_label login_using_external_account %}} button\")"
+msgstr "![Screenshot einer Peertube-Videoseite, mit einem Chat auf der rechten Seite. Am unteren Ende des Chats befindet sich die Schaltfläche \"{{% livechat_label login_using_external_account %}}\".](/peertube-plugin-livechat/images/external_login_button.png?classes=shadow,border&height=200px \"{{% livechat_label login_using_external_account %}} button\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of a dialog with an \"OpenID Connect\" button.](/peertube-plugin-livechat/images/external_login_dialog_oidc.png?classes=shadow,border&height=200px \"External login dialog - OpenID Connect\")"
-msgstr ""
-"![Screenshot eines Dialogs mit einer Schaltfläche \"OpenID Connect\""
-".](/peertube-plugin-livechat/images/"
-"external_login_dialog_oidc.png?classes=shadow,border&height=200px \"Externer "
-"Anmeldedialog - OpenID Connect\")"
+msgstr "![Screenshot eines Dialogs mit einer Schaltfläche \"OpenID Connect\".](/peertube-plugin-livechat/images/external_login_dialog_oidc.png?classes=shadow,border&height=200px \"Externer Anmeldedialog - OpenID Connect\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/external_auth.md
@@ -1997,11 +1980,7 @@ msgstr "Direkt unter den Einstellungen finden Sie die Schaltfläche \"Configure 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/mod_firewall.md
 msgid "![Screenshot of the \"{{% livechat_label prosody_firewall_configuration %}}\" form.](/peertube-plugin-livechat/images/mod_firewall.png?classes=shadow,border&height=400px \"{{% livechat_label prosody_firewall_configuration %}}\")"
-msgstr ""
-"![Screenshot des Formulars \"{{% livechat_label "
-"prosody_firewall_configuration %}}\".](/peertube-plugin-livechat/images/"
-"mod_firewall.png?classes=shadow,border&height=400px \"{{% livechat_label "
-"prosody_firewall_configuration %}}\")"
+msgstr "![Screenshot des Formulars \"{{% livechat_label prosody_firewall_configuration %}}\".](/peertube-plugin-livechat/images/mod_firewall.png?classes=shadow,border&height=400px \"{{% livechat_label prosody_firewall_configuration %}}\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/admin/mod_firewall.md
@@ -2182,9 +2161,7 @@ msgstr "{{% livechat_label avatar_set_option_sepia %}}: [David Revoy's Peertube 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Sepia avatar example](/peertube-plugin-livechat/images/avatar_sepia.png?classes=shadow,border&height=40px \"Sepia\")"
-msgstr ""
-"![Sepia Avatar Beispiel](/peertube-plugin-livechat/images/"
-"avatar_sepia.png?classes=shadow,border&height=40px \"Sepia\")"
+msgstr "![Sepia Avatar Beispiel](/peertube-plugin-livechat/images/avatar_sepia.png?classes=shadow,border&height=40px \"Sepia\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2194,9 +2171,7 @@ msgstr "{{% livechat_label avatar_set_option_cat %}}: [David Revoy's Katzen Avat
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Cats avatar example](/peertube-plugin-livechat/images/avatar_cat.png?classes=shadow,border&height=40px \"Cats\")"
-msgstr ""
-"![Katzen AvatarBeispiel](/peertube-plugin-livechat/images/"
-"avatar_cat.png?classes=shadow,border&height=40px \"Katzen\")"
+msgstr "![Katzen AvatarBeispiel](/peertube-plugin-livechat/images/avatar_cat.png?classes=shadow,border&height=40px \"Katzen\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2206,9 +2181,7 @@ msgstr "{{% livechat_label avatar_set_option_bird %}}: [David Revoy's Vögel Ava
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Birds avatar example](/peertube-plugin-livechat/images/avatar_bird.png?classes=shadow,border&height=40px \"Birds\")"
-msgstr ""
-"![Vogel Avatar Beispiel](/peertube-plugin-livechat/images/"
-"avatar_bird.png?classes=shadow,border&height=40px \"Vögel\")"
+msgstr "![Vogel Avatar Beispiel](/peertube-plugin-livechat/images/avatar_bird.png?classes=shadow,border&height=40px \"Vögel\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2218,9 +2191,7 @@ msgstr "{{% livechat_label avatar_set_option_fenec %}}: [David Revoy's Fenec/Mob
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Fenecs avatar example](/peertube-plugin-livechat/images/avatar_fenec.png?classes=shadow,border&height=40px \"Fenecs\")"
-msgstr ""
-"![Fenecs Avatar Beispiel](/peertube-plugin-livechat/images/"
-"avatar_fenec.png?classes=shadow,border&height=40px \"Fenecs\")"
+msgstr "![Fenecs Avatar Beispiel](/peertube-plugin-livechat/images/avatar_fenec.png?classes=shadow,border&height=40px \"Fenecs\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2230,9 +2201,7 @@ msgstr "{{% livechat_label avatar_set_option_abstract %}}: [David Revoy's Abstra
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Abstracts avatar example](/peertube-plugin-livechat/images/avatar_abstract.png?classes=shadow,border&height=40px \"Abtracts\")"
-msgstr ""
-"![Abstrakt Avatar Beispiel](/peertube-plugin-livechat/images/"
-"avatar_abstract.png?classes=shadow,border&height=40px \"Abstrakt\")"
+msgstr "![Abstrakt Avatar Beispiel](/peertube-plugin-livechat/images/avatar_abstract.png?classes=shadow,border&height=40px \"Abstrakt\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2242,9 +2211,7 @@ msgstr "{{% livechat_label avatar_set_option_legacy %}}: Basierend auf [David Re
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
 msgid "![Legacy avatar example](/peertube-plugin-livechat/images/avatar_legacy.jpg?classes=shadow,border&height=40px \"Legacy\")"
-msgstr ""
-"![Alte Avatare Beispiel](/peertube-plugin-livechat/images/"
-"avatar_legacy.jpg?classes=shadow,border&height=40px \"Alte Avatare\")"
+msgstr "![Alte Avatare Beispiel](/peertube-plugin-livechat/images/avatar_legacy.jpg?classes=shadow,border&height=40px \"Alte Avatare\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/admin/settings.md
@@ -2522,11 +2489,7 @@ msgstr "Öffnen Sie die Plugin-Einstellungen, und klicken Sie auf die Schaltflä
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
 msgid "![Screenshot of the plugin's settings page, with a \"launch diagnostic\" button.](/peertube-plugin-livechat/images/launch_diagnostic.png?classes=shadow,border&height=200px \"Launch diagnostic\")"
-msgstr ""
-"![Screenshot der Einstellungsseite des Plugins, mit einer Schaltfläche "
-"\"Diagnose starten\".](/peertube-plugin-livechat/images/"
-"launch_diagnostic.png?classes=shadow,border&height=200px \"Diagnose starten\""
-")"
+msgstr "![Screenshot der Einstellungsseite des Plugins, mit einer Schaltfläche \"Diagnose starten\".](/peertube-plugin-livechat/images/launch_diagnostic.png?classes=shadow,border&height=200px \"Diagnose starten\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2536,11 +2499,7 @@ msgstr "Wenn auf der Diagnoseseite ein Fehler auftritt, können Sie auf dieser S
 #. type: Plain text
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
 msgid "![Screenshot of the diagnostic result page. This gives a lot of information, with status for different test suites.](/peertube-plugin-livechat/images/diagnostic.png?classes=shadow,border&height=200px \"Diagnostic result\")"
-msgstr ""
-"![Screenshot der Seite mit den Diagnoseergebnissen. Dies gibt eine Menge "
-"Informationen, mit Status für verschiedene Testsuiten.](/peertube-"
-"plugin-livechat/images/diagnostic.png?classes=shadow,border&height=200px "
-"\"Diagnoseergebnisse\")"
+msgstr "![Screenshot der Seite mit den Diagnoseergebnissen. Dies gibt eine Menge Informationen, mit Status für verschiedene Testsuiten.](/peertube-plugin-livechat/images/diagnostic.png?classes=shadow,border&height=200px \"Diagnoseergebnisse\")"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/installation/troubleshooting.md
@@ -2668,11 +2627,7 @@ msgstr "Sie können den Chat ganz einfach in Ihren Videostream integrieren."
 #: support/documentation/content/en/documentation/user/obs.md
 #: support/documentation/content/en/intro/_index.md
 msgid "![Screenshot of a Peertube live, replay, with the chat included at the bottom of the video stream.](/peertube-plugin-livechat/images/embed_chat_in_livestream.png?classes=shadow,border&height=200px \"Embeding the chat in a live stream\")"
-msgstr ""
-"![Screenshot einer Peertube Live-Übertragung, bei der der Chat am unteren "
-"Ende des Video-Streams eingebettet ist.](/peertube-plugin-livechat/images/"
-"embed_chat_in_livestream.png?classes=shadow,border&height=200px \"Einbettung "
-"des Chats in einen Live-Stream\")"
+msgstr "![Screenshot einer Peertube Live-Übertragung, bei der der Chat am unteren Ende des Video-Streams eingebettet ist.](/peertube-plugin-livechat/images/embed_chat_in_livestream.png?classes=shadow,border&height=200px \"Einbettung des Chats in einen Live-Stream\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2688,11 +2643,7 @@ msgstr "Aktivieren Sie das Kontrollkästchen \"{{% livechat_label read_only %}}\
 #: support/documentation/content/en/documentation/user/obs.md
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the \"{{% livechat_label share_chat_link %}}\" dialog, where the \"{{% livechat_label read_only %}}\" option is checked.](/peertube-plugin-livechat/images/share_readonly.png?classes=shadow,border&height=200px \"Share link popup\")"
-msgstr ""
-"![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs, in dem "
-"die Option \"{{% livechat_label read_only %}}\" aktiviert ist](/peertube-"
-"plugin-livechat/images/share_readonly.png?classes=shadow,border&height=200px "
-"\"Link teilen popup\")"
+msgstr "![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs, in dem die Option \"{{% livechat_label read_only %}}\" aktiviert ist](/peertube-plugin-livechat/images/share_readonly.png?classes=shadow,border&height=200px \"Link teilen popup\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2703,11 +2654,7 @@ msgstr "Verwenden Sie dann diesen Link als \"Webbrowser-Quelle\" in OBS."
 #: support/documentation/content/en/documentation/user/obs.md
 #: support/documentation/content/en/intro/_index.md
 msgid "![Screenshot of the OBS software, where the chat was added as web browser source.](/peertube-plugin-livechat/images/embed_chat_in_obs.png?classes=shadow,border&height=200px \"Embeding the chat in OBS\")"
-msgstr ""
-"![Screenshot der OBS-Software, wo der Chat als Webbrowser-Quelle hinzugefügt "
-"wurde.](/peertube-plugin-livechat/images/"
-"embed_chat_in_obs.png?classes=shadow,border&height=200px \"Den Chat in OBS "
-"einbetten\")"
+msgstr "![Screenshot der OBS-Software, wo der Chat als Webbrowser-Quelle hinzugefügt wurde.](/peertube-plugin-livechat/images/embed_chat_in_obs.png?classes=shadow,border&height=200px \"Den Chat in OBS einbetten\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2765,12 +2712,7 @@ msgstr "Verwenden Sie dazu einfach die \"{{% livechat_label share_chat_link %}}\
 #: support/documentation/content/en/documentation/user/obs.md
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the \"{{% livechat_label share_chat_link %}}\" dialog, on the \"{{% livechat_label share_chat_dock %}} tab. A token was generated, and is selectionable.\"](/peertube-plugin-livechat/images/share_dock.png?classes=shadow,border&height=200px \"Share link popup - dock tab\")"
-msgstr ""
-"![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs auf der "
-"Registerkarte \"{{% livechat_label share_chat_dock %}}\". Ein Token wurde "
-"generiert und ist auswählbar.\"](/peertube-plugin-livechat/images/"
-"share_dock.png?classes=shadow,border&height=200px \"Link teilen popup - Dock "
-"Registerkarte\")"
+msgstr "![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs auf der Registerkarte \"{{% livechat_label share_chat_dock %}}\". Ein Token wurde generiert und ist auswählbar.\"](/peertube-plugin-livechat/images/share_dock.png?classes=shadow,border&height=200px \"Link teilen popup - Dock Registerkarte\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2780,18 +2722,12 @@ msgstr "Kopieren Sie dann die URL und verwenden Sie das Menü \"Docks / Benutzer
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
 msgid "![Screenshot of the OBS Dock menu, with a \"Custom Browser Docks\" entry.](/peertube-plugin-livechat/images/obs_dock_menu.png?classes=shadow,border&height=200px \"OBS - Dock menu\")"
-msgstr ""
-"![Screenshot des OBS Dock Menüs mit dem Eintrag \"Benutzerdefinierte Browser-"
-"Docks\"](/peertube-plugin-livechat/images/"
-"obs_dock_menu.png?classes=shadow,border&height=200px \"OBS - Dock menu\")"
+msgstr "![Screenshot des OBS Dock Menüs mit dem Eintrag \"Benutzerdefinierte Browser-Docks\"](/peertube-plugin-livechat/images/obs_dock_menu.png?classes=shadow,border&height=200px \"OBS - Dock menu\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
 msgid "![Screenshot of the OBS Custom Browser Docks dialog, with a new dock called \"My chat\".](/peertube-plugin-livechat/images/obs_dock_dialog.png?classes=shadow,border&height=200px \"OBS - Dock dialog\")"
-msgstr ""
-"![Screenshot des OBS Custom Browser Docks Dialogs, mit einem neuen Dock "
-"namens \"Mein Chat\"](/peertube-plugin-livechat/images/"
-"obs_dock_dialog.png?classes=shadow,border&height=200px \"OBS - Dock Dialog\")"
+msgstr "![Screenshot des OBS Custom Browser Docks Dialogs, mit einem neuen Dock namens \"Mein Chat\"](/peertube-plugin-livechat/images/obs_dock_dialog.png?classes=shadow,border&height=200px \"OBS - Dock Dialog\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2801,11 +2737,7 @@ msgstr "Danach haben Sie ein neues Dock, das mit dem Chat und Ihrem Konto verbun
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
 msgid "![Screenshot of OBS with a new dock including the chat. The user is logged in with their Peertube account, and can chat directly from OBS.](/peertube-plugin-livechat/images/obs_dock.png?classes=shadow,border&height=200px \"OBS - Dock\")"
-msgstr ""
-"![Screenshot von OBS mit einem neuen Dock inklusive Chat. Der Nutzer ist mit "
-"seinem Peertube-Account eingeloggt und kann direkt von OBS aus chatten"
-".](/peertube-plugin-livechat/images/"
-"obs_dock.png?classes=shadow,border&height=200px \"OBS - Dock\")"
+msgstr "![Screenshot von OBS mit einem neuen Dock inklusive Chat. Der Nutzer ist mit seinem Peertube-Account eingeloggt und kann direkt von OBS aus chatten.](/peertube-plugin-livechat/images/obs_dock.png?classes=shadow,border&height=200px \"OBS - Dock\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/obs.md
@@ -2869,10 +2801,7 @@ msgstr "Wenn Sie eine Peertube Live-Stream erstellen oder ändern, gibt es eine 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the Peertube new live form.](/peertube-plugin-livechat/images/new_live.png?classes=shadow,border&height=200px \"New live\")"
-msgstr ""
-"![Screenshot des Peertube-Formulars für die Live-Übertragung (/peertube-"
-"plugin-livechat/images/new_live.png?classes=shadow,border&height=200px "
-"\"Neuer Livestream\")"
+msgstr "![Screenshot des Peertube-Formulars für die Live-Übertragung (/peertube-plugin-livechat/images/new_live.png?classes=shadow,border&height=200px \"Neuer Livestream\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2882,11 +2811,7 @@ msgstr "Auf der Registerkarte \"Plugin-Einstellungen\" gibt es ein Kontrollkäst
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the form, with a \"{{% livechat_label use_chat %}}\" checkbox.](/peertube-plugin-livechat/images/new_live_activate_chat.png?classes=shadow,border&height=200px \"Activate the chat\")"
-msgstr ""
-"![Screenshot des Formulars mit dem Kontrollkästchen \"{{% livechat_label "
-"use_chat %}}\"](/peertube-plugin-livechat/images/"
-"new_live_activate_chat.png?classes=shadow,border&height=200px \"Chat "
-"aktivieren\")"
+msgstr "![Screenshot des Formulars mit dem Kontrollkästchen \"{{% livechat_label use_chat %}}\"](/peertube-plugin-livechat/images/new_live_activate_chat.png?classes=shadow,border&height=200px \"Chat aktivieren\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2958,12 +2883,7 @@ msgstr "Auf der Registerkarte \"{{% livechat_label web %}}\" öffnet die angegeb
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the \"{{% livechat_label share_chat_link %}}\" dialog, on the \"{{% livechat_label web %}} tab. There is a url you can copy.](/peertube-plugin-livechat/images/share_web.png?classes=shadow,border&height=200px \"Share link popup - web tab\")"
-msgstr ""
-"![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs auf der "
-"Registerkarte \"{{% livechat_label web %}}\". Es gibt eine Url, die Sie "
-"kopieren können](/peertube-plugin-livechat/images/"
-"share_web.png?classes=shadow,border&height=200px Link teilen popup - Web "
-"Registerkarte\")"
+msgstr "![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs auf der Registerkarte \"{{% livechat_label web %}}\". Es gibt eine Url, die Sie kopieren können](/peertube-plugin-livechat/images/share_web.png?classes=shadow,border&height=200px Link teilen popup - Web Registerkarte\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -2974,12 +2894,7 @@ msgstr "Das \"{{% livechat_label share_chat_link %}}\" Popup-Fenster kann auch e
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
 msgid "![Screenshot of the \"{{% livechat_label share_chat_link %}}\" dialog, on the \"{{% livechat_label connect_using_xmpp %}}\" tab.](/peertube-plugin-livechat/images/share_xmpp_dialog.png?classes=shadow,border&height=200px \"{{% livechat_label connect_using_xmpp %}}\")"
-msgstr ""
-"![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs, auf der "
-"Registerkarte \"{{% livechat_label connect_using_xmpp %}}\".](/peertube-"
-"plugin-livechat/images/"
-"share_xmpp_dialog.png?classes=shadow,border&height=200px \"{{% "
-"livechat_label connect_using_xmpp %}}\")"
+msgstr "![Screenshot des \"{{% livechat_label share_chat_link %}}\"-Dialogs, auf der Registerkarte \"{{% livechat_label connect_using_xmpp %}}\".](/peertube-plugin-livechat/images/share_xmpp_dialog.png?classes=shadow,border&height=200px \"{{% livechat_label connect_using_xmpp %}}\")"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -3027,10 +2942,7 @@ msgstr "Sie können das Dauerhaftigkeitsverhalten ändern.  [Öffnen Sie das Cha
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of the dropdown menu at the top of the chat. Several entries are available.](/peertube-plugin-livechat/images/top_menu.png?classes=shadow,border&height=200px \"Chat menu\")"
-msgstr ""
-"![Screenshot des Dropdown-Menüs oben im Chat. Es sind mehrere Einträge "
-"verfügbar. ](/peertube-plugin-livechat/images/"
-"top_menu.png?classes=shadow,border&height=200px \"Chat Menü\")"
+msgstr "![Screenshot des Dropdown-Menüs oben im Chat. Es sind mehrere Einträge verfügbar. ](/peertube-plugin-livechat/images/top_menu.png?classes=shadow,border&height=200px \"Chat Menü\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -3040,10 +2952,7 @@ msgstr "Es gibt mehrere Optionen, die geändert werden können."
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
 msgid "![Screenshot of the chat configuration form.](/peertube-plugin-livechat/images/configure.png?classes=shadow,border&height=200px \"Configure chat room\")"
-msgstr ""
-"![Screenshot des Chat-Konfigurationsformulars.](/peertube-plugin-livechat/"
-"images/configure.png?classes=shadow,border&height=200px \"Chatraum "
-"konfigurieren\")"
+msgstr "![Screenshot des Chat-Konfigurationsformulars.](/peertube-plugin-livechat/images/configure.png?classes=shadow,border&height=200px \"Chatraum konfigurieren\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/basics.md
@@ -3091,10 +3000,7 @@ msgstr "Befehle"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
 msgid "![Screenshot of the channel options page, with some fields to configure the bot commands.](/peertube-plugin-livechat/images/bot_commands.png?classes=shadow,border&height=400px \"Commands configuration\")"
-msgstr ""
-"![Screenshot der Seite mit den Kanaloptionen, mit einigen Feldern zur "
-"Konfiguration der Chatbot-Befehle.](/peertube-plugin-livechat/images/"
-"bot_commands.png?classes=shadow,border&height=400px \"Befehlskonfiguration\")"
+msgstr "![Screenshot der Seite mit den Kanaloptionen, mit einigen Feldern zur Konfiguration der Chatbot-Befehle.](/peertube-plugin-livechat/images/bot_commands.png?classes=shadow,border&height=400px \"Befehlskonfiguration\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/commands.md
@@ -3116,20 +3022,12 @@ msgstr "Verbotene Wörter"
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
 msgid "![Screenshot of the channel options page, with several fields to configure the forbidden words.](/peertube-plugin-livechat/images/bot_forbidden_words.png?classes=shadow,border&height=400px \"Forbidden words configuration\")"
-msgstr ""
-"![Screenshot der Seite mit den Kanaloptionen, mit mehreren Feldern zur "
-"Konfiguration der verbotenen Wörter.](/peertube-plugin-livechat/images/"
-"bot_forbidden_words.png?classes=shadow,border&height=400px \"Konfiguration "
-"der verbotenen Wörter\")"
+msgstr "![Screenshot der Seite mit den Kanaloptionen, mit mehreren Feldern zur Konfiguration der verbotenen Wörter.](/peertube-plugin-livechat/images/bot_forbidden_words.png?classes=shadow,border&height=400px \"Konfiguration der verbotenen Wörter\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
 msgid "![Screenshot of a chat message that was deleted, with the following reason: \"No url allowed\".](/peertube-plugin-livechat/images/bot_deleted_message.png?classes=shadow,border&height=100px \"Deleted message\")"
-msgstr ""
-"![Screenshot einer Chat-Nachricht, die mit folgender Begründung gelöscht "
-"wurde: \"Keine URL erlaubt\".](/peertube-plugin-livechat/images/"
-"bot_deleted_message.png?classes=shadow,border&height=100px \"Gelöschte "
-"Nachricht\")"
+msgstr "![Screenshot einer Chat-Nachricht, die mit folgender Begründung gelöscht wurde: \"Keine URL erlaubt\".](/peertube-plugin-livechat/images/bot_deleted_message.png?classes=shadow,border&height=100px \"Gelöschte Nachricht\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/forbidden_words.md
@@ -3210,11 +3108,7 @@ msgstr "Sie können einen Chatbot für Ihre Chaträume aktivieren.  Die Chatbotk
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
 #: support/documentation/content/en/documentation/user/streamers/channel.md
 msgid "![Screenshot of the channel options. There is a form with multiple fields.](/peertube-plugin-livechat/images/channel_configuration.png?classes=shadow,border&height=400px \"Channel configuration\")"
-msgstr ""
-"![Screenshot der Kanaloptionen; es gibt ein Formular mit mehreren Feldern"
-".](/peertube-plugin-livechat/images/"
-"channel_configuration.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration\")"
+msgstr "![Screenshot der Kanaloptionen; es gibt ein Formular mit mehreren Feldern.](/peertube-plugin-livechat/images/channel_configuration.png?classes=shadow,border&height=400px \"Kanalkonfiguration\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/bot/_index.md
@@ -3251,10 +3145,7 @@ msgstr "Wenn sich kein Benutzer im Chatraum befindet, sendet der Chatbot keine N
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/bot/quotes.md
 msgid "![Screenshot of the channel options page, with some fields to configure a new timer.](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px \"Timers configuration\")"
-msgstr ""
-"![Screenshot der Seite mit den Kanaloptionen, mit einigen Feldern zur "
-"Konfiguration eines neuen Timers.](/peertube-plugin-livechat/images/"
-"bot_quotes.png?classes=shadow,border&height=200px \"Timer konfiguration\")"
+msgstr "![Screenshot der Seite mit den Kanaloptionen, mit einigen Feldern zur Konfiguration eines neuen Timers.](/peertube-plugin-livechat/images/bot_quotes.png?classes=shadow,border&height=200px \"Timer konfiguration\")"
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -3276,10 +3167,7 @@ msgstr "Im linken Menü von Peertube gibt es einen Eintrag \"{{% livechat_label 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
 msgid "![Screenshot of the chatrooms configuration page. The page list the user's channels.](/peertube-plugin-livechat/images/chatrooms_menu.png?classes=shadow,border&height=400px \"Chatrooms menu\")"
-msgstr ""
-"![Screenshot der Konfigurationsseite für Chaträume. Die Seite listet die "
-"Kanäle des Benutzers auf.](/peertube-plugin-livechat/images/"
-"chatrooms_menu.png?classes=shadow,border&height=400px \"Chaträume Menü\")"
+msgstr "![Screenshot der Konfigurationsseite für Chaträume. Die Seite listet die Kanäle des Benutzers auf.](/peertube-plugin-livechat/images/chatrooms_menu.png?classes=shadow,border&height=400px \"Chaträume Menü\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/channel.md
@@ -3352,21 +3240,12 @@ msgstr "Öffnen Sie auf der [Kanal Konfigurationsseite](/peertube-plugin-livecha
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/emojis.md
 msgid "![Screenshot of the emoji configuration page. There is a form where you can add new emojis.](/peertube-plugin-livechat/images/channel_custom_emojis_configuration.png?classes=shadow,border&height=400px \"Channel configuration / Channel emojis configuration\")"
-msgstr ""
-"![Screenshot der Emoji-Konfigurationsseite. Es gibt ein Formular, in dem Sie "
-"neue Emojis hinzufügen können.](/peertube-plugin-livechat/images/"
-"channel_custom_emojis_configuration.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration / Kanal Emojis Konfiguration\")"
+msgstr "![Screenshot der Emoji-Konfigurationsseite. Es gibt ein Formular, in dem Sie neue Emojis hinzufügen können.](/peertube-plugin-livechat/images/channel_custom_emojis_configuration.png?classes=shadow,border&height=400px \"Kanalkonfiguration / Kanal Emojis Konfiguration\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/emojis.md
 msgid "![Screenshot of a chat session, with messages containing custom emojis. The emoji picker is open, and shows custom emojis.](/peertube-plugin-livechat/images/channel_custom_emojis.png?classes=shadow,border&height=400px \"Channel configuration / Channel emojis\")"
-msgstr ""
-"![Screenshot einer Chatsitzung mit Nachrichten, die benutzerdefinierte "
-"Emojis enthalten. Die Emoji-Auswahl ist geöffnet und zeigt "
-"benutzerdefinierte Emojis.](/peertube-plugin-livechat/images/"
-"channel_custom_emojis.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration / Kanal Emojis\")"
+msgstr "![Screenshot einer Chatsitzung mit Nachrichten, die benutzerdefinierte Emojis enthalten. Die Emoji-Auswahl ist geöffnet und zeigt benutzerdefinierte Emojis.](/peertube-plugin-livechat/images/channel_custom_emojis.png?classes=shadow,border&height=400px \"Kanalkonfiguration / Kanal Emojis\")"
 
 #. type: Title ###
 #: build/documentation/pot_in/documentation/user/streamers/emojis.md
@@ -3406,6 +3285,57 @@ msgstr ""
 #: build/documentation/pot_in/documentation/user/streamers/emojis.md
 msgid "The `sn` attribute is the short name code.  The `url` attribute can be any image url than your browser can access, or a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) representing the file you want to import."
 msgstr "Das Attribut `sn` ist der Kurznamencode.  Das Attribut \"url\" kann eine beliebige Bild-URL sein, auf die Ihr Browser zugreifen kann, oder eine [Daten-URL] (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs), die die zu importierende Datei darstellt."
+
+#. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+#| msgid "Plugin peertube-plugin-livechat slow mode"
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "Plugin peertube-plugin-livechat Langsamer Modus"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "This feature comes with the livechat plugin version 11.0.0."
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr "Diese Funktion wird mit dem Livechatplugin Version 11.0.0 verfügbar sein."
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "This can be really usefull to:"
+msgid "This mode can be usefull for example:"
+msgstr "Dies kann sehr nützlich sein, um:"
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label livechat_configuration_channel_anonymize_moderation_label %}}\" checkbox."
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr "Um diese Funktion zu aktivieren oder zu deaktivieren, verwenden Sie das [Chat-Dropdown-Menü](/peertube-plugin-livechat/de/documentation/user/viewers), öffnen Sie das Menü \"Konfigurieren\".  In dem Formular finden Sie eine Checkbox \"{{% livechat_label livechat_configuration_channel_anonymize_moderation_label %}}\"."
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "On the [channel configuration page](/peertube-plugin-livechat/documentation/user/streamers/channel), you can set the \"{{% livechat_label moderation_delay %}}\" option:"
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr "Auf der [Kanal Konfigurationsseite](/peertube-plugin-livechat/de/documentation/user/streamers/channel) können Sie die Option \"{{% livechat_label moderation_delay %}}\" einstellen:"
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
@@ -3475,11 +3405,7 @@ msgstr "Auf der [Kanal Konfigurationsseite](/peertube-plugin-livechat/de/documen
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_delay.md
 msgid "![Screenshot of the channel option form, with a field to configure the moderation delay.](/peertube-plugin-livechat/images/moderation_delay_channel_option.png?classes=shadow,border&height=400px \"Channel configuration / Moderation delay\")"
-msgstr ""
-"![Screenshot des Formulars für die Kanaloptionen, mit einem Feld zur "
-"Konfiguration der Moderationsverzögerung.](/peertube-plugin-livechat/images/"
-"moderation_delay_channel_option.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration / Moderationsverzögerung\")"
+msgstr "![Screenshot des Formulars für die Kanaloptionen, mit einem Feld zur Konfiguration der Moderationsverzögerung.](/peertube-plugin-livechat/images/moderation_delay_channel_option.png?classes=shadow,border&height=400px \"Kanalkonfiguration / Moderationsverzögerung\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_delay.md
@@ -3522,11 +3448,7 @@ msgstr "Als Moderator sehen Sie neben dem Datum der Nachricht auch die verbleibe
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_delay.md
 msgid "![Screenshot of a chat message. A timer is displayed next to the message datetime. The timer is in seconds.](/peertube-plugin-livechat/images/moderation_delay_timer.png?classes=shadow,border \"Moderation delay timer\")"
-msgstr ""
-"![Screenshot einer Chat-Nachricht. Neben dem Datum der Nachricht wird ein "
-"Timer angezeigt. Der Timer ist in Sekunden.](/peertube-plugin-livechat/"
-"images/moderation_delay_timer.png?classes=shadow,border "
-"\"Moderationsverzögerungstimer\")"
+msgstr "![Screenshot einer Chat-Nachricht. Neben dem Datum der Nachricht wird ein Timer angezeigt. Der Timer ist in Sekunden.](/peertube-plugin-livechat/images/moderation_delay_timer.png?classes=shadow,border \"Moderationsverzögerungstimer\")"
 
 #. type: Yaml Front Matter Hash Value: description
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
@@ -3606,12 +3528,7 @@ msgstr "Um diese Funktion zu aktivieren oder zu deaktivieren, verwenden Sie das 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
 msgid "![Screenshot of the room configuration form. There is a \"{{% livechat_label livechat_configuration_channel_mute_anonymous_label %}}\" checkbox.](/peertube-plugin-livechat/images/configure_mute_anonymous.png?classes=shadow,border&height=400px \"Room configuration / Mute anonymous users\")"
-msgstr ""
-"![Screenshot des Raumkonfigurationsformulars. Es gibt ein \"{{% "
-"livechat_label livechat_configuration_channel_mute_anonymous_label %}}\""
-"-Kontrollkästchen.](/peertube-plugin-livechat/images/"
-"configure_mute_anonymous.png?classes=shadow,border&height=400px "
-"\"Raumkonfiguration / Anonyme Benutzer stummschalten\")"
+msgstr "![Screenshot des Raumkonfigurationsformulars. Es gibt ein \"{{% livechat_label livechat_configuration_channel_mute_anonymous_label %}}\"-Kontrollkästchen.](/peertube-plugin-livechat/images/configure_mute_anonymous.png?classes=shadow,border&height=400px \"Raumkonfiguration / Anonyme Benutzer stummschalten\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
@@ -3621,12 +3538,7 @@ msgstr "Anonyme Benutzer haben das Nachrichtenfeld nicht und sehen folgende Auff
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
 msgid "![Screenshot of a chat session. The current user has no message field. There is a message: \"{{% livechat_label muted_anonymous_message %}}\"](/peertube-plugin-livechat/images/anonymous_muted.png?classes=shadow,border&height=400px \"Room configuration / Muted anonymous users\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Der aktuelle Benutzer hat kein "
-"Nachrichtenfeld. Es gibt eine Nachricht: \"{{% livechat_label "
-"muted_anonymous_message %}}\"](/peertube-plugin-livechat/images/"
-"anonymous_muted.png?classes=shadow,border&height=400px \"Raumkonfiguration / "
-"Stummgeschaltete anonyme Benutzer\")"
+msgstr "![Screenshot einer Chatsitzung. Der aktuelle Benutzer hat kein Nachrichtenfeld. Es gibt eine Nachricht: \"{{% livechat_label muted_anonymous_message %}}\"](/peertube-plugin-livechat/images/anonymous_muted.png?classes=shadow,border&height=400px \"Raumkonfiguration / Stummgeschaltete anonyme Benutzer\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
@@ -3698,12 +3610,7 @@ msgstr "die Aktion \"{{% livechat_label search_occupant_message %}}\" im Dropdow
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
 msgid "![Screenshot of a chat session. The moderator has open the message menu, and there is a \"{{% livechat_label search_occupant_message %}}\" button.](/peertube-plugin-livechat/images/message_search.png?classes=shadow,border&height=200px \"Message history search\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Der Moderator hat das Nachrichtenmenü "
-"geöffnet, und es gibt eine Schaltfläche \"{{% livechat_label "
-"search_occupant_message %}}\".](/peertube-plugin-livechat/images/"
-"message_search.png?classes=shadow,border&height=200px "
-"\"Nachrichtenverlaufssuche\")"
+msgstr "![Screenshot einer Chatsitzung. Der Moderator hat das Nachrichtenmenü geöffnet, und es gibt eine Schaltfläche \"{{% livechat_label search_occupant_message %}}\".](/peertube-plugin-livechat/images/message_search.png?classes=shadow,border&height=200px \"Nachrichtenverlaufssuche\")"
 
 #. type: Plain text
 #: build/documentation/pot_in/documentation/user/streamers/moderation.md
@@ -3829,22 +3736,12 @@ msgstr "Um die Anwendung Moderationsnotizen zu öffnen, gibt es eine Schaltfläc
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
 msgid "![Screenshot of a Peertube video, with the chat on the right. The chat top menu is open, with a \"{{% livechat_label \"moderator_notes\" %}}\" button.](/peertube-plugin-livechat/images/moderation_notes_open_app_video.png?classes=shadow,border&height=200px \"Opening the Moderator Notes Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Das "
-"obere Menü des Chats ist geöffnet, mit einer \"{{% livechat_label "
-"\"moderator_notes\" %}}\"-Schaltfläche.](/peertube-plugin-livechat/images/"
-"moderation_notes_open_app_video.png?classes=shadow,border&height=200px "
-"\"Öffnen des Moderator Notizen Programms\")"
+msgstr "![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Das obere Menü des Chats ist geöffnet, mit einer \"{{% livechat_label \"moderator_notes\" %}}\"-Schaltfläche.](/peertube-plugin-livechat/images/moderation_notes_open_app_video.png?classes=shadow,border&height=200px \"Öffnen des Moderator Notizen Programms\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
 msgid "![Screenshot of a Peertube chat, fullscreen. The chat top menu open, with a \"{{% livechat_label \"moderator_notes\" %}}\" button.](/peertube-plugin-livechat/images/moderation_notes_open_app_fullpage.png?classes=shadow,border&height=200px \"Opening the Moderator Notes Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Chats, Vollbild. Das obere Menü des Chats ist "
-"geöffnet, mit einer \"{{% livechat_label \"moderator_notes\" %}}\""
-"-Schaltfläche.](/peertube-plugin-livechat/images/"
-"moderation_notes_open_app_fullpage.png?classes=shadow,border&height=200px "
-"\"Öffnen des Moderator Notizen Programms\")"
+msgstr "![Screenshot eines Peertube-Chats, Vollbild. Das obere Menü des Chats ist geöffnet, mit einer \"{{% livechat_label \"moderator_notes\" %}}\"-Schaltfläche.](/peertube-plugin-livechat/images/moderation_notes_open_app_fullpage.png?classes=shadow,border&height=200px \"Öffnen des Moderator Notizen Programms\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
@@ -3854,22 +3751,12 @@ msgstr "Wenn Sie auf diese Schaltfläche klicken, wird die Anzeige der Anwendung
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
 msgid "![Screenshot of a Peertube video, with the chat on the right. The moderation notes application is open. There are several notes, some of them are associated to users.](/peertube-plugin-livechat/images/moderator_notes_app_video_1.png?classes=shadow,border&height=200px \"Moderator Notes Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Die "
-"Anwendung für Moderationsnotizen ist geöffnet. Es gibt mehrere Notizen, "
-"einige davon sind mit Benutzern verknüpft.](/peertube-plugin-livechat/images/"
-"moderator_notes_app_video_1.png?classes=shadow,border&height=200px "
-"\"Moderator Notizen Programm\")"
+msgstr "![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Die Anwendung für Moderationsnotizen ist geöffnet. Es gibt mehrere Notizen, einige davon sind mit Benutzern verknüpft.](/peertube-plugin-livechat/images/moderator_notes_app_video_1.png?classes=shadow,border&height=200px \"Moderator Notizen Programm\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
 msgid "![Screenshot of a Peertube chat, fullscreen. The moderation notes application is open. There are several notes, some of them are associated to users.](/peertube-plugin-livechat/images/moderator_notes_app_fullpage_1.png?classes=shadow,border&height=200px \"Moderator Notes Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Chats, Vollbild. Die Anwendung für "
-"Moderationsnotizen ist geöffnet. Es gibt mehrere Notizen, einige davon sind "
-"mit Benutzern verknüpft.](/peertube-plugin-livechat/images/"
-"moderator_notes_app_fullpage_1.png?classes=shadow,border&height=200px "
-"\"Moderator Notizen Programm\")"
+msgstr "![Screenshot eines Peertube-Chats, Vollbild. Die Anwendung für Moderationsnotizen ist geöffnet. Es gibt mehrere Notizen, einige davon sind mit Benutzern verknüpft.](/peertube-plugin-livechat/images/moderator_notes_app_fullpage_1.png?classes=shadow,border&height=200px \"Moderator Notizen Programm\")"
 
 #. type: Title ###
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
@@ -3987,12 +3874,7 @@ msgstr "Sie können den Filter entfernen, indem Sie auf die Schaltfläche \"Schl
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
 msgid "![Screenshot of the note application, with a filter enabled for user \"Mike\". The only notes that are shown are the notes for the Mike user.](/peertube-plugin-livechat/images/moderation_notes_filters.png?classes=shadow,border&height=200px \"Moderator Notes Application - filtering\")"
-msgstr ""
-"![Screenshot der Notizen-Anwendung, mit einem aktivierten Filter für den "
-"Benutzer \"Mike\". Es werden nur die Notizen für den Benutzer \"Mike\" "
-"angezeigt.](/peertube-plugin-livechat/images/"
-"moderation_notes_filters.png?classes=shadow,border&height=200px \"Moderator "
-"Notizen Programm - Filtern\")"
+msgstr "![Screenshot der Notizen-Anwendung, mit einem aktivierten Filter für den Benutzer \"Mike\". Es werden nur die Notizen für den Benutzer \"Mike\" angezeigt.](/peertube-plugin-livechat/images/moderation_notes_filters.png?classes=shadow,border&height=200px \"Moderator Notizen Programm - Filtern\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/moderation_notes.md
@@ -4022,8 +3904,9 @@ msgstr "Sie können Notizen einfach per Drag & Drop sortieren."
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
-#, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+#, fuzzy, no-wrap
+#| msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr "Sie können Umfragen erstellen, um die Zuschauer nach ihrer Meinung zu fragen."
 
 #. type: Yaml Front Matter Hash Value: title
@@ -4046,11 +3929,7 @@ msgstr "Sie können eine neue Umfrage erstellen, indem Sie die Aktion \"{{% live
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 msgid "![Screenshot of a \"{{% livechat_label new_poll %}}\" form. The form contains several fields: question, duration, choices, …](/peertube-plugin-livechat/images/polls_form.png?classes=shadow,border&height=200px \"Poll form\")"
-msgstr ""
-"![Screenshot eines \"{{% livechat_label new_poll %}}\"-Formulars. Das "
-"Formular enthält mehrere Felder: Frage, Dauer, Auswahlmöglichkeiten, "
-"...](/peertube-plugin-livechat/images/"
-"polls_form.png?classes=shadow,border&height=200px \"Umfrageformular\")"
+msgstr "![Screenshot eines \"{{% livechat_label new_poll %}}\"-Formulars. Das Formular enthält mehrere Felder: Frage, Dauer, Auswahlmöglichkeiten, ...](/peertube-plugin-livechat/images/polls_form.png?classes=shadow,border&height=200px \"Umfrageformular\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
@@ -4142,12 +4021,7 @@ msgstr "Außerdem wird ein Banner erscheinen, das die Umfrage anzeigt und regelm
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 msgid "![Screenshot of a chat session. In the chat, there is a message with the poll question, and the different choices. There is also a banner on the top of the chat, where you can see the question, and the number of votes for each answers.](/peertube-plugin-livechat/images/polls_start.png?classes=shadow,border&height=200px \"Poll start\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Im Chat gibt es eine Nachricht mit der Frage "
-"und den verschiedenen Wahlmöglichkeiten. Außerdem gibt es ein Banner am "
-"oberen Rand des Chats, auf dem die Frage und die Anzahl der Stimmen für die "
-"einzelnen Antworten zu sehen sind.](/peertube-plugin-livechat/images/"
-"polls_start.png?classes=shadow,border&height=200px \"Umfragestart\")"
+msgstr "![Screenshot einer Chatsitzung. Im Chat gibt es eine Nachricht mit der Frage und den verschiedenen Wahlmöglichkeiten. Außerdem gibt es ein Banner am oberen Rand des Chats, auf dem die Frage und die Anzahl der Stimmen für die einzelnen Antworten zu sehen sind.](/peertube-plugin-livechat/images/polls_start.png?classes=shadow,border&height=200px \"Umfragestart\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
@@ -4167,11 +4041,7 @@ msgstr "Die Zuschauer können ihre Wahl jederzeit ändern, indem sie einfach ein
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 msgid "![Screenshot of a chat session, with an ongoing poll. The current user has just voted by sending \"!1\".](/peertube-plugin-livechat/images/polls_votes.png?classes=shadow,border&height=200px \"Poll votes\")"
-msgstr ""
-"![Screenshot einer Chatsitzung mit einer laufenden Umfrage. Der aktuelle "
-"Benutzer hat gerade abgestimmt, indem er \"!1\" gesendet hat.](/peertube-"
-"plugin-livechat/images/polls_votes.png?classes=shadow,border&height=200px "
-"\"Umfrage abstimmen\")"
+msgstr "![Screenshot einer Chatsitzung mit einer laufenden Umfrage. Der aktuelle Benutzer hat gerade abgestimmt, indem er \"!1\" gesendet hat.](/peertube-plugin-livechat/images/polls_votes.png?classes=shadow,border&height=200px \"Umfrage abstimmen\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
@@ -4196,13 +4066,7 @@ msgstr "Wenn die Umfrage beendet ist, wird im Chat eine neue Nachricht mit den E
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 msgid "![Screenshot of a chat session, with poll that has ended. The banner no more accept new votes. There is a message in the chat with the poll results. For each choice, there is the number of votes, and the percentage of the total it represents.](/peertube-plugin-livechat/images/polls_end.png?classes=shadow,border&height=200px \"Poll end\")"
-msgstr ""
-"![Screenshot einer Chatsitzung, mit einer Umfrage, die beendet wurde. Das "
-"banner nimmt keine neuen Stimmen mehr an. Im Chat erscheint eine Nachricht "
-"mit den Ergebnissen der Umfrage. Für jede Wahl gibt es die Anzahl der "
-"Stimmen und den prozentualen Anteil an der Gesamtzahl.](/peertube-"
-"plugin-livechat/images/polls_end.png?classes=shadow,border&height=200px "
-"\"Umfrageende\")"
+msgstr "![Screenshot einer Chatsitzung, mit einer Umfrage, die beendet wurde. Das banner nimmt keine neuen Stimmen mehr an. Im Chat erscheint eine Nachricht mit den Ergebnissen der Umfrage. Für jede Wahl gibt es die Anzahl der Stimmen und den prozentualen Anteil an der Gesamtzahl.](/peertube-plugin-livechat/images/polls_end.png?classes=shadow,border&height=200px \"Umfrageende\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/polls.md
@@ -4270,11 +4134,7 @@ msgstr "Auf der [Kanal Konfigurations Seite](/peertube-plugin-livechat/de/docume
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "![Screenshot of the channel options form, with a slow mode field.](/peertube-plugin-livechat/images/slow_mode_channel_option.png?classes=shadow,border&height=400px \"Channel configuration / Slow Mode\")"
-msgstr ""
-"![Screenshot des Formulars für die Kanaloptionen, mit einem Feld für den "
-"langsamen Modus.](/peertube-plugin-livechat/images/"
-"slow_mode_channel_option.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration / Langsamer Modus\")"
+msgstr "![Screenshot des Formulars für die Kanaloptionen, mit einem Feld für den langsamen Modus.](/peertube-plugin-livechat/images/slow_mode_channel_option.png?classes=shadow,border&height=400px \"Kanalkonfiguration / Langsamer Modus\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -4301,12 +4161,7 @@ msgstr "Wenn der langsame Modus aktiviert ist, wird der Benutzer durch eine Nach
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
 msgid "![Screenshot of a chat session. There is a banner on the bottom of the chat, indicating that the slow mode is enabled, and that users can send a message every 2 seconds.](/peertube-plugin-livechat/images/slow_mode.png?classes=shadow,border&height=400px \"Slow mode infobox\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Am unteren Rand des Chats befindet sich ein "
-"Banner, das darauf hinweist, dass der langsame Modus aktiviert ist und die "
-"Benutzer alle 2 Sekunden eine Nachricht senden können.](/peertube-"
-"plugin-livechat/images/slow_mode.png?classes=shadow,border&height=400px "
-"\"Langsamer Modus Infobox\")"
+msgstr "![Screenshot einer Chatsitzung. Am unteren Rand des Chats befindet sich ein Banner, das darauf hinweist, dass der langsame Modus aktiviert ist und die Benutzer alle 2 Sekunden eine Nachricht senden können.](/peertube-plugin-livechat/images/slow_mode.png?classes=shadow,border&height=400px \"Langsamer Modus Infobox\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/slow_mode.md
@@ -4370,22 +4225,12 @@ msgstr "Um die Aufgabenanwendung zu öffnen, gibt es eine Schaltfläche \"{{% li
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a Peertube video, with the chat on the right. The chat top menu is open, with a \"{{% livechat_label tasks %}}\" button.](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px \"Opening the Task Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Das "
-"obere Menü des Chats ist geöffnet, mit einer Schaltfläche \"{{% "
-"livechat_label tasks %}}\".](/peertube-plugin-livechat/images/"
-"task_open_app_video.png?classes=shadow,border&height=200px \"Öffnen der "
-"Aufgabenanwendung\")"
+msgstr "![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Das obere Menü des Chats ist geöffnet, mit einer Schaltfläche \"{{% livechat_label tasks %}}\".](/peertube-plugin-livechat/images/task_open_app_video.png?classes=shadow,border&height=200px \"Öffnen der Aufgabenanwendung\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a Peertube chat, fullscreen. The chat top menu open, with a \"{{% livechat_label tasks %}}\" button.](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px \"Opening the Task Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Chats, Vollbild. Das obere Menü des Chats ist "
-"geöffnet, mit der Schaltfläche \"{{% livechat_label tasks %}}\".](/peertube-"
-"plugin-livechat/images/"
-"task_open_app_fullpage.png?classes=shadow,border&height=200px \"Öffnen der "
-"Aufgabenanwendung\")"
+msgstr "![Screenshot eines Peertube-Chats, Vollbild. Das obere Menü des Chats ist geöffnet, mit der Schaltfläche \"{{% livechat_label tasks %}}\".](/peertube-plugin-livechat/images/task_open_app_fullpage.png?classes=shadow,border&height=200px \"Öffnen der Aufgabenanwendung\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4395,22 +4240,12 @@ msgstr "Wenn Sie auf diese Schaltfläche klicken, wird die Anzeige der Aufgabena
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a Peertube video, with the chat on the right. The Task application is open. There is a task list, and a form to create a new task.](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px \"Task Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Die "
-"Aufgabenanwendung ist geöffnet. Es gibt eine Aufgabenliste und ein Formular, "
-"um eine neue Aufgabe zu erstellen.](/peertube-plugin-livechat/images/"
-"task_app_video_1.png?classes=shadow,border&height=200px \"Aufgabenanwendung\""
-")"
+msgstr "![Screenshot eines Peertube-Videos, mit dem Chat auf der rechten Seite. Die Aufgabenanwendung ist geöffnet. Es gibt eine Aufgabenliste und ein Formular, um eine neue Aufgabe zu erstellen.](/peertube-plugin-livechat/images/task_app_video_1.png?classes=shadow,border&height=200px \"Aufgabenanwendung\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a Peertube chat, fullscreen.  The Task application is open. There is a task list, and a form to create a new task.](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px \"Task Application\")"
-msgstr ""
-"![Screenshot eines Peertube-Chats, Vollbild.  Die Aufgabenanwendung ist "
-"geöffnet. Es gibt eine Aufgabenliste und ein Formular, um eine neue Aufgabe "
-"zu erstellen.](/peertube-plugin-livechat/images/"
-"task_app_fullpage_1.png?classes=shadow,border&height=200px "
-"\"Aufgabenanwendung\")"
+msgstr "![Screenshot eines Peertube-Chats, Vollbild.  Die Aufgabenanwendung ist geöffnet. Es gibt eine Aufgabenliste und ein Formular, um eine neue Aufgabe zu erstellen.](/peertube-plugin-livechat/images/task_app_fullpage_1.png?classes=shadow,border&height=200px \"Aufgabenanwendung\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4446,11 +4281,7 @@ msgstr "Die Aufgabenlisten sind alphabetisch sortiert."
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a chat session, with the Task application. There are several task lists.](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px \"Task lists\")"
-msgstr ""
-"![Screenshot einer Chatsitzung mit der Aufgabenanwendung. Es gibt mehrere "
-"Aufgabenlisten.](/peertube-plugin-livechat/images/"
-"task_app_task_lists.png?classes=shadow,border&height=200px \"Aufgabenlisten\""
-")"
+msgstr "![Screenshot einer Chatsitzung mit der Aufgabenanwendung. Es gibt mehrere Aufgabenlisten.](/peertube-plugin-livechat/images/task_app_task_lists.png?classes=shadow,border&height=200px \"Aufgabenlisten\")"
 
 #. type: Title ###
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4472,20 +4303,12 @@ msgstr "Sie können eine Aufgabe über die Schaltfläche rechts neben der Aufgab
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. Under the first task list, there is a form to create a new task.](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px \"Task form\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Unter der ersten Aufgabenliste befindet "
-"sich ein Formular zum Erstellen einer neuen Aufgabe.](/peertube-"
-"plugin-livechat/images/"
-"task_app_task_form.png?classes=shadow,border&height=200px \"Aufgabenformular"
-"\")"
+msgstr "![Screenshot der Aufgabenanwendung. Unter der ersten Aufgabenliste befindet sich ein Formular zum Erstellen einer neuen Aufgabe.](/peertube-plugin-livechat/images/task_app_task_form.png?classes=shadow,border&height=200px \"Aufgabenformular\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. Under the first task list, a new task was created.](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px \"Task created\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Unter der ersten Aufgabenliste wurde "
-"eine neue Aufgabe erstellt.](/peertube-plugin-livechat/images/"
-"task_app_task_1.png?classes=shadow,border&height=200px \"Aufgabe erstellt\")"
+msgstr "![Screenshot der Aufgabenanwendung. Unter der ersten Aufgabenliste wurde eine neue Aufgabe erstellt.](/peertube-plugin-livechat/images/task_app_task_1.png?classes=shadow,border&height=200px \"Aufgabe erstellt\")"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4506,11 +4329,7 @@ msgstr "Aufgaben können durch direktes Anklicken des Kontrollkästchens in der 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. Under task lists, there are several tasks. Some of them are checked, other not.](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px \"Tasks\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Unter den Aufgabenlisten gibt es mehrere "
-"Aufgaben. Einige von ihnen sind markiert, andere nicht.](/peertube-"
-"plugin-livechat/images/"
-"task_app_task_2.png?classes=shadow,border&height=200px \"Aufgaben\")"
+msgstr "![Screenshot der Aufgabenanwendung. Unter den Aufgabenlisten gibt es mehrere Aufgaben. Einige von ihnen sind markiert, andere nicht.](/peertube-plugin-livechat/images/task_app_task_2.png?classes=shadow,border&height=200px \"Aufgaben\")"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4526,20 +4345,12 @@ msgstr "Sie können Aufgaben sortieren oder von einer Liste in eine andere versc
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. There is a task that is dragged over another.](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px \"Drag and drop to sort\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Eine Aufgabe wird über eine andere "
-"gezogen](/peertube-plugin-livechat/images/"
-"task_drag_drop.png?classes=shadow,border&height=200px \"Drag und drop zum "
-"sortieren\")"
+msgstr "![Screenshot der Aufgabenanwendung. Eine Aufgabe wird über eine andere gezogen](/peertube-plugin-livechat/images/task_drag_drop.png?classes=shadow,border&height=200px \"Drag und drop zum sortieren\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. There is a task that is dragged over another task list.](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px \"Drag and drop to move to another list\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Es gibt eine Aufgabe, die über eine "
-"andere Aufgabenliste gezogen wird.](/peertube-plugin-livechat/images/"
-"task_drag_drop_task_list.png?classes=shadow,border&height=200px \"Drag und "
-"drop zum verschieben zu einer anderen Liste\")"
+msgstr "![Screenshot der Aufgabenanwendung. Es gibt eine Aufgabe, die über eine andere Aufgabenliste gezogen wird.](/peertube-plugin-livechat/images/task_drag_drop_task_list.png?classes=shadow,border&height=200px \"Drag und drop zum verschieben zu einer anderen Liste\")"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4555,32 +4366,17 @@ msgstr "Sie können eine Aufgabe aus einer Nachricht in einem Chat erstellen, in
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a chat session. The menu besides a message is open, with a button to create a new task.](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px \"Create task from message\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Das Menü neben einer Nachricht ist geöffnet, "
-"mit einer Schaltfläche zum Erstellen einer neuen Aufgabe.](/peertube-"
-"plugin-livechat/images/"
-"task_from_message_1.png?classes=shadow,border&height=200px \"Aufgabe aus "
-"einer Nachricht erstellen\")"
+msgstr "![Screenshot einer Chatsitzung. Das Menü neben einer Nachricht ist geöffnet, mit einer Schaltfläche zum Erstellen einer neuen Aufgabe.](/peertube-plugin-livechat/images/task_from_message_1.png?classes=shadow,border&height=200px \"Aufgabe aus einer Nachricht erstellen\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of a dialog, where you can choose in which task list you want to add the new task.](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px \"Choose the task list\")"
-msgstr ""
-"![Screenshot eines Dialogs, in dem Sie auswählen können, in welcher "
-"Aufgabenliste Sie die neue Aufgabe hinzufügen möchten.](/peertube-"
-"plugin-livechat/images/"
-"task_from_message_2.png?classes=shadow,border&height=200px \"Aufgabenliste "
-"auswählen\")"
+msgstr "![Screenshot eines Dialogs, in dem Sie auswählen können, in welcher Aufgabenliste Sie die neue Aufgabe hinzufügen möchten.](/peertube-plugin-livechat/images/task_from_message_2.png?classes=shadow,border&height=200px \"Aufgabenliste auswählen\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
 msgid "![Screenshot of the task application. A new task was added in the \"chat questions\" task list, with the user's nickname, and the message as content.](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px \"Task created\")"
-msgstr ""
-"![Screenshot der Aufgabenanwendung. Eine neue Aufgabe wurde in der "
-"Aufgabenliste \"Chat-Fragen\" hinzugefügt, mit dem Spitznamen des Benutzers "
-"und der Nachricht als Inhalt.](/peertube-plugin-livechat/images/"
-"task_from_message_3.png?classes=shadow,border&height=200px \"Aufgabe "
-"erstellt\")"
+msgstr "![Screenshot der Aufgabenanwendung. Eine neue Aufgabe wurde in der Aufgabenliste \"Chat-Fragen\" hinzugefügt, mit dem Spitznamen des Benutzers und der Nachricht als Inhalt.](/peertube-plugin-livechat/images/task_from_message_3.png?classes=shadow,border&height=200px \"Aufgabe erstellt\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/tasks.md
@@ -4618,11 +4414,7 @@ msgstr "Um die Nutzungsbedingungen zu konfigurieren, gehen Sie auf die [Kanal-Ko
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/terms.md
 msgid "![Screenshot of the channel options form, with a field to configure your terms and conditions.](/peertube-plugin-livechat/images/channel_terms_config.png?classes=shadow,border&height=400px \"Channel configuration / Terms\")"
-msgstr ""
-"![Screenshot des Formulars für die Kanaloptionen mit einem Feld für die "
-"Konfiguration der Nutzungsbedingungen.](/peertube-plugin-livechat/images/"
-"channel_terms_config.png?classes=shadow,border&height=400px "
-"\"Kanalkonfiguration / Nutzungsbedingungen\")"
+msgstr "![Screenshot des Formulars für die Kanaloptionen mit einem Feld für die Konfiguration der Nutzungsbedingungen.](/peertube-plugin-livechat/images/channel_terms_config.png?classes=shadow,border&height=400px \"Kanalkonfiguration / Nutzungsbedingungen\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/terms.md
@@ -4643,10 +4435,7 @@ msgstr "Wenn Sie dem Chat beitreten, sehen die Zuschauer die Bedingungen:"
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/terms.md
 msgid "![Screenshot of a chat session. On the top of the chat, there are terms and conditions for both the server and the channel.](/peertube-plugin-livechat/images/terms.png?classes=shadow,border&height=400px \"Terms\")"
-msgstr ""
-"![Screenshot einer Chatsitzung. Am oberen Rand des Chats stehen die "
-"Bedingungen für den Server und den Kanal.](/peertube-plugin-livechat/images/"
-"terms.png?classes=shadow,border&height=400px \"Nutzungsbedingungen\")"
+msgstr "![Screenshot einer Chatsitzung. Am oberen Rand des Chats stehen die Bedingungen für den Server und den Kanal.](/peertube-plugin-livechat/images/terms.png?classes=shadow,border&height=400px \"Nutzungsbedingungen\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/streamers/terms.md
@@ -4695,10 +4484,7 @@ msgstr "Wenn Sie ein Peertube-Video ansehen, bei dem der Chat aktiviert ist, seh
 #: support/documentation/content/en/_index.md
 #: support/documentation/content/en/intro/_index.md
 msgid "![Screenshot of a Peertube video page, with a web chat on the right of the video.](/peertube-plugin-livechat/images/chat.png?classes=shadow,border&height=200px \"Chat screenshot\")"
-msgstr ""
-"![Screenshot einer Peertube-Videoseite mit einem Web-Chat rechts neben dem "
-"Video.](/peertube-plugin-livechat/images/"
-"chat.png?classes=shadow,border&height=200px \"Chat Bildschirmfoto\")"
+msgstr "![Screenshot einer Peertube-Videoseite mit einem Web-Chat rechts neben dem Video.](/peertube-plugin-livechat/images/chat.png?classes=shadow,border&height=200px \"Chat Bildschirmfoto\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4719,12 +4505,7 @@ msgstr "Wenn Sie auf der Peertube-Instanz, auf der Sie das Video ansehen, nicht 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of a chat. In the participant list, there is John Livingston, and an anonymous account using \"Anonymous 212873\" nickname.](/peertube-plugin-livechat/images/chat_with_anonymous.png?classes=shadow,border&height=200px \"Chat with an anonymous user\")"
-msgstr ""
-"![Screenshot eines Chats. In der Teilnehmerliste gibt es John Livingston und "
-"einen anonymen Account mit dem Nicknamen \"Anonymous 212873\".](/peertube-"
-"plugin-livechat/images/"
-"chat_with_anonymous.png?classes=shadow,border&height=200px \"Chat mit einem "
-"anonymen Benutzer\")"
+msgstr "![Screenshot eines Chats. In der Teilnehmerliste gibt es John Livingston und einen anonymen Account mit dem Nicknamen \"Anonymous 212873\".](/peertube-plugin-livechat/images/chat_with_anonymous.png?classes=shadow,border&height=200px \"Chat mit einem anonymen Benutzer\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4734,11 +4515,7 @@ msgstr "Bevor Sie im Chatraum sprechen können, müssen Sie einen Spitznamen in 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of the chat. The current user is not logged in, and must choose a nickname before being able to write in the chat.](/peertube-plugin-livechat/images/chat_anonymous.png?classes=shadow,border&height=200px \"Joining chat when not connected\")"
-msgstr ""
-"![Screenshot des Chats. Der aktuelle Benutzer ist nicht eingeloggt und muss "
-"einen Spitznamen wählen, bevor er im Chat schreiben kann.](/peertube-"
-"plugin-livechat/images/chat_anonymous.png?classes=shadow,border&height=200px "
-"\"Chat beitreten, wenn nicht verbunden\")"
+msgstr "![Screenshot des Chats. Der aktuelle Benutzer ist nicht eingeloggt und muss einen Spitznamen wählen, bevor er im Chat schreiben kann.](/peertube-plugin-livechat/images/chat_anonymous.png?classes=shadow,border&height=200px \"Chat beitreten, wenn nicht verbunden\")"
 
 #. type: Title ####
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4791,12 +4568,7 @@ msgstr "Wenn Sie ein Peertube Konto haben, aber nicht auf der aktuellen Instanz,
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of the \"{{% livechat_label login_using_external_account %}}\" dialog. There is a field where you can enter a Peertube url.](/peertube-plugin-livechat/images/external_login_dialog.png?classes=shadow,border&height=200px \"External login dialog\")"
-msgstr ""
-"![Screenshot des Dialogs \"{{% livechat_label login_using_external_account "
-"%}}\". Es gibt ein Feld, in das Sie eine Peertube-URL eingeben können"
-".](/peertube-plugin-livechat/images/"
-"external_login_dialog.png?classes=shadow,border&height=200px \"Externer "
-"Anmeldedialog\")"
+msgstr "![Screenshot des Dialogs \"{{% livechat_label login_using_external_account %}}\". Es gibt ein Feld, in das Sie eine Peertube-URL eingeben können.](/peertube-plugin-livechat/images/external_login_dialog.png?classes=shadow,border&height=200px \"Externer Anmeldedialog\")"
 
 #. type: Title ##
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4838,11 +4610,7 @@ msgstr "Um die Liste der Teilnehmer zu sehen, öffnen Sie einfach das rechte Men
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
 msgid "![Screenshot of a chat session, with on the right the list of participants.](/peertube-plugin-livechat/images/open_participants_list.png?classes=shadow,border&height=200px \"Participants list\")"
-msgstr ""
-"![Screenshot einer Chatsitzung, rechts die Liste der Teilnehmer](/peertube-"
-"plugin-livechat/images/"
-"open_participants_list.png?classes=shadow,border&height=200px "
-"\"Teilnehmerliste\")"
+msgstr "![Screenshot einer Chatsitzung, rechts die Liste der Teilnehmer](/peertube-plugin-livechat/images/open_participants_list.png?classes=shadow,border&height=200px \"Teilnehmerliste\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4875,10 +4643,7 @@ msgstr "Oben im Chat gibt es eine Schaltfläche, um den Chat im Vollbildmodus zu
 #: support/documentation/content/en/documentation/user/viewers.md
 #: support/documentation/content/en/intro/_index.md
 msgid "![Screenshot of a chat using the full web page.](/peertube-plugin-livechat/images/fullscreen.png?classes=shadow,border&height=200px \"Fullscreen chat screenshot\")"
-msgstr ""
-"![Screenshot des Chats über die gesamte Webseite.](/peertube-plugin-livechat/"
-"images/fullscreen.png?classes=shadow,border&height=200px \"Vollbild Chat "
-"Bildschirmfoto\")"
+msgstr "![Screenshot des Chats über die gesamte Webseite.](/peertube-plugin-livechat/images/fullscreen.png?classes=shadow,border&height=200px \"Vollbild Chat Bildschirmfoto\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/viewers.md
@@ -4936,10 +4701,7 @@ msgstr "Um die Adresse des Raums, dem Sie beitreten möchten, zu erhalten, könn
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
 msgid "![Screenshot of the chat, with a share button on the top.](/peertube-plugin-livechat/images/share_button.png?classes=shadow,border&height=200px \"Share button\")"
-msgstr ""
-"![Screenshot des Chats mit einer Schaltfläche zum Teilen am oberen Rand"
-".](/peertube-plugin-livechat/images/"
-"share_button.png?classes=shadow,border&height=200px \"Teilen Schaltfläche\")"
+msgstr "![Screenshot des Chats mit einer Schaltfläche zum Teilen am oberen Rand.](/peertube-plugin-livechat/images/share_button.png?classes=shadow,border&height=200px \"Teilen Schaltfläche\")"
 
 #. type: Plain text
 #: support/documentation/content/en/documentation/user/xmpp_clients.md
@@ -5043,12 +4805,7 @@ msgstr "Als Peertube-Administrator können Sie dieses Plugin auf Ihrer Instanz e
 #. type: Plain text
 #: support/documentation/content/en/intro/_index.md
 msgid "![Screenshot of Peertube plugins admin page. The search fields contains \"livechat\", and the search results show the livechat plugin.](/peertube-plugin-livechat/images/installation.png?classes=shadow,border&height=200px \"Livechat installation\")"
-msgstr ""
-"![Screenshot der Peertube Plugin Administrator Seite. Die Suchfelder "
-"enthalten \"livechat\", und die Suchergebnisse zeigen das Livechat-Plugin"
-".](/peertube-plugin-livechat/images/"
-"installation.png?classes=shadow,border&height=200px \"Livechat installation\""
-")"
+msgstr "![Screenshot der Peertube Plugin Administrator Seite. Die Suchfelder enthalten \"livechat\", und die Suchergebnisse zeigen das Livechat-Plugin.](/peertube-plugin-livechat/images/installation.png?classes=shadow,border&height=200px \"Livechat installation\")"
 
 #. type: Title ##
 #: support/documentation/content/en/intro/_index.md

--- a/support/documentation/po/livechat.el.po
+++ b/support/documentation/po/livechat.el.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/el/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.en.pot
+++ b/support/documentation/po/livechat.en.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3622,6 +3622,54 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, markdown-text
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -4266,7 +4314,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.eo.po
+++ b/support/documentation/po/livechat.eo.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eo/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.es.po
+++ b/support/documentation/po/livechat.es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-04-16 21:38+0000\n"
 "Last-Translator: rnek0 <rnek0@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Spanish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/es/>\n"
@@ -3249,6 +3249,49 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+#| msgid "Write documentation"
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "Redactar la documentación"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3814,7 +3857,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.eu.po
+++ b/support/documentation/po/livechat.eu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/eu/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fa.po
+++ b/support/documentation/po/livechat.fa.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fa/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fi.po
+++ b/support/documentation/po/livechat.fi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fi/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.fr.po
+++ b/support/documentation/po/livechat.fr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-08-12 11:25+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: French <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/fr/>\n"
@@ -3371,6 +3371,57 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr "L'attribut `sn` est le code du nom court.  L'attribut `url` peut être n'importe quelle url d'image à laquelle votre navigateur peut accéder, ou une [URL de données](https://developer.mozilla.org/fr-FR/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) représentant le fichier que vous souhaitez importer."
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+#| msgid "Plugin peertube-plugin-livechat slow mode"
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "Mode lent du plugin peertube-plugin-livechat"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "This feature comes with the livechat plugin version 11.0.0."
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr "Cette fonctionnalité arrive avec le plugin livechat version 11.0.0."
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "This can be really usefull to:"
+msgid "This mode can be usefull for example:"
+msgstr "Cela peut s'avérer très utile pour :"
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label livechat_configuration_channel_anonymize_moderation_label %}}\" checkbox."
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr "Pour activer ou désactiver cette fonctionnalité, utilisez le [menu déroulant du chat](/peertube-plugin-livechat/fr/documentation/user/viewers), puis ouvrez le menu \"configurer\".  Dans le formulaire, vous trouverez une case à cocher \"{{% livechat_label livechat_configuration_channel_anonymize_moderation_label %}}\"."
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "On the [channel configuration page](/peertube-plugin-livechat/documentation/user/streamers/channel), you can set the \"{{% livechat_label moderation_delay %}}\" option:"
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr "Sur la [page de configuration de la chaîne](/peertube-plugin-livechat/fr/documentation/user/streamers/channel), vous pouvez définir une valeur pour l'option \"{{% livechat_label moderation_delay %}}\" :"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3972,8 +4023,9 @@ msgstr "Vous pouvez trier les tâches ou les déplacer d'une liste à l'autre pa
 
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
-#, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+#, fuzzy, no-wrap
+#| msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr "Vous pouvez créer des sondages pour demander l'avis des spectateur⋅rices."
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.gd.po
+++ b/support/documentation/po/livechat.gd.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Gaelic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gd/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.gl.po
+++ b/support/documentation/po/livechat.gl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Galician <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/gl/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.hr.po
+++ b/support/documentation/po/livechat.hr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-07-19 17:45+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hr/>\n"
@@ -3262,6 +3262,53 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr "Atribut `sn` je kod kratkog imena. Atribut `url` može biti bilo koji url slike kojem tvoj preglednik može pristupiti ili [URL podataka](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) koji predstavlja datoteku koju želiš uvesti."
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+#| msgid "Plugin documentation"
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "Dokumentacija dodataka"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "This feature comes with the livechat plugin version 10.0.0."
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr "Ova je funkcija dostupna s dodatkom za chat uživo verzije 10.0.0."
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+#| msgid "On the [channel configuration page](/peertube-plugin-livechat/documentation/user/streamers/channel), you can set the \"{{% livechat_label moderation_delay %}}\" option:"
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr "Na [stranici za konfiguraciju kanala](/peertube-plugin-livechat/hr/documentation/user/streamers/channel) možeš postaviti opciju „{{% livechat_label moderation_delay %}}”:"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3840,7 +3887,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.hu.po
+++ b/support/documentation/po/livechat.hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hungarian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/hu/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.is.po
+++ b/support/documentation/po/livechat.is.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Icelandic <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/is/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.it.po
+++ b/support/documentation/po/livechat.it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 14:21+0000\n"
 "Last-Translator: John Livingston <git@john-livingston.fr>\n"
 "Language-Team: Italian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/it/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ja.po
+++ b/support/documentation/po/livechat.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2024-08-29 10:38+0000\n"
 "Last-Translator: \"T.S\" <fusen@users.noreply.weblate.framasoft.org>\n"
 "Language-Team: Japanese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ja/>\n"
@@ -3314,6 +3314,50 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr "PeerTube ライブチャットプラグイン"
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr "PeerTube ライブチャットプラグイン"
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, fuzzy
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr "PeerTube ライブチャットプラグイン"
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3899,7 +3943,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.kab.po
+++ b/support/documentation/po/livechat.kab.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Kabyle <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/kab/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nb.po
+++ b/support/documentation/po/livechat.nb.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nb_NO/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nl.po
+++ b/support/documentation/po/livechat.nl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nl/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.nn.po
+++ b/support/documentation/po/livechat.nn.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Nynorsk <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/nn/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.oc.po
+++ b/support/documentation/po/livechat.oc.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Occitan <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/oc/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.pl.po
+++ b/support/documentation/po/livechat.pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pl/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.pt.po
+++ b/support/documentation/po/livechat.pt.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/pt/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.ru.po
+++ b/support/documentation/po/livechat.ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/ru/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.sq.po
+++ b/support/documentation/po/livechat.sq.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Albanian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sq/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.sv.po
+++ b/support/documentation/po/livechat.sv.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/sv/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.th.po
+++ b/support/documentation/po/livechat.th.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Thai <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/th/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.tok.po
+++ b/support/documentation/po/livechat.tok.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Toki Pona <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/tok/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.tr.po
+++ b/support/documentation/po/livechat.tr.po
@@ -3189,6 +3189,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3754,7 +3796,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.uk.po
+++ b/support/documentation/po/livechat.uk.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/uk/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.vi.po
+++ b/support/documentation/po/livechat.vi.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Vietnamese <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/vi/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.zh-Hans.po
+++ b/support/documentation/po/livechat.zh-Hans.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hans/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title

--- a/support/documentation/po/livechat.zh-Hant.po
+++ b/support/documentation/po/livechat.zh-Hant.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: peertube-plugin-livechat-documentation VERSION\n"
-"POT-Creation-Date: 2024-08-30 16:24+0200\n"
+"POT-Creation-Date: 2024-09-06 12:33+0200\n"
 "PO-Revision-Date: 2023-07-17 10:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://weblate.framasoft.org/projects/peertube-livechat/peertube-plugin-livechat-documentation/zh_Hant/>\n"
@@ -3208,6 +3208,48 @@ msgid "The `sn` attribute is the short name code.  The `url` attribute can be an
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: description
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Plugin peertube-plugin-livechat emojis only mode"
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+#, no-wrap
+msgid "Emojis only mode"
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This feature comes with the livechat plugin version 11.1.0."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "This mode can be usefull for example:"
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To avoid spam or offensive message when you are not here to moderate."
+msgstr ""
+
+#. type: Bullet: '* '
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "When there are too many speaking participants, and you can't no more moderate correctly."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "To enable or disable this feature, use the [chat dropdown menu](/peertube-plugin-livechat/documentation/user/viewers), open the \"configure\" menu.  In the form, you will find a \"{{% livechat_label emoji_only_mode_title %}}\" checkbox."
+msgstr ""
+
+#. type: Plain text
+#: build/documentation/pot_in/documentation/user/streamers/emojis_only.md
+msgid "If you want to enable it for all your chatrooms at once, open the [channel emojis configuration page](/peertube-plugin-livechat/documentation/user/streamers/emojis/), and use the \"{{% livechat_label emoji_only_enable_all_rooms %}}\" button."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/_index.md
 #, no-wrap
 msgid "How to setup the chat for your live stream"
@@ -3773,7 +3815,7 @@ msgstr ""
 #. type: Yaml Front Matter Hash Value: description
 #: support/documentation/content/en/documentation/user/streamers/polls.md
 #, no-wrap
-msgid "You can create polls to ask viewers their opinion."
+msgid "You can create polls to ask viewers their opinion"
 msgstr ""
 
 #. type: Yaml Front Matter Hash Value: title


### PR DESCRIPTION
## Description

This feature implements an emojis only mode: https://livingston.frama.io/peertube-plugin-livechat/documentation/user/streamers/emojis_only/

## Related issues

#131 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [ ] I have run `npm run lint` to check that my changes respects the coding conventions
- [x] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [x] I added some documentation and I have run `npm run doc:translate` to generate translations files
