### PR TITLE
Adding a warning in settings if theme is not set to Peertube or if autocolors are disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix shebangs (for NixOS compatibility).
 * Translations updates.
 * Updating various dependencies.
+* Adding a warning in settings if theme is not set to Peertube or if autocolors are disabled.
 
 ## 12.0.3
 

--- a/client/admin-plugin-client-plugin.ts
+++ b/client/admin-plugin-client-plugin.ts
@@ -269,6 +269,9 @@ function register (clientOptions: RegisterClientOptions): void {
           return options.formValues['prosody-components'] !== true
         case 'converse-autocolors':
           return options.formValues['converse-theme'] !== 'peertube'
+        case 'converse-theme-warning':
+          return options.formValues['converse-theme'] === 'peertube' &&
+            options.formValues['converse-autocolors'] === true
         case 'chat-per-live-video-warning':
           return !(options.formValues['chat-all-lives'] === true && options.formValues['chat-per-live-video'] === true)
         case 'auto-ban-anonymous-ip':

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -676,3 +676,9 @@ announcements_message_type_standard: Standard
 announcements_message_type_announcement: Announcement
 announcements_message_type_highlight: Highlight
 announcements_message_type_warning: Warning
+
+converse_theme_warning_description: |
+  <span class="peertube-plugin-livechat-warning">
+    It is strongly recommanded to keep the "Peertube theme", in combinaison with the "Automatic color detection" feature.
+    Otherwise some user may experience issues depending on the Peertube theme they use.
+  </span>

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -532,7 +532,6 @@ function initThemingSettings ({ registerSetting }: RegisterServerOptions): void 
     ] as Array<{ value: ConverseJSTheme, label: string }>,
     descriptionHTML: loc('converse_theme_description')
   })
-
   registerSetting({
     name: 'converse-autocolors',
     label: loc('autocolors_label'),
@@ -540,6 +539,12 @@ function initThemingSettings ({ registerSetting }: RegisterServerOptions): void 
     default: true,
     private: false,
     descriptionHTML: loc('autocolors_description')
+  })
+  registerSetting({
+    name: 'converse-theme-warning',
+    type: 'html',
+    private: true,
+    descriptionHTML: loc('converse_theme_warning_description')
   })
 
   registerSetting({


### PR DESCRIPTION
## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
