### PR TITLE
Short uuid handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix #547: add button to go to the end of the chat
 * Fix #503: set custom emojis max height to text height + bigger when posted alone
 * Fix: Converse bottom panel messages not visible on new Peertube v7 theme (for example for muted users)
+* Fix #75: New short video urls makes it difficult to use the settings «Activate chat for these videos».
 
 ## 12.0.4
 

--- a/client/tsconfig.json.license
+++ b/client/tsconfig.json.license
@@ -1,3 +1,4 @@
 SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-FileCopyrightText: 2025 Mehdi Benadel <https://mehdibenadel.com>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -149,7 +149,7 @@ all_non_lives_description: "If checked, the chat will be enabled for all video t
 
 videos_list_label: "Activate chat for these videos"
 videos_list_description: |
-  Videos UUIDs for which we want a web chat.
+  Videos UUIDs for which we want a web chat (short UUID or UUIDv4).
   Can be non-live videos. One per line. <br />
   You can add comments: everything after the # character will be stripped off, and empty lines ignored.<br />
   Don't add private videos, the UUIDs will be sent to the frontend.

--- a/languages/es.yml
+++ b/languages/es.yml
@@ -152,7 +152,7 @@ prosody_muc_expiration_description: "Aquí puede elegir cuánto tiempo el servid
   durante 1 <b>año</b>. Puede reemplazar 1 por cualquier valor entero.</li>\n    \
   \ <li><b>nunca</b>: el contenido nunca caducará y se mantendrá para siempre.</li>\n\
   </ul>\n"
-videos_list_description: "UUIDs de los videos para los cuales se desea un chat web.\n
+videos_list_description: "UUIDs de los videos para los cuales se desea un chat web (corto UUID o UUIDv4).\n
   Pueden ser videos no en vivo. Una por línea. <br />\nPuede agregar comentarios:
   todo lo que este detras del caracter # no sera interpretado y las líneas vacías
   ignoradas. <br />\nNo agregue videos privados, los UUID se enviarán al frontend.\n"

--- a/languages/fr.yml
+++ b/languages/fr.yml
@@ -111,7 +111,7 @@ all_non_lives_description: "Si coché, il y aura un tchat pour toutes les vidéo
 
 videos_list_label: "Activer le tchat pour ces vidéos"
 videos_list_description: |
-  Mettez ici les UUIDs des vidéos pour lesquelles vous voulez forcer l'activation du tchat.
+  Mettez ici les UUIDs des vidéos pour lesquelles vous voulez forcer l'activation du tchat (UUID court ou UUIDv4).
   Cela peut être des directs, ou non. Un UUID par ligne. <br />
   Vous pouvez ajouter des commentaires : tout ce qui se trouve après le caractère # sera retiré, et les lignes vides ignorées. <br />
   N'ajoutez pas de vidéos privées, les UUIDs fuiteraient.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "http-proxy": "^1.18.1",
         "log-rotate": "^0.2.8",
         "openid-client": "^5.7.1",
+        "short-uuid": "^5.2.0",
         "validate-color": "^2.2.4",
         "xmppjs-chat-bot": "^0.5.0"
       },
@@ -3250,6 +3251,20 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/@peertube/peertube-types/node_modules/short-uuid": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
+      "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-base": "^1.1.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -5138,8 +5153,7 @@
     "node_modules/any-base": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-      "dev": true
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -11637,16 +11651,29 @@
       }
     },
     "node_modules/short-uuid": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.0.tgz",
-      "integrity": "sha512-r3cxuPPZSuF0QkKsK9bBR7u+7cwuCRzWzgjPh07F5N2iIUNgblnMHepBY16xgj5t1lG9iOP9k/TEafY1qhRzaw==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-5.2.0.tgz",
+      "integrity": "sha512-296/Nzi4DmANh93iYBwT4NoYRJuHnKEzefrkSagQbTH/A6NTaB68hSPDjm5IlbI5dx9FXdmtqPcj6N5H+CPm6w==",
+      "license": "MIT",
       "dependencies": {
         "any-base": "^1.1.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
+      }
+    },
+    "node_modules/short-uuid/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/side-channel": {
@@ -15504,6 +15531,16 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
           "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
           "dev": true
+        },
+        "short-uuid": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
+          "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+          "dev": true,
+          "requires": {
+            "any-base": "^1.1.0",
+            "uuid": "^8.3.2"
+          }
         }
       }
     },
@@ -16987,8 +17024,7 @@
     "any-base": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-      "dev": true
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -21663,13 +21699,19 @@
       "dev": true
     },
     "short-uuid": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.0.tgz",
-      "integrity": "sha512-r3cxuPPZSuF0QkKsK9bBR7u+7cwuCRzWzgjPh07F5N2iIUNgblnMHepBY16xgj5t1lG9iOP9k/TEafY1qhRzaw==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-5.2.0.tgz",
+      "integrity": "sha512-296/Nzi4DmANh93iYBwT4NoYRJuHnKEzefrkSagQbTH/A6NTaB68hSPDjm5IlbI5dx9FXdmtqPcj6N5H+CPm6w==",
       "requires": {
         "any-base": "^1.1.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "side-channel": {

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,3 +1,4 @@
 SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-FileCopyrightText: 2025 Mehdi Benadel <https://mehdibenadel.com>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "http-proxy": "^1.18.1",
     "log-rotate": "^0.2.8",
     "openid-client": "^5.7.1",
+    "short-uuid": "^5.2.0",
     "validate-color": "^2.2.4",
     "xmppjs-chat-bot": "^0.5.0"
   },

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,4 @@
 SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+SPDX-FileCopyrightText: 2025 Mehdi Benadel <https://mehdibenadel.com>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@tsconfig/node16/tsconfig.json",
 	"compilerOptions": {
 		"noImplicitReturns": true,
-    "noImplicitOverride": true,
+		"noImplicitOverride": true,
 		"noUnusedLocals": true,
 		"removeComments": true,
 		"sourceMap": true,

--- a/shared/lib/config.ts
+++ b/shared/lib/config.ts
@@ -1,6 +1,23 @@
 // SPDX-FileCopyrightText: 2024 John Livingston <https://www.john-livingston.fr/>
+// SPDX-FileCopyrightText: 2025 Mehdi Benadel <https://mehdibenadel.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-only
+
+const short = require('short-uuid')
+
+const translator = short()
+
+function shortToUUID (shortUUID: string): string {
+  if (!shortUUID) return shortUUID
+
+  return translator.toUUID(shortUUID)
+}
+
+function isShortUUID (value: string): boolean {
+  if (!value) return false
+
+  return value.length === translator.maxLength
+}
 
 function parseConfigUUIDs (s: string): string[] {
   if (!s) {
@@ -8,9 +25,11 @@ function parseConfigUUIDs (s: string): string[] {
   }
   let a = s.split('\n')
   a = a.map(line => {
-    return line.replace(/#.*$/, '')
+    line = line.replace(/#.*$/, '')
       .replace(/^\s+/, '')
       .replace(/\s+$/, '')
+
+    return isShortUUID(line) ? shortToUUID(line) : line
   })
   return a.filter(line => line !== '')
 }


### PR DESCRIPTION
## Description

Makes it possible to activate chat on short uuid videos.

## Related issues

Fixes [#75](https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/75)

## Mandatory Checks

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [x] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
