### PR TITLE
Fix moderation bot not loading on some configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor changes and fixes
 
 * Fix chat federation on Peertube >= 8.0.0.
+* Fix moderation bot not loading on some configuration.
 
 ## 14.0.3
 

--- a/server/lib/bots/ctl.ts
+++ b/server/lib/bots/ctl.ts
@@ -8,6 +8,7 @@ import { BotConfiguration } from '../configuration/bot'
 import { pluginName } from '../helpers'
 import * as child_process from 'child_process'
 import * as path from 'path'
+import * as fs from 'fs'
 
 let singleton: BotsCtl | undefined
 
@@ -67,7 +68,12 @@ class BotsCtl {
     // Indeed, this will spawn subprocesses, and kill signals sent to the child
     // will not be sent to the real bot process.
     // So we will search the path of the bot executable, and launch it directly.
+
     const botExecPath = this._botExecPath()
+    if (!botExecPath) {
+      this.logger.error('Did not find the botExecPath, cant start the bot.')
+      return
+    }
     const execArgs = [
       'run',
       '-f',
@@ -195,7 +201,7 @@ class BotsCtl {
     singleton = undefined
   }
 
-  protected _botExecPath (): string {
+  protected _botExecPath (): string | undefined {
     let dir: string = __dirname
     let watchDog = 100
 
@@ -206,13 +212,26 @@ class BotsCtl {
 
     if (path.basename(dir) !== pluginName) {
       this.logger.error('Cant find the ' + pluginName + ' base dir, and so cant find the bot exec path.')
-      throw new Error('Cant find the bot exec path')
+      return undefined
     }
 
     // xmppjs-chat-bot must be ./node_modules/.bin/xmppjs-chat-bot
-    const result = path.resolve(dir, 'node_modules', '.bin', 'xmppjs-chat-bot')
-    this.logger.info(`The bot path should be ${result}`)
-    return result
+    let result = path.resolve(dir, 'node_modules', '.bin', 'xmppjs-chat-bot')
+    if (fs.existsSync(result)) {
+      this.logger.info(`The bot path is ${result}`)
+      return result
+    }
+
+    // But for some installation it could also be in ../nodes_modules/.bin.xmppjs-chat-bot
+    this.logger.debug(`${result} was not found, trying in the parent directory`)
+    result = path.resolve(dir, '..', '.bin', 'xmppjs-chat-bot')
+    if (fs.existsSync(result)) {
+      this.logger.info(`The bot path is ${result}`)
+      return result
+    }
+
+    this.logger.error('Cant find the bot exec path')
+    return undefined
   }
 }
 


### PR DESCRIPTION
## Description

Peertube v8 use pnpm instead of yarn to install plugins.
The folder where will be installed the xmppjs-chat-bot can change compared to the previous way to install plugins.
This PR solves this issue.

Note: It appears that sometimes the xmppjs-chat-bot CLI has no exec permission. I was not able to reproduce this bug properly.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Mandatory Checks

<!-- This section lists a few important points to think about. -->
<!-- These do not necessarily apply to all types of contributions. -->
<!-- Put an `x` in the box(es) that applies: -->

- [x] I have added a description of the changes in the CHANGELOG files
- [x] I have run `npm run lint` to check that my changes respects the coding conventions
- [ ] I have added user documentation for the new features I added
- [ ] I have added technical documentation for the new features I added
- [ ] I added some documentation and I have run `npm run doc:translate` to generate translations files

## Screenshots

<!-- delete if not relevant -->
