### PR TITLE
fix: call isLocal() as a method instead of accessing as property

### DIFF
--- a/server/lib/custom-fields.ts
+++ b/server/lib/custom-fields.ts
@@ -68,7 +68,7 @@ async function initCustomFields (options: RegisterServerOptions): Promise<void> 
     handler: async (video: Video): Promise<Video> => {
       logger.debug('Getting a video, searching for custom fields and data')
       await fillVideoCustomFields(options, video)
-      if (!video.isLocal) {
+      if (!video.isLocal()) {
         await fillVideoRemoteLiveChat(options, video)
       }
       return video
@@ -111,7 +111,7 @@ async function fillVideoRemoteLiveChat (
   video: Video | MVideoThumbnail
 ): Promise<void> {
   if (('remote' in video) && !video.remote) { return }
-  if (('isLocal' in video) && video.isLocal) { return }
+  if (('isLocal' in video) && video.isLocal()) { return }
   const infos = await getVideoLiveChatInfos(options, video)
   if (!infos) { return }
 


### PR DESCRIPTION
**Description**

In PeerTube 8.x, `isLocal()` is a method on the Sequelize `VideoModel` prototype, not a property. Accessing `video.isLocal` without parentheses returns the function reference (always truthy), so:

1. `!video.isLocal` at line 71 is always `false` → `fillVideoRemoteLiveChat` is never called for remote videos.
2. `video.isLocal` at line 114 is always truthy → even if called, the guard returns immediately.

This means `pluginData["livechat-remote"]` is never set, and the remote chat never opens on federated videos.

**Changes**

- `server/lib/custom-fields.ts`: Added `()` to call `isLocal()` on lines 71 and 114.

**Related issue**

Closes #780