### PR TITLE
Fix #780: fix remote chat not working on Peertube >=v8.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 14.0.3 (Not Released Yet).
+## 14.0.3 (Not Released Yet)
 
+* Fix chat federation on Peertube >= 8.0.0.
 * Fix CS translations, that made the documentation build fail.
 * Translation updates.
 * Upgrading dependencies.

--- a/server/lib/custom-fields.ts
+++ b/server/lib/custom-fields.ts
@@ -2,9 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { RegisterServerOptions, Video, MVideoThumbnail } from '@peertube/peertube-types'
+import type { RegisterServerOptions, Video as PVideo, MVideoThumbnail } from '@peertube/peertube-types'
 import { getVideoLiveChatInfos } from './federation/storage'
 import { anonymousConnectionInfos, compatibleRemoteAuthenticatedConnectionEnabled } from './federation/connection-infos'
+
+// FIXME: In Peertube 8.0.0, video.isLocal becomes a method... So we do this hack.
+interface Video extends Omit<PVideo, 'isLocal'> {
+  isLocal: boolean | (() => boolean)
+}
 
 async function initCustomFields (options: RegisterServerOptions): Promise<void> {
   const registerHook = options.registerHook
@@ -68,7 +73,13 @@ async function initCustomFields (options: RegisterServerOptions): Promise<void> 
     handler: async (video: Video): Promise<Video> => {
       logger.debug('Getting a video, searching for custom fields and data')
       await fillVideoCustomFields(options, video)
-      if (!video.isLocal) {
+      if (
+        !(
+          (typeof video.isLocal === 'function')
+            ? video.isLocal()
+            : video.isLocal
+        )
+      ) {
         await fillVideoRemoteLiveChat(options, video)
       }
       return video
@@ -81,6 +92,7 @@ async function initCustomFields (options: RegisterServerOptions): Promise<void> 
 interface LiveChatCustomFieldsVideo {
   id?: number | string
   isLive: boolean
+  isLocal?: boolean | (() => boolean) // In Peertube 8.0.0, this becomes a method...
   pluginData?: {
     'livechat-active'?: boolean
     'livechat-remote'?: boolean
@@ -111,7 +123,12 @@ async function fillVideoRemoteLiveChat (
   video: Video | MVideoThumbnail
 ): Promise<void> {
   if (('remote' in video) && !video.remote) { return }
-  if (('isLocal' in video) && video.isLocal) { return }
+  if ('isLocal' in video) {
+    if (typeof video.isLocal === 'function') {
+      if (video.isLocal()) { return }
+    }
+    if (video.isLocal) { return }
+  }
   const infos = await getVideoLiveChatInfos(options, video)
   if (!infos) { return }
 

--- a/server/lib/federation/storage.ts
+++ b/server/lib/federation/storage.ts
@@ -2,12 +2,19 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { RegisterServerOptions, MVideoFullLight, MVideoAP, Video, MVideoThumbnail } from '@peertube/peertube-types'
+import type {
+  RegisterServerOptions, MVideoFullLight, MVideoAP, Video as PVideo, MVideoThumbnail
+} from '@peertube/peertube-types'
 import type { LiveChatJSONLDAttribute, LiveChatJSONLDAttributeV1, PeertubeXMPPServerInfos } from './types'
 import { sanitizePeertubeLiveChatInfos, sanitizeXMPPHostFromInstanceUrl } from './sanitize'
 import { URL } from 'url'
 import * as fs from 'fs'
 import * as path from 'path'
+
+// FIXME: In Peertube 8.0.0, video.isLocal becomes a method... So we do this hack.
+interface Video extends Omit<PVideo, 'isLocal'> {
+  isLocal: boolean | (() => boolean)
+}
 
 /*
 Important Note: we could store these data in database. For example by using storageManager.storeData.
@@ -82,7 +89,11 @@ async function getVideoLiveChatInfos (
   const cached = cache.get(video.url)
   if (cached !== undefined) { return cached }
 
-  const remote = ('remote' in video) ? video.remote : !video.isLocal
+  const remote = ('remote' in video)
+    ? video.remote
+    : (typeof video.isLocal === 'function')
+        ? !video.isLocal()
+        : !video.isLocal
   const filePath = await _getFilePath(options, remote, video.uuid, video.url)
   if (!filePath) {
     logger.error('Cant compute the file path for storing liveChat infos for video ' + video.uuid)

--- a/shared/lib/video.ts
+++ b/shared/lib/video.ts
@@ -26,6 +26,7 @@ interface SharedVideoFrontend extends SharedVideoBase {
 
 interface SharedVideoBackend extends SharedVideoBase {
   remote: boolean
+  isLocal?: boolean | (() => boolean) // In Peertube 8.0.0, video.isLocal is a method.
 }
 
 type SharedVideo = SharedVideoBackend | SharedVideoFrontend
@@ -39,6 +40,9 @@ type SharedVideo = SharedVideoBackend | SharedVideoFrontend
 function videoHasWebchat (settings: VideoHasWebchatSettings, video: SharedVideo): boolean {
   // Never use webchat on remote videos.
   if ('isLocal' in video) {
+    if (typeof video.isLocal === 'function') {
+      if (!video.isLocal()) return false
+    }
     if (!video.isLocal) return false
   } else {
     if (video.remote) return false


### PR DESCRIPTION
## Description
This fix solves https://github.com/JohnXLivingston/peertube-plugin-livechat/issues/780.
It replaces https://github.com/JohnXLivingston/peertube-plugin-livechat/pull/781, which was not backward compatible, and who missed an occurence of `video.isLocal`.

## Related issues

https://github.com/JohnXLivingston/peertube-plugin-livechat/pull/781

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files
