### PR TITLE
Various UX/UI Improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 12.0.5
+
+### Minor changes and fixes
+
+* Fix #329: auto focus message field after anonymous user has entered nickname.
+* Fix #392: add draggable items touch screen handling
+* Fix #506: hide offline users by default in occupant list
+* Fix #547: add button to go to the end of the chat
+* Fix #503: set custom emojis max height to text height + bigger when posted alone
+
 ## 12.0.4
 
 ### Minor changes and fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 12.0.5
+## ??? (Not Released Yet)
 
 ### Minor changes and fixes
 
@@ -9,6 +9,7 @@
 * Fix #506: hide offline users by default in occupant list
 * Fix #547: add button to go to the end of the chat
 * Fix #503: set custom emojis max height to text height + bigger when posted alone
+* Fix: Converse bottom panel messages not visible on new Peertube v7 theme (for example for muted users)
 
 ## 12.0.4
 

--- a/conversejs/custom/shared/components/draggables/styles/draggables.scss
+++ b/conversejs/custom/shared/components/draggables/styles/draggables.scss
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ * SPDX-FileCopyrightText: 2025 Nicolas Chesnais <https://autre.space>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,5 +16,9 @@
 
   .livechat-drag-top-half > .draggables-line {
     border-top: 4px solid blue;
+  }
+
+  [draggable="true"] {
+    touch-action: none;
   }
 }

--- a/conversejs/custom/shared/styles/_peertubetheme.scss
+++ b/conversejs/custom/shared/styles/_peertubetheme.scss
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+ * SPDX-FileCopyrightText: 2025 Nicolas Chesnais <https://autre.space>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -149,11 +150,12 @@
       background-color: var(--peertube-grey-background) !important;
     }
 
-    // Changing size for emojis, to have bigger custom emojis
+    // Resize custom emojis to text height
     img.emoji {
       width: unset !important;
       height: unset !important;
-      max-height: 3em !important; // and no max-width
+      max-height: 1.5em !important; // and no max-width
+      vertical-align: -0.45em !important;
     }
 
     // underline links in chat messages

--- a/conversejs/custom/shared/styles/_peertubetheme.scss
+++ b/conversejs/custom/shared/styles/_peertubetheme.scss
@@ -158,6 +158,11 @@
       vertical-align: -0.45em !important;
     }
 
+    // Trick to enlarge a single custom emoji with no text in message
+    &[text^=":"][text$=":"] img.emoji:only-child {
+      max-height: 2.5em !important;
+    }
+
     // underline links in chat messages
     a[href] {
       text-decoration: underline;

--- a/conversejs/custom/shared/styles/livechat.scss
+++ b/conversejs/custom/shared/styles/livechat.scss
@@ -264,3 +264,13 @@ body.converse-embedded {
     justify-content: normal !important;
   }
 }
+
+/* stylelint-disable-next-line no-duplicate-selectors */
+.conversejs {
+  converse-muc {
+    .muc-bottom-panel, converse-muc-bottom-panel {
+      // Fixing a color (Converse use a hardcoded "white", which does not work with Peertube v7 new theme)
+      color: var(--peertube-menu-foreground) !important;
+    }
+  }
+}

--- a/conversejs/custom/shared/styles/livechat.scss
+++ b/conversejs/custom/shared/styles/livechat.scss
@@ -227,6 +227,21 @@ body.converse-embedded {
 
       .occupants {
         width: 100%;
+
+        // Put occupants filters items on a single line
+        converse-list-filter form > div {
+          display: flex;
+          align-items: center;
+
+          .filter-by {
+            margin-right: 4px;
+          }
+
+          // Let search input take the whole width when displayed
+          .btn-group:has(+ select.hidden) {
+            width: 100%;
+          }
+        }
       }
     }
   }

--- a/conversejs/custom/templates/muc-bottom-panel.js
+++ b/conversejs/custom/templates/muc-bottom-panel.js
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+// SPDX-FileCopyrightText: 2025 Nicolas Chesnais <https://autre.space>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -22,6 +23,7 @@ async function setNickname (ev, model) {
   _converse.api.trigger('livechatViewerModeSetNickname', model, nick, {
     synchronous: true
   })
