### PR TITLE
Fix #626: Bot timer was buggy, using seconds as delay instead of minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## ??? (Not Released Yet)
+## 13.0.0 (Not Released Yet)
+
+### Breaking changes
+
+There was a regression some months ago in the "bot timer" functionnality.
+In the channels settings, the delay between two quotes is supposed to be in minutes, but in fact we applied seconds.
+We don't have any way to detect if the user meant seconds or minutes when they configured their channels (it depends if it was before or after the regression).
+So we encourage all streamers to go through their channel settings, check the frequency of their bot timers (if enabled), set them to the correct value, and save the form.
+Users must save the form to be sure to apply the correct value.
 
 ### Minor changes and fixes
 
@@ -16,6 +24,7 @@
 * Fix moderation notes: fix filter button wrongly displayed on notes without associated occupant.
 * Fix tasks: checkbox state does not change when clicked.
 * Fix: bot timer can't be negative or null.
+* Fix #626: Bot timer was buggy, using seconds as delay instead of minutes.
 
 ## 12.0.4
 


### PR DESCRIPTION
There was a regression some months ago in the "bot timer" functionnality. In the channels settings, the delay between two quotes is supposed to be in minutes, but in fact we applied seconds. We don't have any way to detect if the user meant seconds or minutes when they configured their channels (it depends if it was before or after the regression). So we encourage all streamers to go through their channel settings, check the frequency of their bot timers (if enabled), set them to the correct value, and save the form. Users must save the form to be sure to apply the correct value.

## Description

<!-- Please include a summary of the change, with motivation and context -->

## Related issues

#626 

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [ ] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
