### PR TITLE
Fix #660: don't send headers twice on emoji router errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## (???) Not Released Yet
+
+### Minor changes and fixes
+
+* Fix #660: don't send headers twice on emoji router errors.
+
 ## 12.0.3
 
 ### Minor changes and fixes

--- a/server/lib/routers/emojis.ts
+++ b/server/lib/routers/emojis.ts
@@ -78,7 +78,9 @@ export async function initEmojisRouter (
           },
           (err) => {
             if (err) {
-              res.sendStatus(404)
+              if (!res.headersSent) {
+                res.sendStatus(404)
+              }
             }
           }
         )


### PR DESCRIPTION

## Related issues
#660 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files