+  document.querySelector('.chat-textarea')?.focus()
 }
 
 class SlowMode extends CustomElement {

--- a/conversejs/custom/templates/muc-bottom-panel.js
+++ b/conversejs/custom/templates/muc-bottom-panel.js
@@ -13,7 +13,7 @@ import tplMucBottomPanel from '../../src/plugins/muc-views/templates/muc-bottom-
 import { CustomElement } from 'shared/components/element.js'
 import 'shared/modals/livechat-external-login.js'
 
-async function setNickname (ev, model) {
+async function setNicknameAndFocus (ev, model) {
   ev.preventDefault()
   const nick = ev.target.nick.value.trim()
   if (!nick) {
@@ -162,7 +162,7 @@ const tplViewerMode = (o) => {
   const i18nExternalLogin = __(LOC_login_using_external_account)
   return html`
     <div class="livechat-viewer-mode-content chatroom-form-container">
-        <form class="converse-form chatroom-form" @submit=${ev => setNickname(ev, model)}>
+        <form class="converse-form chatroom-form" @submit=${ev => setNicknameAndFocus(ev, model)}>
             <label>${i18nHeading}</label>
             <fieldset>
               <input type="text"

--- a/conversejs/lib/plugins/livechat-specific/toolbar.ts
+++ b/conversejs/lib/plugins/livechat-specific/toolbar.ts
@@ -57,8 +57,8 @@ function getToolbarButtons (this: any, toolbarEl: any, buttons: any[]): any {
 
                 // Hide offline occupants by default
                 const sideBarEl = document.querySelector('converse-muc-sidebar') as unknown as any
-                sideBarEl.model.set('filter_visible', true)
-                sideBarEl.filter.set('type', 'state')
+                sideBarEl?.model.set('filter_visible', true)
+                sideBarEl?.filter.set('type', 'state')
               }}>
               ${icon}
       </button>`

--- a/conversejs/lib/plugins/livechat-specific/toolbar.ts
+++ b/conversejs/lib/plugins/livechat-specific/toolbar.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+// SPDX-FileCopyrightText: 2025 Nicolas Chesnais <https://autre.space>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -53,6 +54,11 @@ function getToolbarButtons (this: any, toolbarEl: any, buttons: any[]): any {
                 toolbarEl.model.save({
                   hidden_occupants: !toolbarEl.model.get('hidden_occupants')
                 })
+
+                // Hide offline occupants by default
+                const sideBarEl = document.querySelector('converse-muc-sidebar') as unknown as any
+                sideBarEl.model.set('filter_visible', true)
+                sideBarEl.filter.set('type', 'state')
               }}>
               ${icon}
       </button>`

--- a/conversejs/loc.keys.js
+++ b/conversejs/loc.keys.js
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+// SPDX-FileCopyrightText: 2025 Nicolas Chesnais <https://autre.space>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -68,7 +69,8 @@ const locKeys = [
   'announcements_message_type_standard',
   'announcements_message_type_announcement',
   'announcements_message_type_highlight',
-  'announcements_message_type_warning'
+  'announcements_message_type_warning',
+  'back_to_last_msg'
 ]
 
 module.exports = locKeys

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -682,3 +682,4 @@ converse_theme_warning_description: |
     It is strongly recommanded to keep the "Peertube theme", in combinaison with the "Automatic color detection" feature.
     Otherwise some user may experience issues depending on the Peertube theme they use.
   </span>
+back_to_last_msg: Go back to last message

--- a/languages/fr.yml
+++ b/languages/fr.yml
@@ -654,3 +654,4 @@ livechat_configuration_channel_no_duplicate_desc: "En activant cette option, le 
   de modération modérera automatiquement les messages en double.\nCela signifie que
   si un⋅e utilisateur⋅rice envoie deux fois le même message en l'espace de X secondes,
   le deuxième message sera supprimé.\n"
+back_to_last_msg: Retourner au dernier message


### PR DESCRIPTION
## Description

- auto focus message field after anonymous user has entered nickname.
- add draggable items touch screen handling
- when clicking on the occupant list panel button, hides offline users
- add button to go to the end of the chat when chat scrolled
- set custom emojis max height to text height + bigger when posted alone

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

* Fix #329
* Fix #392
* Fix #506
* Fix #547
* Fix #503

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

![image](https://github.com/user-attachments/assets/dc476dba-2f55-46cb-bc33-c10ca120e480)
Custom emojis no longer break the text height. If posted alone, it is displayed a bit bigger like regular emoji.

![image](https://github.com/user-attachments/assets/f6ca1356-2c8d-4111-9b3a-b15cdfaa117b)
Button to go to the last message if chat is scrolled
![image](https://github.com/user-attachments/assets/8995ac83-afa5-48e4-a736-8483305b3b3e)
But does not show up if there's new messages for which there's already a button